### PR TITLE
feat: add 'set_log_level' to control iroh logging from other languages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1725,6 +1725,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-util",
+ "tracing-subscriber",
  "uniffi",
 ]
 
@@ -2180,6 +2181,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2349,6 +2360,12 @@ dependencies = [
  "quote",
  "syn 2.0.29",
 ]
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "p256"
@@ -3391,6 +3408,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shared_child"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3713,6 +3739,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
 name = "time"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3911,6 +3947,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
 dependencies = [
  "once_cell",
+ "valuable",
 ]
 
 [[package]]
@@ -3921,6 +3958,31 @@ checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
  "pin-project",
  "tracing",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -4199,6 +4261,12 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "version_check"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,9 +301,9 @@ checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
-version = "0.21.2"
+version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
+checksum = "414dcefbc63d77c526a76b3afcf6fbb9b5e2791c19c3aa2297733208750c6e53"
 
 [[package]]
 name = "base64ct"
@@ -1044,9 +1044,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "erased-serde"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "837c0466252947ada828b975e12daf82e18bb5444e4df87be6038d4469e2a3d2"
+checksum = "6c138974f9d5e7fe373eb04df7cae98833802ae4b11c24ac7039a21d5af4b26c"
 dependencies = [
  "serde",
 ]
@@ -1622,7 +1622,7 @@ checksum = "28b29a3cd74f0f4598934efe3aeba42bae0eb4680554128851ebbecb02af14e6"
 [[package]]
 name = "iroh"
 version = "0.5.1"
-source = "git+https://github.com/n0-computer/iroh?branch=main#bcce8a0b41fe9faf5cb3cc62f96bb451a060cb57"
+source = "git+https://github.com/n0-computer/iroh?branch=main#904342fba341a6c0816147a45bb91b6ebfb50479"
 dependencies = [
  "anyhow",
  "bao-tree",
@@ -1674,7 +1674,7 @@ dependencies = [
 [[package]]
 name = "iroh-bytes"
 version = "0.5.0"
-source = "git+https://github.com/n0-computer/iroh?branch=main#bcce8a0b41fe9faf5cb3cc62f96bb451a060cb57"
+source = "git+https://github.com/n0-computer/iroh?branch=main#904342fba341a6c0816147a45bb91b6ebfb50479"
 dependencies = [
  "anyhow",
  "bao-tree",
@@ -1732,7 +1732,7 @@ dependencies = [
 [[package]]
 name = "iroh-gossip"
 version = "0.5.1"
-source = "git+https://github.com/n0-computer/iroh?branch=main#bcce8a0b41fe9faf5cb3cc62f96bb451a060cb57"
+source = "git+https://github.com/n0-computer/iroh?branch=main#904342fba341a6c0816147a45bb91b6ebfb50479"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1772,7 +1772,7 @@ dependencies = [
 [[package]]
 name = "iroh-metrics"
 version = "0.5.0"
-source = "git+https://github.com/n0-computer/iroh?branch=main#bcce8a0b41fe9faf5cb3cc62f96bb451a060cb57"
+source = "git+https://github.com/n0-computer/iroh?branch=main#904342fba341a6c0816147a45bb91b6ebfb50479"
 dependencies = [
  "erased_set",
  "hyper",
@@ -1786,7 +1786,7 @@ dependencies = [
 [[package]]
 name = "iroh-net"
 version = "0.5.1"
-source = "git+https://github.com/n0-computer/iroh?branch=main#bcce8a0b41fe9faf5cb3cc62f96bb451a060cb57"
+source = "git+https://github.com/n0-computer/iroh?branch=main#904342fba341a6c0816147a45bb91b6ebfb50479"
 dependencies = [
  "aead",
  "anyhow",
@@ -1852,7 +1852,7 @@ dependencies = [
 [[package]]
 name = "iroh-sync"
 version = "0.5.1"
-source = "git+https://github.com/n0-computer/iroh?branch=main#bcce8a0b41fe9faf5cb3cc62f96bb451a060cb57"
+source = "git+https://github.com/n0-computer/iroh?branch=main#904342fba341a6c0816147a45bb91b6ebfb50479"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2511,9 +2511,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12cc1b0bf1727a77a54b6654e7b5f1af8604923edc8b81885f8ec92f9e3f0a05"
+checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
 
 [[package]]
 name = "pin-utils"
@@ -2609,9 +2609,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f32154ba0af3a075eefa1eda8bb414ee928f62303a54ea85b8d6638ff1a6ee9e"
+checksum = "31114a898e107c51bb1609ffaf55a0e011cf6a4d7f1170d0015a165082c0338b"
 
 [[package]]
 name = "positioned-io"
@@ -2979,9 +2979,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.9.3"
+version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81bc1d4caf89fac26a70747fe603c130093b53c773888797a6329091246d651a"
+checksum = "12de2eff854e5fa4b1295edd650e227e9d8fb0c9e90b12e7f36d6a6811791a29"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2991,9 +2991,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed1ceff11a1dddaee50c9dc8e4938bd106e9d89ae372f192311e7da498e3b69"
+checksum = "49530408a136e16e5b486e883fbb6ba058e8e4e8ae6621a77b048b314336e629"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3002,9 +3002,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
+checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "reqwest"
@@ -3153,9 +3153,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.8"
+version = "0.38.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ed4fa021d81c8392ce04db050a3da9a60299050b7ae1cf482d862b54a7218f"
+checksum = "9bfe0f2582b4931a45d1fa608f8a8722e8b3c7ac54dd6d5f3b3212791fedef49"
 dependencies = [
  "bitflags 2.4.0",
  "errno",
@@ -3330,9 +3330,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.186"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f5db24220c009de9bd45e69fb2938f4b6d2df856aa9304ce377b3180f83b7c1"
+checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
 dependencies = [
  "serde_derive",
 ]
@@ -3348,9 +3348,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.186"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ad697f7e0b65af4983a4ce8f56ed5b357e8d3c36651bf6a7e13639c17b8e670"
+checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ tokio-util = { version = "0.7", features = ["io-util", "io"] }
 uniffi = { version = "0.24.3", features = ["cli"] }
 futures = "0.3.28"
 quic-rpc = "0.6.1"
+tracing-subscriber = { version = "0.3.17" }
 
 [build-dependencies]
 uniffi = { version = "0.24.3", features = ["build"] }

--- a/Iroh.xcframework/ios-arm64/Iroh.framework/Headers/irohFFI.h
+++ b/Iroh.xcframework/ios-arm64/Iroh.framework/Headers/irohFFI.h
@@ -118,6 +118,8 @@ RustBuffer uniffi_iroh_fn_method_docticket_to_string(void*_Nonnull ptr, RustCall
 );
 void uniffi_iroh_fn_init_callback_subscribecallback(ForeignCallback _Nonnull callback_stub, RustCallStatus *_Nonnull out_status
 );
+void uniffi_iroh_fn_func_set_log_level(RustBuffer level, RustCallStatus *_Nonnull out_status
+);
 RustBuffer ffi_iroh_rustbuffer_alloc(int32_t size, RustCallStatus *_Nonnull out_status
 );
 RustBuffer ffi_iroh_rustbuffer_from_bytes(ForeignBytes bytes, RustCallStatus *_Nonnull out_status
@@ -125,6 +127,9 @@ RustBuffer ffi_iroh_rustbuffer_from_bytes(ForeignBytes bytes, RustCallStatus *_N
 void ffi_iroh_rustbuffer_free(RustBuffer buf, RustCallStatus *_Nonnull out_status
 );
 RustBuffer ffi_iroh_rustbuffer_reserve(RustBuffer buf, int32_t additional, RustCallStatus *_Nonnull out_status
+);
+uint16_t uniffi_iroh_checksum_func_set_log_level(void
+    
 );
 uint16_t uniffi_iroh_checksum_method_irohnode_peer_id(void
     

--- a/Iroh.xcframework/ios-arm64_x86_64-simulator/Iroh.framework/Headers/irohFFI.h
+++ b/Iroh.xcframework/ios-arm64_x86_64-simulator/Iroh.framework/Headers/irohFFI.h
@@ -118,6 +118,8 @@ RustBuffer uniffi_iroh_fn_method_docticket_to_string(void*_Nonnull ptr, RustCall
 );
 void uniffi_iroh_fn_init_callback_subscribecallback(ForeignCallback _Nonnull callback_stub, RustCallStatus *_Nonnull out_status
 );
+void uniffi_iroh_fn_func_set_log_level(RustBuffer level, RustCallStatus *_Nonnull out_status
+);
 RustBuffer ffi_iroh_rustbuffer_alloc(int32_t size, RustCallStatus *_Nonnull out_status
 );
 RustBuffer ffi_iroh_rustbuffer_from_bytes(ForeignBytes bytes, RustCallStatus *_Nonnull out_status
@@ -125,6 +127,9 @@ RustBuffer ffi_iroh_rustbuffer_from_bytes(ForeignBytes bytes, RustCallStatus *_N
 void ffi_iroh_rustbuffer_free(RustBuffer buf, RustCallStatus *_Nonnull out_status
 );
 RustBuffer ffi_iroh_rustbuffer_reserve(RustBuffer buf, int32_t additional, RustCallStatus *_Nonnull out_status
+);
+uint16_t uniffi_iroh_checksum_func_set_log_level(void
+    
 );
 uint16_t uniffi_iroh_checksum_method_irohnode_peer_id(void
     

--- a/src/iroh.udl
+++ b/src/iroh.udl
@@ -1,4 +1,14 @@
 namespace iroh {
+  void set_log_level(LogLevel level);
+};
+
+enum LogLevel {
+  "Trace",
+  "Debug",
+  "Info",
+  "Warn",
+  "Error",
+  "Off",
 };
 
 interface IrohNode {

--- a/src/node.rs
+++ b/src/node.rs
@@ -47,9 +47,11 @@ pub fn set_log_level(level: LogLevel) {
     use tracing_subscriber::{fmt, prelude::*, reload};
     let filter: LevelFilter = level.into();
     let (filter, _) = reload::Layer::new(filter);
+    let mut layer = fmt::Layer::default();
+    layer.set_ansi(false);
     tracing_subscriber::registry()
         .with(filter)
-        .with(fmt::Layer::default())
+        .with(layer)
         .init();
 }
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -19,6 +19,39 @@ use crate::error::IrohError as Error;
 
 pub use iroh::rpc_protocol::CounterStats;
 pub use iroh::sync::Entry;
+use tracing_subscriber::filter::LevelFilter;
+
+pub enum LogLevel {
+    Trace,
+    Debug,
+    Info,
+    Warn,
+    Error,
+    Off,
+}
+
+impl From<LogLevel> for LevelFilter {
+    fn from(level: LogLevel) -> LevelFilter {
+        match level {
+            LogLevel::Trace => LevelFilter::TRACE,
+            LogLevel::Debug => LevelFilter::DEBUG,
+            LogLevel::Info => LevelFilter::INFO,
+            LogLevel::Warn => LevelFilter::WARN,
+            LogLevel::Error => LevelFilter::ERROR,
+            LogLevel::Off => LevelFilter::OFF,
+        }
+    }
+}
+
+pub fn set_log_level(level: LogLevel) {
+    use tracing_subscriber::{fmt, prelude::*, reload};
+    let filter: LevelFilter = level.into();
+    let (filter, _) = reload::Layer::new(filter);
+    tracing_subscriber::registry()
+        .with(filter)
+        .with(fmt::Layer::default())
+        .init();
+}
 
 #[derive(Debug)]
 pub enum LiveEvent {


### PR DESCRIPTION
output isn't very glamorous, but at least lets you see what's going on.
I've updated to not show ANSI after this screenshot was taken:
<img width="1920" alt="Screenshot 2023-08-25 at 5 15 53 PM" src="https://github.com/n0-computer/iroh-ffi/assets/1154390/78abb861-94c7-4e0f-a2a0-84778f6a4bf6">
