### PR TITLE
build: bump Cargo.toml version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iroh-ffi"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 publish = false
 readme = "README.md"


### PR DESCRIPTION
This version is used by the python bindings.  Since this is a new
release bump them to the next number.  We don't currently match the
version number with iroh's version number.