### PR TITLE
add `blob_add` command, that adds a blob by a path

### DIFF
--- a/Iroh.xcframework/ios-arm64/Iroh.framework/Headers/irohFFI.h
+++ b/Iroh.xcframework/ios-arm64/Iroh.framework/Headers/irohFFI.h
@@ -123,6 +123,8 @@ RustBuffer uniffi_iroh_fn_method_irohnode_author_list(void*_Nonnull ptr, RustCal
 );
 void*_Nonnull uniffi_iroh_fn_method_irohnode_author_new(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
+RustBuffer uniffi_iroh_fn_method_irohnode_blob_add(void*_Nonnull ptr, RustBuffer path, int8_t in_place, RustBuffer tag, int8_t wrap, RustBuffer filename, RustCallStatus *_Nonnull out_status
+);
 RustBuffer uniffi_iroh_fn_method_irohnode_blob_get(void*_Nonnull ptr, void*_Nonnull hash, RustCallStatus *_Nonnull out_status
 );
 RustBuffer uniffi_iroh_fn_method_irohnode_blob_list_blobs(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
@@ -240,6 +242,9 @@ uint16_t uniffi_iroh_checksum_method_irohnode_author_list(void
     
 );
 uint16_t uniffi_iroh_checksum_method_irohnode_author_new(void
+    
+);
+uint16_t uniffi_iroh_checksum_method_irohnode_blob_add(void
     
 );
 uint16_t uniffi_iroh_checksum_method_irohnode_blob_get(void

--- a/Iroh.xcframework/ios-arm64_x86_64-simulator/Iroh.framework/Headers/irohFFI.h
+++ b/Iroh.xcframework/ios-arm64_x86_64-simulator/Iroh.framework/Headers/irohFFI.h
@@ -123,6 +123,8 @@ RustBuffer uniffi_iroh_fn_method_irohnode_author_list(void*_Nonnull ptr, RustCal
 );
 void*_Nonnull uniffi_iroh_fn_method_irohnode_author_new(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
+RustBuffer uniffi_iroh_fn_method_irohnode_blob_add(void*_Nonnull ptr, RustBuffer path, int8_t in_place, RustBuffer tag, int8_t wrap, RustBuffer filename, RustCallStatus *_Nonnull out_status
+);
 RustBuffer uniffi_iroh_fn_method_irohnode_blob_get(void*_Nonnull ptr, void*_Nonnull hash, RustCallStatus *_Nonnull out_status
 );
 RustBuffer uniffi_iroh_fn_method_irohnode_blob_list_blobs(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
@@ -240,6 +242,9 @@ uint16_t uniffi_iroh_checksum_method_irohnode_author_list(void
     
 );
 uint16_t uniffi_iroh_checksum_method_irohnode_author_new(void
+    
+);
+uint16_t uniffi_iroh_checksum_method_irohnode_blob_add(void
     
 );
 uint16_t uniffi_iroh_checksum_method_irohnode_blob_get(void

--- a/go/iroh/iroh.go
+++ b/go/iroh/iroh.go
@@ -528,6 +528,15 @@ func uniffiCheckChecksums() {
 	}
 	{
 		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_iroh_checksum_method_irohnode_blob_add(uniffiStatus)
+		})
+		if checksum != 27487 {
+			// If this happens try cleaning and rebuilding your project
+			panic("iroh: uniffi_iroh_checksum_method_irohnode_blob_add: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_iroh_checksum_method_irohnode_blob_get(uniffiStatus)
 		})
 		if checksum != 2655 {
@@ -1484,6 +1493,21 @@ func (_self *IrohNode) AuthorNew() (*AuthorId, error) {
 	}
 }
 
+func (_self *IrohNode) BlobAdd(path string, inPlace bool, tag *string, wrap bool, filename *string) ([]BlobEntry, error) {
+	_pointer := _self.ffiObject.incrementPointer("*IrohNode")
+	defer _self.ffiObject.decrementPointer()
+	_uniffiRV, _uniffiErr := rustCallWithError(FfiConverterTypeIrohError{}, func(_uniffiStatus *C.RustCallStatus) RustBufferI {
+		return C.uniffi_iroh_fn_method_irohnode_blob_add(
+			_pointer, FfiConverterStringINSTANCE.Lower(path), FfiConverterBoolINSTANCE.Lower(inPlace), FfiConverterOptionalStringINSTANCE.Lower(tag), FfiConverterBoolINSTANCE.Lower(wrap), FfiConverterOptionalStringINSTANCE.Lower(filename), _uniffiStatus)
+	})
+	if _uniffiErr != nil {
+		var _uniffiDefaultValue []BlobEntry
+		return _uniffiDefaultValue, _uniffiErr
+	} else {
+		return FfiConverterSequenceTypeBlobEntryINSTANCE.Lift(_uniffiRV), _uniffiErr
+	}
+}
+
 func (_self *IrohNode) BlobGet(hash *Hash) ([]byte, error) {
 	_pointer := _self.ffiObject.incrementPointer("*IrohNode")
 	defer _self.ffiObject.decrementPointer()
@@ -1888,6 +1912,50 @@ func (c FfiConverterPublicKey) Write(writer io.Writer, value *PublicKey) {
 type FfiDestroyerPublicKey struct{}
 
 func (_ FfiDestroyerPublicKey) Destroy(value *PublicKey) {
+	value.Destroy()
+}
+
+type BlobEntry struct {
+	Name string
+	Size uint64
+	Hash *Hash
+}
+
+func (r *BlobEntry) Destroy() {
+	FfiDestroyerString{}.Destroy(r.Name)
+	FfiDestroyerUint64{}.Destroy(r.Size)
+	FfiDestroyerHash{}.Destroy(r.Hash)
+}
+
+type FfiConverterTypeBlobEntry struct{}
+
+var FfiConverterTypeBlobEntryINSTANCE = FfiConverterTypeBlobEntry{}
+
+func (c FfiConverterTypeBlobEntry) Lift(rb RustBufferI) BlobEntry {
+	return LiftFromRustBuffer[BlobEntry](c, rb)
+}
+
+func (c FfiConverterTypeBlobEntry) Read(reader io.Reader) BlobEntry {
+	return BlobEntry{
+		FfiConverterStringINSTANCE.Read(reader),
+		FfiConverterUint64INSTANCE.Read(reader),
+		FfiConverterHashINSTANCE.Read(reader),
+	}
+}
+
+func (c FfiConverterTypeBlobEntry) Lower(value BlobEntry) RustBuffer {
+	return LowerIntoRustBuffer[BlobEntry](c, value)
+}
+
+func (c FfiConverterTypeBlobEntry) Write(writer io.Writer, value BlobEntry) {
+	FfiConverterStringINSTANCE.Write(writer, value.Name)
+	FfiConverterUint64INSTANCE.Write(writer, value.Size)
+	FfiConverterHashINSTANCE.Write(writer, value.Hash)
+}
+
+type FfiDestroyerTypeBlobEntry struct{}
+
+func (_ FfiDestroyerTypeBlobEntry) Destroy(value BlobEntry) {
 	value.Destroy()
 }
 
@@ -3272,6 +3340,49 @@ type FfiDestroyerSequenceNamespaceId struct{}
 func (FfiDestroyerSequenceNamespaceId) Destroy(sequence []*NamespaceId) {
 	for _, value := range sequence {
 		FfiDestroyerNamespaceId{}.Destroy(value)
+	}
+}
+
+type FfiConverterSequenceTypeBlobEntry struct{}
+
+var FfiConverterSequenceTypeBlobEntryINSTANCE = FfiConverterSequenceTypeBlobEntry{}
+
+func (c FfiConverterSequenceTypeBlobEntry) Lift(rb RustBufferI) []BlobEntry {
+	return LiftFromRustBuffer[[]BlobEntry](c, rb)
+}
+
+func (c FfiConverterSequenceTypeBlobEntry) Read(reader io.Reader) []BlobEntry {
+	length := readInt32(reader)
+	if length == 0 {
+		return nil
+	}
+	result := make([]BlobEntry, 0, length)
+	for i := int32(0); i < length; i++ {
+		result = append(result, FfiConverterTypeBlobEntryINSTANCE.Read(reader))
+	}
+	return result
+}
+
+func (c FfiConverterSequenceTypeBlobEntry) Lower(value []BlobEntry) RustBuffer {
+	return LowerIntoRustBuffer[[]BlobEntry](c, value)
+}
+
+func (c FfiConverterSequenceTypeBlobEntry) Write(writer io.Writer, value []BlobEntry) {
+	if len(value) > math.MaxInt32 {
+		panic("[]BlobEntry is too large to fit into Int32")
+	}
+
+	writeInt32(writer, int32(len(value)))
+	for _, item := range value {
+		FfiConverterTypeBlobEntryINSTANCE.Write(writer, item)
+	}
+}
+
+type FfiDestroyerSequenceTypeBlobEntry struct{}
+
+func (FfiDestroyerSequenceTypeBlobEntry) Destroy(sequence []BlobEntry) {
+	for _, value := range sequence {
+		FfiDestroyerTypeBlobEntry{}.Destroy(value)
 	}
 }
 

--- a/go/iroh/iroh.h
+++ b/go/iroh/iroh.h
@@ -210,6 +210,16 @@ void* uniffi_iroh_fn_method_irohnode_author_new(
 	RustCallStatus* out_status
 );
 
+RustBuffer uniffi_iroh_fn_method_irohnode_blob_add(
+	void* ptr,
+	RustBuffer path,
+	int8_t in_place,
+	RustBuffer tag,
+	int8_t wrap,
+	RustBuffer filename,
+	RustCallStatus* out_status
+);
+
 RustBuffer uniffi_iroh_fn_method_irohnode_blob_get(
 	void* ptr,
 	void* hash,
@@ -438,6 +448,10 @@ uint16_t uniffi_iroh_checksum_method_irohnode_author_new(
 	RustCallStatus* out_status
 );
 
+uint16_t uniffi_iroh_checksum_method_irohnode_blob_add(
+	RustCallStatus* out_status
+);
+
 uint16_t uniffi_iroh_checksum_method_irohnode_blob_get(
 	RustCallStatus* out_status
 );
@@ -555,5 +569,6 @@ void uniffiFutureCallbackHandlerSequenceAuthorIdTypeIrohError(void *, RustBuffer
 void uniffiFutureCallbackHandlerSequenceEntryTypeIrohError(void *, RustBuffer, RustCallStatus);
 void uniffiFutureCallbackHandlerSequenceHashTypeIrohError(void *, RustBuffer, RustCallStatus);
 void uniffiFutureCallbackHandlerSequenceNamespaceIdTypeIrohError(void *, RustBuffer, RustCallStatus);
+void uniffiFutureCallbackHandlerSequenceTypeBlobEntryTypeIrohError(void *, RustBuffer, RustCallStatus);
 void uniffiFutureCallbackHandlerSequenceTypeConnectionInfoTypeIrohError(void *, RustBuffer, RustCallStatus);
 void uniffiFutureCallbackHandlerMapStringTypeCounterStatsTypeIrohError(void *, RustBuffer, RustCallStatus);

--- a/go/main.go
+++ b/go/main.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"bufio"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/n0-computer/iroh-ffi/iroh"
 )
@@ -87,6 +89,22 @@ func main() {
 	fmt.Printf("Listing all %d documents:\n", len(docs))
 	for _, doc_id := range docs {
 		fmt.Printf("\t%s\n", doc_id.ToString())
+	}
+
+	reader := bufio.NewReader(os.Stdin)
+	fmt.Printf("\nSupply a path to add files to the blob store: ")
+	text, err := reader.ReadString('\n')
+	if err != nil {
+		panic(err)
+	}
+	text = strings.TrimSpace(text)
+	fmt.Printf("\nAdding %s to the blob store...\n", text)
+	blobs, err := node.BlobAdd(text, false, nil, false, nil)
+	if err != nil {
+		panic(err)
+	}
+	for _, blob := range blobs {
+		fmt.Printf("\tblob %s, hash %s, size %d\n", blob.Name, blob.Hash.ToString(), blob.Size)
 	}
 
 	fmt.Printf("Goodbye!\n")

--- a/python/main.py
+++ b/python/main.py
@@ -11,8 +11,22 @@ if __name__ == "__main__":
     # parse arguments
     parser = argparse.ArgumentParser(description='Python Iroh Node Demo')
     parser.add_argument('--ticket', type=str, help='ticket to join a document')
+    parser.add_argument('--path', type=str, help='path to add to the blob store')
 
     args = parser.parse_args()
+
+    if args.path:
+        # create iroh node
+        node = iroh.IrohNode(IROH_DATA_DIR)
+        print("Started Iroh node: {}".format(node.node_id()))
+
+        print("Adding {} to the blob store...".format(args.path))
+        blobs = node.blob_add(args.path, False, None, False, None)
+        
+        for blob in blobs:
+            print("blob {}, hash {}, size {}".format(blob.name, blob.hash.to_string(), blob.size))
+
+        exit()
 
     if not args.ticket:
         print("In example mode")

--- a/src/iroh.udl
+++ b/src/iroh.udl
@@ -38,6 +38,8 @@ interface IrohNode {
   sequence<Hash> blob_list_blobs();
   [Throws=IrohError]
   bytes blob_get(Hash hash);
+  [Throws=IrohError]
+  sequence<BlobEntry> blob_add(string path, boolean in_place, string? tag, boolean wrap, string? filename);
 };
 
 interface Doc {
@@ -73,6 +75,12 @@ interface Entry {
   AuthorId author();
   bytes key();
   Hash hash();
+};
+
+dictionary BlobEntry {
+  string name;
+  u64 size;
+  Hash hash;
 };
 
 interface Hash {


### PR DESCRIPTION
Takes the same inputs as the `iroh blob add` command, but returns a list of `BlobEntries`, that contain the name, hash, and size of the blob added.