### PR TITLE
refactor: `Socketaddr`

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -1,0 +1,78 @@
+# Developers
+
+- This uses https://mozilla.github.io/uniffi-rs/ for building the interface
+
+## translating the iroh API into iroh ffi bindings
+Use these general guidelines when translating the rust API featured in the rust
+`iroh` library with the API we detail in this crate:
+- `PathBuf` -> `String`
+- `Bytes`, `[u8]`, etc -> Vec<u8>
+- Any methods that stream files or have `Reader` inputs or outputs should instead expect to read from or write to a file. Also, see if it's logical for any structs or enums that have a method to return a `Reader` to instead have `size` method, so that the user can investigate the size of the data before attempting to save it or load it in memory.
+- Any methods that return a `Stream` of structs (such as a `list` method), should return a `Vec` instead. You should also add a comment that warns the user that this method will load all the entries into memory.
+- Any methods that return progress or events should instead take a call back. Check out the `Doc::subscribe` method and the `SubscribeCallback` trait for how this should be implemented
+- Most methods that return a `Result` should likely get their own unique `IrohError`s, follow the pattern layed out in `error.rs`.
+- Except for unit enums, every struct and enum should be represented in the `udl` file as an interface. It should be expected that the foreign language use constructor methods in order to create structs, and use setters and getters to manipulate the struct, rather than having access to the internal fields themselves.
+- Anything that can be represented as a string, should have a `to_string` and `from_string` method, eg `NamespaceId`, `DocTicket`
+- Enums that have enum variants which contain data should look at the `SocketAddr` or `LiveEvent` enums for the expected translation.
+
+## Testing
+Please include tests when you add new pieces of the API to the ffi bindings
+
+### python
+
+#### pytest
+We use [`pytest`](https://docs.pytest.org/en/7.1.x/contents.html) to test the python api.
+
+Ensure you have the correct virtualenv active, then run `pip install pytest`
+
+Run the tests by using `python -m pytest` in order to correctly include all of the iroh bindings.
+
+#### translations
+Uniffi translates the rust to python in a systematic way. The biggest discrepency between the rust and python syntax are around how new objects are constructed
+
+- constructor methods w/ `new` name:
+    `Ipv4Addr::new(127, 0, 0, 1)` in rust would be `Ipv4Addr(127, 0, 0, 1)` in python
+- constructor methods with any other name in rust:
+    `SocketAddr::from_ipv4(..)` in rust would be `SocketAddr.from_ipv4(..)` in python
+- method names will stay the same:
+     `SocketAddr.as_ipv4` in rust will be called `SocketAddr.as_ipv4` in python
+- unit enums will have the same names:
+    `SocketAddrType::V4` in rust will be `SocketAddrType.V4` in python
+- methods that return `Result` in rust will potentially throw exceptions on error in python
+
+#### test file
+Create a test file for each rust module that you create, and test all pieces of the API in that module in the python test file. The file should be named "[MODULENAME]\_test.py". For example, the `iroh::net` ffi bindings crate should have a corresponding "net\_test.py" file. 
+
+### go 
+
+#### go test 
+Read the [Running](#running) section to ensure you include all the pieces necessary for running `go` commands (in this case, `go tests ./...`)
+
+#### translations
+Uniffi translates the rust to go in a systematic way. The biggest discrepency between the rust and go syntax are around how new objects are constructed. Here are the main differences
+
+- constructor methods w/ the name `new` in rust:
+    `Ipv4Addr::new(127, 0, 0, 1)` in rust would be `NewIpv4Addr(127, 0, 0, 1)` in go
+- constructor methods that have any other name in rust:
+    `SocketAddr::from_string(..)` in rust would be `SocketAddrFromString(..)` in go
+- method names become PascalCase:
+    `SocketAddr.as_ipv4` in rust will be called `SocketAddr.AsIpv4` in go 
+- unit enums: 
+    `SocketAddrType::V4` in rust will be `SocketAddrV4` in go 
+- methods that return `Result` in rust:
+    `Ipv4Addr::from_string(..)` returns `Result<String, IrohError>` in rust
+    `Ipv4AddrFromString(..)` returns `String, IrohError` in go
+    as an example:
+    ```go
+        ipv4Addr, err := Ipv4AddrFromString("127.0.0.1")
+        if err != nil {
+            // handle error here
+        }
+    ```
+
+#### test file
+Create a test file for each rust module that you create, and test all pieces of the API in that module in the go test file. The file should be named "[MODULENAME]\_test.go". For example, the `iroh::net` ffi bindings crate should have a corresponding "net\_test.go" file. 
+
+
+
+

--- a/Iroh.xcframework/ios-arm64/Iroh.framework/Headers/irohFFI.h
+++ b/Iroh.xcframework/ios-arm64/Iroh.framework/Headers/irohFFI.h
@@ -61,6 +61,12 @@ typedef struct RustCallStatus {
 
 // Callbacks for UniFFI Futures
 typedef void (*UniFfiFutureCallbackUInt8)(const void * _Nonnull, uint8_t, RustCallStatus);
+typedef void (*UniFfiFutureCallbackUInt16)(const void * _Nonnull, uint16_t, RustCallStatus);
+typedef void (*UniFfiFutureCallbackUnsafeMutableRawPointer)(const void * _Nonnull, void*_Nonnull, RustCallStatus);
+typedef void (*UniFfiFutureCallbackUnsafeMutableRawPointer)(const void * _Nonnull, void*_Nonnull, RustCallStatus);
+typedef void (*UniFfiFutureCallbackUnsafeMutableRawPointer)(const void * _Nonnull, void*_Nonnull, RustCallStatus);
+typedef void (*UniFfiFutureCallbackUnsafeMutableRawPointer)(const void * _Nonnull, void*_Nonnull, RustCallStatus);
+typedef void (*UniFfiFutureCallbackUnsafeMutableRawPointer)(const void * _Nonnull, void*_Nonnull, RustCallStatus);
 typedef void (*UniFfiFutureCallbackUnsafeMutableRawPointer)(const void * _Nonnull, void*_Nonnull, RustCallStatus);
 typedef void (*UniFfiFutureCallbackUnsafeMutableRawPointer)(const void * _Nonnull, void*_Nonnull, RustCallStatus);
 typedef void (*UniFfiFutureCallbackUnsafeMutableRawPointer)(const void * _Nonnull, void*_Nonnull, RustCallStatus);
@@ -115,6 +121,26 @@ RustBuffer uniffi_iroh_fn_method_hash_to_bytes(void*_Nonnull ptr, RustCallStatus
 );
 RustBuffer uniffi_iroh_fn_method_hash_to_string(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
+void uniffi_iroh_fn_free_ipv4addr(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+void*_Nonnull uniffi_iroh_fn_constructor_ipv4addr_from_string(RustBuffer str, RustCallStatus *_Nonnull out_status
+);
+void*_Nonnull uniffi_iroh_fn_constructor_ipv4addr_new(uint8_t a, uint8_t b, uint8_t c, uint8_t d, RustCallStatus *_Nonnull out_status
+);
+RustBuffer uniffi_iroh_fn_method_ipv4addr_octets(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+RustBuffer uniffi_iroh_fn_method_ipv4addr_to_string(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+void uniffi_iroh_fn_free_ipv6addr(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+void*_Nonnull uniffi_iroh_fn_constructor_ipv6addr_from_string(RustBuffer str, RustCallStatus *_Nonnull out_status
+);
+void*_Nonnull uniffi_iroh_fn_constructor_ipv6addr_new(uint16_t a, uint16_t b, uint16_t c, uint16_t d, uint16_t e, uint16_t f, uint16_t g, uint16_t h, RustCallStatus *_Nonnull out_status
+);
+RustBuffer uniffi_iroh_fn_method_ipv6addr_segments(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+RustBuffer uniffi_iroh_fn_method_ipv6addr_to_string(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
 void uniffi_iroh_fn_free_irohnode(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
 void*_Nonnull uniffi_iroh_fn_constructor_irohnode_new(RustBuffer path, RustCallStatus *_Nonnull out_status
@@ -166,6 +192,42 @@ void uniffi_iroh_fn_free_publickey(void*_Nonnull ptr, RustCallStatus *_Nonnull o
 RustBuffer uniffi_iroh_fn_method_publickey_to_bytes(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
 RustBuffer uniffi_iroh_fn_method_publickey_to_string(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+void uniffi_iroh_fn_free_socketaddr(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+void*_Nonnull uniffi_iroh_fn_constructor_socketaddr_from_v4(void*_Nonnull ipv4, uint16_t port, RustCallStatus *_Nonnull out_status
+);
+void*_Nonnull uniffi_iroh_fn_constructor_socketaddr_from_v6(void*_Nonnull ipv6, uint16_t port, RustCallStatus *_Nonnull out_status
+);
+RustBuffer uniffi_iroh_fn_method_socketaddr_type(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+void*_Nonnull uniffi_iroh_fn_method_socketaddr_v4(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+void*_Nonnull uniffi_iroh_fn_method_socketaddr_v6(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+void uniffi_iroh_fn_free_socketaddrv4(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+void*_Nonnull uniffi_iroh_fn_constructor_socketaddrv4_from_string(RustBuffer str, RustCallStatus *_Nonnull out_status
+);
+void*_Nonnull uniffi_iroh_fn_constructor_socketaddrv4_new(void*_Nonnull ipv4, uint16_t port, RustCallStatus *_Nonnull out_status
+);
+void*_Nonnull uniffi_iroh_fn_method_socketaddrv4_ip(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+uint16_t uniffi_iroh_fn_method_socketaddrv4_port(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+RustBuffer uniffi_iroh_fn_method_socketaddrv4_to_string(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+void uniffi_iroh_fn_free_socketaddrv6(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+void*_Nonnull uniffi_iroh_fn_constructor_socketaddrv6_from_string(RustBuffer str, RustCallStatus *_Nonnull out_status
+);
+void*_Nonnull uniffi_iroh_fn_constructor_socketaddrv6_new(void*_Nonnull ipv6, uint16_t port, RustCallStatus *_Nonnull out_status
+);
+void*_Nonnull uniffi_iroh_fn_method_socketaddrv6_ip(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+uint16_t uniffi_iroh_fn_method_socketaddrv6_port(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+RustBuffer uniffi_iroh_fn_method_socketaddrv6_to_string(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
 void uniffi_iroh_fn_init_callback_subscribecallback(ForeignCallback _Nonnull callback_stub, RustCallStatus *_Nonnull out_status
 );
@@ -236,6 +298,18 @@ uint16_t uniffi_iroh_checksum_method_hash_to_bytes(void
 uint16_t uniffi_iroh_checksum_method_hash_to_string(void
     
 );
+uint16_t uniffi_iroh_checksum_method_ipv4addr_octets(void
+    
+);
+uint16_t uniffi_iroh_checksum_method_ipv4addr_to_string(void
+    
+);
+uint16_t uniffi_iroh_checksum_method_ipv6addr_segments(void
+    
+);
+uint16_t uniffi_iroh_checksum_method_ipv6addr_to_string(void
+    
+);
 uint16_t uniffi_iroh_checksum_method_irohnode_author_list(void
     
 );
@@ -299,10 +373,67 @@ uint16_t uniffi_iroh_checksum_method_publickey_to_bytes(void
 uint16_t uniffi_iroh_checksum_method_publickey_to_string(void
     
 );
+uint16_t uniffi_iroh_checksum_method_socketaddr_type(void
+    
+);
+uint16_t uniffi_iroh_checksum_method_socketaddr_v4(void
+    
+);
+uint16_t uniffi_iroh_checksum_method_socketaddr_v6(void
+    
+);
+uint16_t uniffi_iroh_checksum_method_socketaddrv4_ip(void
+    
+);
+uint16_t uniffi_iroh_checksum_method_socketaddrv4_port(void
+    
+);
+uint16_t uniffi_iroh_checksum_method_socketaddrv4_to_string(void
+    
+);
+uint16_t uniffi_iroh_checksum_method_socketaddrv6_ip(void
+    
+);
+uint16_t uniffi_iroh_checksum_method_socketaddrv6_port(void
+    
+);
+uint16_t uniffi_iroh_checksum_method_socketaddrv6_to_string(void
+    
+);
 uint16_t uniffi_iroh_checksum_constructor_docticket_from_string(void
     
 );
+uint16_t uniffi_iroh_checksum_constructor_ipv4addr_from_string(void
+    
+);
+uint16_t uniffi_iroh_checksum_constructor_ipv4addr_new(void
+    
+);
+uint16_t uniffi_iroh_checksum_constructor_ipv6addr_from_string(void
+    
+);
+uint16_t uniffi_iroh_checksum_constructor_ipv6addr_new(void
+    
+);
 uint16_t uniffi_iroh_checksum_constructor_irohnode_new(void
+    
+);
+uint16_t uniffi_iroh_checksum_constructor_socketaddr_from_v4(void
+    
+);
+uint16_t uniffi_iroh_checksum_constructor_socketaddr_from_v6(void
+    
+);
+uint16_t uniffi_iroh_checksum_constructor_socketaddrv4_from_string(void
+    
+);
+uint16_t uniffi_iroh_checksum_constructor_socketaddrv4_new(void
+    
+);
+uint16_t uniffi_iroh_checksum_constructor_socketaddrv6_from_string(void
+    
+);
+uint16_t uniffi_iroh_checksum_constructor_socketaddrv6_new(void
     
 );
 uint16_t uniffi_iroh_checksum_method_subscribecallback_event(void

--- a/Iroh.xcframework/ios-arm64_x86_64-simulator/Iroh.framework/Headers/irohFFI.h
+++ b/Iroh.xcframework/ios-arm64_x86_64-simulator/Iroh.framework/Headers/irohFFI.h
@@ -61,6 +61,12 @@ typedef struct RustCallStatus {
 
 // Callbacks for UniFFI Futures
 typedef void (*UniFfiFutureCallbackUInt8)(const void * _Nonnull, uint8_t, RustCallStatus);
+typedef void (*UniFfiFutureCallbackUInt16)(const void * _Nonnull, uint16_t, RustCallStatus);
+typedef void (*UniFfiFutureCallbackUnsafeMutableRawPointer)(const void * _Nonnull, void*_Nonnull, RustCallStatus);
+typedef void (*UniFfiFutureCallbackUnsafeMutableRawPointer)(const void * _Nonnull, void*_Nonnull, RustCallStatus);
+typedef void (*UniFfiFutureCallbackUnsafeMutableRawPointer)(const void * _Nonnull, void*_Nonnull, RustCallStatus);
+typedef void (*UniFfiFutureCallbackUnsafeMutableRawPointer)(const void * _Nonnull, void*_Nonnull, RustCallStatus);
+typedef void (*UniFfiFutureCallbackUnsafeMutableRawPointer)(const void * _Nonnull, void*_Nonnull, RustCallStatus);
 typedef void (*UniFfiFutureCallbackUnsafeMutableRawPointer)(const void * _Nonnull, void*_Nonnull, RustCallStatus);
 typedef void (*UniFfiFutureCallbackUnsafeMutableRawPointer)(const void * _Nonnull, void*_Nonnull, RustCallStatus);
 typedef void (*UniFfiFutureCallbackUnsafeMutableRawPointer)(const void * _Nonnull, void*_Nonnull, RustCallStatus);
@@ -115,6 +121,26 @@ RustBuffer uniffi_iroh_fn_method_hash_to_bytes(void*_Nonnull ptr, RustCallStatus
 );
 RustBuffer uniffi_iroh_fn_method_hash_to_string(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
+void uniffi_iroh_fn_free_ipv4addr(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+void*_Nonnull uniffi_iroh_fn_constructor_ipv4addr_from_string(RustBuffer str, RustCallStatus *_Nonnull out_status
+);
+void*_Nonnull uniffi_iroh_fn_constructor_ipv4addr_new(uint8_t a, uint8_t b, uint8_t c, uint8_t d, RustCallStatus *_Nonnull out_status
+);
+RustBuffer uniffi_iroh_fn_method_ipv4addr_octets(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+RustBuffer uniffi_iroh_fn_method_ipv4addr_to_string(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+void uniffi_iroh_fn_free_ipv6addr(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+void*_Nonnull uniffi_iroh_fn_constructor_ipv6addr_from_string(RustBuffer str, RustCallStatus *_Nonnull out_status
+);
+void*_Nonnull uniffi_iroh_fn_constructor_ipv6addr_new(uint16_t a, uint16_t b, uint16_t c, uint16_t d, uint16_t e, uint16_t f, uint16_t g, uint16_t h, RustCallStatus *_Nonnull out_status
+);
+RustBuffer uniffi_iroh_fn_method_ipv6addr_segments(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+RustBuffer uniffi_iroh_fn_method_ipv6addr_to_string(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
 void uniffi_iroh_fn_free_irohnode(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
 void*_Nonnull uniffi_iroh_fn_constructor_irohnode_new(RustBuffer path, RustCallStatus *_Nonnull out_status
@@ -166,6 +192,42 @@ void uniffi_iroh_fn_free_publickey(void*_Nonnull ptr, RustCallStatus *_Nonnull o
 RustBuffer uniffi_iroh_fn_method_publickey_to_bytes(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
 RustBuffer uniffi_iroh_fn_method_publickey_to_string(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+void uniffi_iroh_fn_free_socketaddr(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+void*_Nonnull uniffi_iroh_fn_constructor_socketaddr_from_v4(void*_Nonnull ipv4, uint16_t port, RustCallStatus *_Nonnull out_status
+);
+void*_Nonnull uniffi_iroh_fn_constructor_socketaddr_from_v6(void*_Nonnull ipv6, uint16_t port, RustCallStatus *_Nonnull out_status
+);
+RustBuffer uniffi_iroh_fn_method_socketaddr_type(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+void*_Nonnull uniffi_iroh_fn_method_socketaddr_v4(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+void*_Nonnull uniffi_iroh_fn_method_socketaddr_v6(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+void uniffi_iroh_fn_free_socketaddrv4(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+void*_Nonnull uniffi_iroh_fn_constructor_socketaddrv4_from_string(RustBuffer str, RustCallStatus *_Nonnull out_status
+);
+void*_Nonnull uniffi_iroh_fn_constructor_socketaddrv4_new(void*_Nonnull ipv4, uint16_t port, RustCallStatus *_Nonnull out_status
+);
+void*_Nonnull uniffi_iroh_fn_method_socketaddrv4_ip(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+uint16_t uniffi_iroh_fn_method_socketaddrv4_port(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+RustBuffer uniffi_iroh_fn_method_socketaddrv4_to_string(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+void uniffi_iroh_fn_free_socketaddrv6(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+void*_Nonnull uniffi_iroh_fn_constructor_socketaddrv6_from_string(RustBuffer str, RustCallStatus *_Nonnull out_status
+);
+void*_Nonnull uniffi_iroh_fn_constructor_socketaddrv6_new(void*_Nonnull ipv6, uint16_t port, RustCallStatus *_Nonnull out_status
+);
+void*_Nonnull uniffi_iroh_fn_method_socketaddrv6_ip(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+uint16_t uniffi_iroh_fn_method_socketaddrv6_port(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+RustBuffer uniffi_iroh_fn_method_socketaddrv6_to_string(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
 void uniffi_iroh_fn_init_callback_subscribecallback(ForeignCallback _Nonnull callback_stub, RustCallStatus *_Nonnull out_status
 );
@@ -236,6 +298,18 @@ uint16_t uniffi_iroh_checksum_method_hash_to_bytes(void
 uint16_t uniffi_iroh_checksum_method_hash_to_string(void
     
 );
+uint16_t uniffi_iroh_checksum_method_ipv4addr_octets(void
+    
+);
+uint16_t uniffi_iroh_checksum_method_ipv4addr_to_string(void
+    
+);
+uint16_t uniffi_iroh_checksum_method_ipv6addr_segments(void
+    
+);
+uint16_t uniffi_iroh_checksum_method_ipv6addr_to_string(void
+    
+);
 uint16_t uniffi_iroh_checksum_method_irohnode_author_list(void
     
 );
@@ -299,10 +373,67 @@ uint16_t uniffi_iroh_checksum_method_publickey_to_bytes(void
 uint16_t uniffi_iroh_checksum_method_publickey_to_string(void
     
 );
+uint16_t uniffi_iroh_checksum_method_socketaddr_type(void
+    
+);
+uint16_t uniffi_iroh_checksum_method_socketaddr_v4(void
+    
+);
+uint16_t uniffi_iroh_checksum_method_socketaddr_v6(void
+    
+);
+uint16_t uniffi_iroh_checksum_method_socketaddrv4_ip(void
+    
+);
+uint16_t uniffi_iroh_checksum_method_socketaddrv4_port(void
+    
+);
+uint16_t uniffi_iroh_checksum_method_socketaddrv4_to_string(void
+    
+);
+uint16_t uniffi_iroh_checksum_method_socketaddrv6_ip(void
+    
+);
+uint16_t uniffi_iroh_checksum_method_socketaddrv6_port(void
+    
+);
+uint16_t uniffi_iroh_checksum_method_socketaddrv6_to_string(void
+    
+);
 uint16_t uniffi_iroh_checksum_constructor_docticket_from_string(void
     
 );
+uint16_t uniffi_iroh_checksum_constructor_ipv4addr_from_string(void
+    
+);
+uint16_t uniffi_iroh_checksum_constructor_ipv4addr_new(void
+    
+);
+uint16_t uniffi_iroh_checksum_constructor_ipv6addr_from_string(void
+    
+);
+uint16_t uniffi_iroh_checksum_constructor_ipv6addr_new(void
+    
+);
 uint16_t uniffi_iroh_checksum_constructor_irohnode_new(void
+    
+);
+uint16_t uniffi_iroh_checksum_constructor_socketaddr_from_v4(void
+    
+);
+uint16_t uniffi_iroh_checksum_constructor_socketaddr_from_v6(void
+    
+);
+uint16_t uniffi_iroh_checksum_constructor_socketaddrv4_from_string(void
+    
+);
+uint16_t uniffi_iroh_checksum_constructor_socketaddrv4_new(void
+    
+);
+uint16_t uniffi_iroh_checksum_constructor_socketaddrv6_from_string(void
+    
+);
+uint16_t uniffi_iroh_checksum_constructor_socketaddrv6_new(void
     
 );
 uint16_t uniffi_iroh_checksum_method_subscribecallback_event(void

--- a/IrohLib/Sources/IrohLib/IrohLib.swift
+++ b/IrohLib/Sources/IrohLib/IrohLib.swift
@@ -863,6 +863,200 @@ public func FfiConverterTypeHash_lower(_ value: Hash) -> UnsafeMutableRawPointer
     return FfiConverterTypeHash.lower(value)
 }
 
+public protocol Ipv4AddrProtocol {
+    func octets() -> [UInt8]
+    func toString() -> String
+}
+
+public class Ipv4Addr: Ipv4AddrProtocol {
+    fileprivate let pointer: UnsafeMutableRawPointer
+
+    // TODO: We'd like this to be `private` but for Swifty reasons,
+    // we can't implement `FfiConverter` without making this `required` and we can't
+    // make it `required` without making it `public`.
+    required init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
+        self.pointer = pointer
+    }
+
+    public convenience init(a: UInt8, b: UInt8, c: UInt8, d: UInt8) {
+        self.init(unsafeFromRawPointer: try! rustCall {
+            uniffi_iroh_fn_constructor_ipv4addr_new(
+                FfiConverterUInt8.lower(a),
+                FfiConverterUInt8.lower(b),
+                FfiConverterUInt8.lower(c),
+                FfiConverterUInt8.lower(d), $0
+            )
+        })
+    }
+
+    deinit {
+        try! rustCall { uniffi_iroh_fn_free_ipv4addr(pointer, $0) }
+    }
+
+    public static func fromString(str: String) throws -> Ipv4Addr {
+        return try Ipv4Addr(unsafeFromRawPointer: rustCallWithError(FfiConverterTypeIrohError.lift) {
+            uniffi_iroh_fn_constructor_ipv4addr_from_string(
+                FfiConverterString.lower(str), $0
+            )
+        })
+    }
+
+    public func octets() -> [UInt8] {
+        return try! FfiConverterSequenceUInt8.lift(
+            try!
+                rustCall {
+                    uniffi_iroh_fn_method_ipv4addr_octets(self.pointer, $0)
+                }
+        )
+    }
+
+    public func toString() -> String {
+        return try! FfiConverterString.lift(
+            try!
+                rustCall {
+                    uniffi_iroh_fn_method_ipv4addr_to_string(self.pointer, $0)
+                }
+        )
+    }
+}
+
+public struct FfiConverterTypeIpv4Addr: FfiConverter {
+    typealias FfiType = UnsafeMutableRawPointer
+    typealias SwiftType = Ipv4Addr
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> Ipv4Addr {
+        let v: UInt64 = try readInt(&buf)
+        // The Rust code won't compile if a pointer won't fit in a UInt64.
+        // We have to go via `UInt` because that's the thing that's the size of a pointer.
+        let ptr = UnsafeMutableRawPointer(bitPattern: UInt(truncatingIfNeeded: v))
+        if ptr == nil {
+            throw UniffiInternalError.unexpectedNullPointer
+        }
+        return try lift(ptr!)
+    }
+
+    public static func write(_ value: Ipv4Addr, into buf: inout [UInt8]) {
+        // This fiddling is because `Int` is the thing that's the same size as a pointer.
+        // The Rust code won't compile if a pointer won't fit in a `UInt64`.
+        writeInt(&buf, UInt64(bitPattern: Int64(Int(bitPattern: lower(value)))))
+    }
+
+    public static func lift(_ pointer: UnsafeMutableRawPointer) throws -> Ipv4Addr {
+        return Ipv4Addr(unsafeFromRawPointer: pointer)
+    }
+
+    public static func lower(_ value: Ipv4Addr) -> UnsafeMutableRawPointer {
+        return value.pointer
+    }
+}
+
+public func FfiConverterTypeIpv4Addr_lift(_ pointer: UnsafeMutableRawPointer) throws -> Ipv4Addr {
+    return try FfiConverterTypeIpv4Addr.lift(pointer)
+}
+
+public func FfiConverterTypeIpv4Addr_lower(_ value: Ipv4Addr) -> UnsafeMutableRawPointer {
+    return FfiConverterTypeIpv4Addr.lower(value)
+}
+
+public protocol Ipv6AddrProtocol {
+    func segments() -> [UInt16]
+    func toString() -> String
+}
+
+public class Ipv6Addr: Ipv6AddrProtocol {
+    fileprivate let pointer: UnsafeMutableRawPointer
+
+    // TODO: We'd like this to be `private` but for Swifty reasons,
+    // we can't implement `FfiConverter` without making this `required` and we can't
+    // make it `required` without making it `public`.
+    required init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
+        self.pointer = pointer
+    }
+
+    public convenience init(a: UInt16, b: UInt16, c: UInt16, d: UInt16, e: UInt16, f: UInt16, g: UInt16, h: UInt16) {
+        self.init(unsafeFromRawPointer: try! rustCall {
+            uniffi_iroh_fn_constructor_ipv6addr_new(
+                FfiConverterUInt16.lower(a),
+                FfiConverterUInt16.lower(b),
+                FfiConverterUInt16.lower(c),
+                FfiConverterUInt16.lower(d),
+                FfiConverterUInt16.lower(e),
+                FfiConverterUInt16.lower(f),
+                FfiConverterUInt16.lower(g),
+                FfiConverterUInt16.lower(h), $0
+            )
+        })
+    }
+
+    deinit {
+        try! rustCall { uniffi_iroh_fn_free_ipv6addr(pointer, $0) }
+    }
+
+    public static func fromString(str: String) throws -> Ipv6Addr {
+        return try Ipv6Addr(unsafeFromRawPointer: rustCallWithError(FfiConverterTypeIrohError.lift) {
+            uniffi_iroh_fn_constructor_ipv6addr_from_string(
+                FfiConverterString.lower(str), $0
+            )
+        })
+    }
+
+    public func segments() -> [UInt16] {
+        return try! FfiConverterSequenceUInt16.lift(
+            try!
+                rustCall {
+                    uniffi_iroh_fn_method_ipv6addr_segments(self.pointer, $0)
+                }
+        )
+    }
+
+    public func toString() -> String {
+        return try! FfiConverterString.lift(
+            try!
+                rustCall {
+                    uniffi_iroh_fn_method_ipv6addr_to_string(self.pointer, $0)
+                }
+        )
+    }
+}
+
+public struct FfiConverterTypeIpv6Addr: FfiConverter {
+    typealias FfiType = UnsafeMutableRawPointer
+    typealias SwiftType = Ipv6Addr
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> Ipv6Addr {
+        let v: UInt64 = try readInt(&buf)
+        // The Rust code won't compile if a pointer won't fit in a UInt64.
+        // We have to go via `UInt` because that's the thing that's the size of a pointer.
+        let ptr = UnsafeMutableRawPointer(bitPattern: UInt(truncatingIfNeeded: v))
+        if ptr == nil {
+            throw UniffiInternalError.unexpectedNullPointer
+        }
+        return try lift(ptr!)
+    }
+
+    public static func write(_ value: Ipv6Addr, into buf: inout [UInt8]) {
+        // This fiddling is because `Int` is the thing that's the same size as a pointer.
+        // The Rust code won't compile if a pointer won't fit in a `UInt64`.
+        writeInt(&buf, UInt64(bitPattern: Int64(Int(bitPattern: lower(value)))))
+    }
+
+    public static func lift(_ pointer: UnsafeMutableRawPointer) throws -> Ipv6Addr {
+        return Ipv6Addr(unsafeFromRawPointer: pointer)
+    }
+
+    public static func lower(_ value: Ipv6Addr) -> UnsafeMutableRawPointer {
+        return value.pointer
+    }
+}
+
+public func FfiConverterTypeIpv6Addr_lift(_ pointer: UnsafeMutableRawPointer) throws -> Ipv6Addr {
+    return try FfiConverterTypeIpv6Addr.lift(pointer)
+}
+
+public func FfiConverterTypeIpv6Addr_lower(_ value: Ipv6Addr) -> UnsafeMutableRawPointer {
+    return FfiConverterTypeIpv6Addr.lower(value)
+}
+
 public protocol IrohNodeProtocol {
     func authorList() throws -> [AuthorId]
     func authorNew() throws -> AuthorId
@@ -1298,6 +1492,314 @@ public func FfiConverterTypePublicKey_lower(_ value: PublicKey) -> UnsafeMutable
     return FfiConverterTypePublicKey.lower(value)
 }
 
+public protocol SocketAddrProtocol {
+    func type() -> SocketAddrType
+    func v4() throws -> SocketAddrV4
+    func v6() throws -> SocketAddrV6
+}
+
+public class SocketAddr: SocketAddrProtocol {
+    fileprivate let pointer: UnsafeMutableRawPointer
+
+    // TODO: We'd like this to be `private` but for Swifty reasons,
+    // we can't implement `FfiConverter` without making this `required` and we can't
+    // make it `required` without making it `public`.
+    required init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
+        self.pointer = pointer
+    }
+
+    deinit {
+        try! rustCall { uniffi_iroh_fn_free_socketaddr(pointer, $0) }
+    }
+
+    public static func fromV4(ipv4: Ipv4Addr, port: UInt16) -> SocketAddr {
+        return SocketAddr(unsafeFromRawPointer: try! rustCall {
+            uniffi_iroh_fn_constructor_socketaddr_from_v4(
+                FfiConverterTypeIpv4Addr.lower(ipv4),
+                FfiConverterUInt16.lower(port), $0
+            )
+        })
+    }
+
+    public static func fromV6(ipv6: Ipv6Addr, port: UInt16) -> SocketAddr {
+        return SocketAddr(unsafeFromRawPointer: try! rustCall {
+            uniffi_iroh_fn_constructor_socketaddr_from_v6(
+                FfiConverterTypeIpv6Addr.lower(ipv6),
+                FfiConverterUInt16.lower(port), $0
+            )
+        })
+    }
+
+    public func type() -> SocketAddrType {
+        return try! FfiConverterTypeSocketAddrType.lift(
+            try!
+                rustCall {
+                    uniffi_iroh_fn_method_socketaddr_type(self.pointer, $0)
+                }
+        )
+    }
+
+    public func v4() throws -> SocketAddrV4 {
+        return try FfiConverterTypeSocketAddrV4.lift(
+            rustCallWithError(FfiConverterTypeIrohError.lift) {
+                uniffi_iroh_fn_method_socketaddr_v4(self.pointer, $0)
+            }
+        )
+    }
+
+    public func v6() throws -> SocketAddrV6 {
+        return try FfiConverterTypeSocketAddrV6.lift(
+            rustCallWithError(FfiConverterTypeIrohError.lift) {
+                uniffi_iroh_fn_method_socketaddr_v6(self.pointer, $0)
+            }
+        )
+    }
+}
+
+public struct FfiConverterTypeSocketAddr: FfiConverter {
+    typealias FfiType = UnsafeMutableRawPointer
+    typealias SwiftType = SocketAddr
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SocketAddr {
+        let v: UInt64 = try readInt(&buf)
+        // The Rust code won't compile if a pointer won't fit in a UInt64.
+        // We have to go via `UInt` because that's the thing that's the size of a pointer.
+        let ptr = UnsafeMutableRawPointer(bitPattern: UInt(truncatingIfNeeded: v))
+        if ptr == nil {
+            throw UniffiInternalError.unexpectedNullPointer
+        }
+        return try lift(ptr!)
+    }
+
+    public static func write(_ value: SocketAddr, into buf: inout [UInt8]) {
+        // This fiddling is because `Int` is the thing that's the same size as a pointer.
+        // The Rust code won't compile if a pointer won't fit in a `UInt64`.
+        writeInt(&buf, UInt64(bitPattern: Int64(Int(bitPattern: lower(value)))))
+    }
+
+    public static func lift(_ pointer: UnsafeMutableRawPointer) throws -> SocketAddr {
+        return SocketAddr(unsafeFromRawPointer: pointer)
+    }
+
+    public static func lower(_ value: SocketAddr) -> UnsafeMutableRawPointer {
+        return value.pointer
+    }
+}
+
+public func FfiConverterTypeSocketAddr_lift(_ pointer: UnsafeMutableRawPointer) throws -> SocketAddr {
+    return try FfiConverterTypeSocketAddr.lift(pointer)
+}
+
+public func FfiConverterTypeSocketAddr_lower(_ value: SocketAddr) -> UnsafeMutableRawPointer {
+    return FfiConverterTypeSocketAddr.lower(value)
+}
+
+public protocol SocketAddrV4Protocol {
+    func ip() -> Ipv4Addr
+    func port() -> UInt16
+    func toString() -> String
+}
+
+public class SocketAddrV4: SocketAddrV4Protocol {
+    fileprivate let pointer: UnsafeMutableRawPointer
+
+    // TODO: We'd like this to be `private` but for Swifty reasons,
+    // we can't implement `FfiConverter` without making this `required` and we can't
+    // make it `required` without making it `public`.
+    required init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
+        self.pointer = pointer
+    }
+
+    public convenience init(ipv4: Ipv4Addr, port: UInt16) {
+        self.init(unsafeFromRawPointer: try! rustCall {
+            uniffi_iroh_fn_constructor_socketaddrv4_new(
+                FfiConverterTypeIpv4Addr.lower(ipv4),
+                FfiConverterUInt16.lower(port), $0
+            )
+        })
+    }
+
+    deinit {
+        try! rustCall { uniffi_iroh_fn_free_socketaddrv4(pointer, $0) }
+    }
+
+    public static func fromString(str: String) throws -> SocketAddrV4 {
+        return try SocketAddrV4(unsafeFromRawPointer: rustCallWithError(FfiConverterTypeIrohError.lift) {
+            uniffi_iroh_fn_constructor_socketaddrv4_from_string(
+                FfiConverterString.lower(str), $0
+            )
+        })
+    }
+
+    public func ip() -> Ipv4Addr {
+        return try! FfiConverterTypeIpv4Addr.lift(
+            try!
+                rustCall {
+                    uniffi_iroh_fn_method_socketaddrv4_ip(self.pointer, $0)
+                }
+        )
+    }
+
+    public func port() -> UInt16 {
+        return try! FfiConverterUInt16.lift(
+            try!
+                rustCall {
+                    uniffi_iroh_fn_method_socketaddrv4_port(self.pointer, $0)
+                }
+        )
+    }
+
+    public func toString() -> String {
+        return try! FfiConverterString.lift(
+            try!
+                rustCall {
+                    uniffi_iroh_fn_method_socketaddrv4_to_string(self.pointer, $0)
+                }
+        )
+    }
+}
+
+public struct FfiConverterTypeSocketAddrV4: FfiConverter {
+    typealias FfiType = UnsafeMutableRawPointer
+    typealias SwiftType = SocketAddrV4
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SocketAddrV4 {
+        let v: UInt64 = try readInt(&buf)
+        // The Rust code won't compile if a pointer won't fit in a UInt64.
+        // We have to go via `UInt` because that's the thing that's the size of a pointer.
+        let ptr = UnsafeMutableRawPointer(bitPattern: UInt(truncatingIfNeeded: v))
+        if ptr == nil {
+            throw UniffiInternalError.unexpectedNullPointer
+        }
+        return try lift(ptr!)
+    }
+
+    public static func write(_ value: SocketAddrV4, into buf: inout [UInt8]) {
+        // This fiddling is because `Int` is the thing that's the same size as a pointer.
+        // The Rust code won't compile if a pointer won't fit in a `UInt64`.
+        writeInt(&buf, UInt64(bitPattern: Int64(Int(bitPattern: lower(value)))))
+    }
+
+    public static func lift(_ pointer: UnsafeMutableRawPointer) throws -> SocketAddrV4 {
+        return SocketAddrV4(unsafeFromRawPointer: pointer)
+    }
+
+    public static func lower(_ value: SocketAddrV4) -> UnsafeMutableRawPointer {
+        return value.pointer
+    }
+}
+
+public func FfiConverterTypeSocketAddrV4_lift(_ pointer: UnsafeMutableRawPointer) throws -> SocketAddrV4 {
+    return try FfiConverterTypeSocketAddrV4.lift(pointer)
+}
+
+public func FfiConverterTypeSocketAddrV4_lower(_ value: SocketAddrV4) -> UnsafeMutableRawPointer {
+    return FfiConverterTypeSocketAddrV4.lower(value)
+}
+
+public protocol SocketAddrV6Protocol {
+    func ip() -> Ipv6Addr
+    func port() -> UInt16
+    func toString() -> String
+}
+
+public class SocketAddrV6: SocketAddrV6Protocol {
+    fileprivate let pointer: UnsafeMutableRawPointer
+
+    // TODO: We'd like this to be `private` but for Swifty reasons,
+    // we can't implement `FfiConverter` without making this `required` and we can't
+    // make it `required` without making it `public`.
+    required init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
+        self.pointer = pointer
+    }
+
+    public convenience init(ipv6: Ipv6Addr, port: UInt16) {
+        self.init(unsafeFromRawPointer: try! rustCall {
+            uniffi_iroh_fn_constructor_socketaddrv6_new(
+                FfiConverterTypeIpv6Addr.lower(ipv6),
+                FfiConverterUInt16.lower(port), $0
+            )
+        })
+    }
+
+    deinit {
+        try! rustCall { uniffi_iroh_fn_free_socketaddrv6(pointer, $0) }
+    }
+
+    public static func fromString(str: String) throws -> SocketAddrV6 {
+        return try SocketAddrV6(unsafeFromRawPointer: rustCallWithError(FfiConverterTypeIrohError.lift) {
+            uniffi_iroh_fn_constructor_socketaddrv6_from_string(
+                FfiConverterString.lower(str), $0
+            )
+        })
+    }
+
+    public func ip() -> Ipv6Addr {
+        return try! FfiConverterTypeIpv6Addr.lift(
+            try!
+                rustCall {
+                    uniffi_iroh_fn_method_socketaddrv6_ip(self.pointer, $0)
+                }
+        )
+    }
+
+    public func port() -> UInt16 {
+        return try! FfiConverterUInt16.lift(
+            try!
+                rustCall {
+                    uniffi_iroh_fn_method_socketaddrv6_port(self.pointer, $0)
+                }
+        )
+    }
+
+    public func toString() -> String {
+        return try! FfiConverterString.lift(
+            try!
+                rustCall {
+                    uniffi_iroh_fn_method_socketaddrv6_to_string(self.pointer, $0)
+                }
+        )
+    }
+}
+
+public struct FfiConverterTypeSocketAddrV6: FfiConverter {
+    typealias FfiType = UnsafeMutableRawPointer
+    typealias SwiftType = SocketAddrV6
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SocketAddrV6 {
+        let v: UInt64 = try readInt(&buf)
+        // The Rust code won't compile if a pointer won't fit in a UInt64.
+        // We have to go via `UInt` because that's the thing that's the size of a pointer.
+        let ptr = UnsafeMutableRawPointer(bitPattern: UInt(truncatingIfNeeded: v))
+        if ptr == nil {
+            throw UniffiInternalError.unexpectedNullPointer
+        }
+        return try lift(ptr!)
+    }
+
+    public static func write(_ value: SocketAddrV6, into buf: inout [UInt8]) {
+        // This fiddling is because `Int` is the thing that's the same size as a pointer.
+        // The Rust code won't compile if a pointer won't fit in a `UInt64`.
+        writeInt(&buf, UInt64(bitPattern: Int64(Int(bitPattern: lower(value)))))
+    }
+
+    public static func lift(_ pointer: UnsafeMutableRawPointer) throws -> SocketAddrV6 {
+        return SocketAddrV6(unsafeFromRawPointer: pointer)
+    }
+
+    public static func lower(_ value: SocketAddrV6) -> UnsafeMutableRawPointer {
+        return value.pointer
+    }
+}
+
+public func FfiConverterTypeSocketAddrV6_lift(_ pointer: UnsafeMutableRawPointer) throws -> SocketAddrV6 {
+    return try FfiConverterTypeSocketAddrV6.lift(pointer)
+}
+
+public func FfiConverterTypeSocketAddrV6_lower(_ value: SocketAddrV6) -> UnsafeMutableRawPointer {
+    return FfiConverterTypeSocketAddrV6.lower(value)
+}
+
 public struct ConnectionInfo {
     public var id: UInt64
     public var publicKey: PublicKey
@@ -1541,7 +2043,7 @@ public func FfiConverterTypeSyncEvent_lower(_ value: SyncEvent) -> RustBuffer {
 // Note that we don't yet support `indirect` for enums.
 // See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
 public enum ConnectionType {
-    case direct(addr: SocketAddr)
+    case direct(addr: String, port: UInt16)
     case relay(port: UInt16)
     case none
 }
@@ -1553,7 +2055,8 @@ public struct FfiConverterTypeConnectionType: FfiConverterRustBuffer {
         let variant: Int32 = try readInt(&buf)
         switch variant {
         case 1: return try .direct(
-                addr: FfiConverterTypeSocketAddr.read(from: &buf)
+                addr: FfiConverterString.read(from: &buf),
+                port: FfiConverterUInt16.read(from: &buf)
             )
 
         case 2: return try .relay(
@@ -1568,9 +2071,10 @@ public struct FfiConverterTypeConnectionType: FfiConverterRustBuffer {
 
     public static func write(_ value: ConnectionType, into buf: inout [UInt8]) {
         switch value {
-        case let .direct(addr):
+        case let .direct(addr, port):
             writeInt(&buf, Int32(1))
-            FfiConverterTypeSocketAddr.write(addr, into: &buf)
+            FfiConverterString.write(addr, into: &buf)
+            FfiConverterUInt16.write(port, into: &buf)
 
         case let .relay(port):
             writeInt(&buf, Int32(2))
@@ -1649,6 +2153,11 @@ public enum IrohError {
     case Uniffi(description: String)
     case Connection(description: String)
     case Blob(description: String)
+    case Ipv4Addr(description: String)
+    case Ipv6Addr(description: String)
+    case SocketAddrV4(description: String)
+    case SocketAddrV6(description: String)
+    case SocketAddr(description: String)
 
     fileprivate static func uniffiErrorHandler(_ error: RustBuffer) throws -> Error {
         return try FfiConverterTypeIrohError.lift(error)
@@ -1683,6 +2192,21 @@ public struct FfiConverterTypeIrohError: FfiConverterRustBuffer {
                 description: FfiConverterString.read(from: &buf)
             )
         case 8: return try .Blob(
+                description: FfiConverterString.read(from: &buf)
+            )
+        case 9: return try .Ipv4Addr(
+                description: FfiConverterString.read(from: &buf)
+            )
+        case 10: return try .Ipv6Addr(
+                description: FfiConverterString.read(from: &buf)
+            )
+        case 11: return try .SocketAddrV4(
+                description: FfiConverterString.read(from: &buf)
+            )
+        case 12: return try .SocketAddrV6(
+                description: FfiConverterString.read(from: &buf)
+            )
+        case 13: return try .SocketAddr(
                 description: FfiConverterString.read(from: &buf)
             )
 
@@ -1722,6 +2246,26 @@ public struct FfiConverterTypeIrohError: FfiConverterRustBuffer {
 
         case let .Blob(description):
             writeInt(&buf, Int32(8))
+            FfiConverterString.write(description, into: &buf)
+
+        case let .Ipv4Addr(description):
+            writeInt(&buf, Int32(9))
+            FfiConverterString.write(description, into: &buf)
+
+        case let .Ipv6Addr(description):
+            writeInt(&buf, Int32(10))
+            FfiConverterString.write(description, into: &buf)
+
+        case let .SocketAddrV4(description):
+            writeInt(&buf, Int32(11))
+            FfiConverterString.write(description, into: &buf)
+
+        case let .SocketAddrV6(description):
+            writeInt(&buf, Int32(12))
+            FfiConverterString.write(description, into: &buf)
+
+        case let .SocketAddr(description):
+            writeInt(&buf, Int32(13))
             FfiConverterString.write(description, into: &buf)
         }
     }
@@ -1916,57 +2460,45 @@ extension Origin: Equatable, Hashable {}
 
 // Note that we don't yet support `indirect` for enums.
 // See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
-public enum SocketAddr {
-    case v4(a: UInt8, b: UInt8, c: UInt8, d: UInt8)
-    case v6(addr: Data)
+public enum SocketAddrType {
+    case v4
+    case v6
 }
 
-public struct FfiConverterTypeSocketAddr: FfiConverterRustBuffer {
-    typealias SwiftType = SocketAddr
+public struct FfiConverterTypeSocketAddrType: FfiConverterRustBuffer {
+    typealias SwiftType = SocketAddrType
 
-    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SocketAddr {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SocketAddrType {
         let variant: Int32 = try readInt(&buf)
         switch variant {
-        case 1: return try .v4(
-                a: FfiConverterUInt8.read(from: &buf),
-                b: FfiConverterUInt8.read(from: &buf),
-                c: FfiConverterUInt8.read(from: &buf),
-                d: FfiConverterUInt8.read(from: &buf)
-            )
+        case 1: return .v4
 
-        case 2: return try .v6(
-                addr: FfiConverterData.read(from: &buf)
-            )
+        case 2: return .v6
 
         default: throw UniffiInternalError.unexpectedEnumCase
         }
     }
 
-    public static func write(_ value: SocketAddr, into buf: inout [UInt8]) {
+    public static func write(_ value: SocketAddrType, into buf: inout [UInt8]) {
         switch value {
-        case let .v4(a, b, c, d):
+        case .v4:
             writeInt(&buf, Int32(1))
-            FfiConverterUInt8.write(a, into: &buf)
-            FfiConverterUInt8.write(b, into: &buf)
-            FfiConverterUInt8.write(c, into: &buf)
-            FfiConverterUInt8.write(d, into: &buf)
 
-        case let .v6(addr):
+        case .v6:
             writeInt(&buf, Int32(2))
-            FfiConverterData.write(addr, into: &buf)
         }
     }
 }
 
-public func FfiConverterTypeSocketAddr_lift(_ buf: RustBuffer) throws -> SocketAddr {
-    return try FfiConverterTypeSocketAddr.lift(buf)
+public func FfiConverterTypeSocketAddrType_lift(_ buf: RustBuffer) throws -> SocketAddrType {
+    return try FfiConverterTypeSocketAddrType.lift(buf)
 }
 
-public func FfiConverterTypeSocketAddr_lower(_ value: SocketAddr) -> RustBuffer {
-    return FfiConverterTypeSocketAddr.lower(value)
+public func FfiConverterTypeSocketAddrType_lower(_ value: SocketAddrType) -> RustBuffer {
+    return FfiConverterTypeSocketAddrType.lower(value)
 }
 
-extension SocketAddr: Equatable, Hashable {}
+extension SocketAddrType: Equatable, Hashable {}
 
 // Note that we don't yet support `indirect` for enums.
 // See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
@@ -2265,6 +2797,50 @@ private struct FfiConverterOptionTypeConnectionInfo: FfiConverterRustBuffer {
     }
 }
 
+private struct FfiConverterSequenceUInt8: FfiConverterRustBuffer {
+    typealias SwiftType = [UInt8]
+
+    public static func write(_ value: [UInt8], into buf: inout [UInt8]) {
+        let len = Int32(value.count)
+        writeInt(&buf, len)
+        for item in value {
+            FfiConverterUInt8.write(item, into: &buf)
+        }
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> [UInt8] {
+        let len: Int32 = try readInt(&buf)
+        var seq = [UInt8]()
+        seq.reserveCapacity(Int(len))
+        for _ in 0 ..< len {
+            try seq.append(FfiConverterUInt8.read(from: &buf))
+        }
+        return seq
+    }
+}
+
+private struct FfiConverterSequenceUInt16: FfiConverterRustBuffer {
+    typealias SwiftType = [UInt16]
+
+    public static func write(_ value: [UInt16], into buf: inout [UInt8]) {
+        let len = Int32(value.count)
+        writeInt(&buf, len)
+        for item in value {
+            FfiConverterUInt16.write(item, into: &buf)
+        }
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> [UInt16] {
+        let len: Int32 = try readInt(&buf)
+        var seq = [UInt16]()
+        seq.reserveCapacity(Int(len))
+        for _ in 0 ..< len {
+            try seq.append(FfiConverterUInt16.read(from: &buf))
+        }
+        return seq
+    }
+}
+
 private struct FfiConverterSequenceTypeAuthorId: FfiConverterRustBuffer {
     typealias SwiftType = [AuthorId]
 
@@ -2353,28 +2929,6 @@ private struct FfiConverterSequenceTypeNamespaceId: FfiConverterRustBuffer {
     }
 }
 
-private struct FfiConverterSequenceTypeConnectionInfo: FfiConverterRustBuffer {
-    typealias SwiftType = [ConnectionInfo]
-
-    public static func write(_ value: [ConnectionInfo], into buf: inout [UInt8]) {
-        let len = Int32(value.count)
-        writeInt(&buf, len)
-        for item in value {
-            FfiConverterTypeConnectionInfo.write(item, into: &buf)
-        }
-    }
-
-    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> [ConnectionInfo] {
-        let len: Int32 = try readInt(&buf)
-        var seq = [ConnectionInfo]()
-        seq.reserveCapacity(Int(len))
-        for _ in 0 ..< len {
-            try seq.append(FfiConverterTypeConnectionInfo.read(from: &buf))
-        }
-        return seq
-    }
-}
-
 private struct FfiConverterSequenceTypeSocketAddr: FfiConverterRustBuffer {
     typealias SwiftType = [SocketAddr]
 
@@ -2392,6 +2946,28 @@ private struct FfiConverterSequenceTypeSocketAddr: FfiConverterRustBuffer {
         seq.reserveCapacity(Int(len))
         for _ in 0 ..< len {
             try seq.append(FfiConverterTypeSocketAddr.read(from: &buf))
+        }
+        return seq
+    }
+}
+
+private struct FfiConverterSequenceTypeConnectionInfo: FfiConverterRustBuffer {
+    typealias SwiftType = [ConnectionInfo]
+
+    public static func write(_ value: [ConnectionInfo], into buf: inout [UInt8]) {
+        let len = Int32(value.count)
+        writeInt(&buf, len)
+        for item in value {
+            FfiConverterTypeConnectionInfo.write(item, into: &buf)
+        }
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> [ConnectionInfo] {
+        let len: Int32 = try readInt(&buf)
+        var seq = [ConnectionInfo]()
+        seq.reserveCapacity(Int(len))
+        for _ in 0 ..< len {
+            try seq.append(FfiConverterTypeConnectionInfo.read(from: &buf))
         }
         return seq
     }
@@ -2526,6 +3102,18 @@ private var initializationResult: InitializationResult {
     if uniffi_iroh_checksum_method_hash_to_string() != 61408 {
         return InitializationResult.apiChecksumMismatch
     }
+    if uniffi_iroh_checksum_method_ipv4addr_octets() != 17752 {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if uniffi_iroh_checksum_method_ipv4addr_to_string() != 5658 {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if uniffi_iroh_checksum_method_ipv6addr_segments() != 41182 {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if uniffi_iroh_checksum_method_ipv6addr_to_string() != 46637 {
+        return InitializationResult.apiChecksumMismatch
+    }
     if uniffi_iroh_checksum_method_irohnode_author_list() != 12499 {
         return InitializationResult.apiChecksumMismatch
     }
@@ -2589,10 +3177,67 @@ private var initializationResult: InitializationResult {
     if uniffi_iroh_checksum_method_publickey_to_string() != 48998 {
         return InitializationResult.apiChecksumMismatch
     }
+    if uniffi_iroh_checksum_method_socketaddr_type() != 50972 {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if uniffi_iroh_checksum_method_socketaddr_v4() != 62655 {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if uniffi_iroh_checksum_method_socketaddr_v6() != 50034 {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if uniffi_iroh_checksum_method_socketaddrv4_ip() != 54004 {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if uniffi_iroh_checksum_method_socketaddrv4_port() != 34504 {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if uniffi_iroh_checksum_method_socketaddrv4_to_string() != 43672 {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if uniffi_iroh_checksum_method_socketaddrv6_ip() != 49803 {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if uniffi_iroh_checksum_method_socketaddrv6_port() != 39562 {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if uniffi_iroh_checksum_method_socketaddrv6_to_string() != 14154 {
+        return InitializationResult.apiChecksumMismatch
+    }
     if uniffi_iroh_checksum_constructor_docticket_from_string() != 40262 {
         return InitializationResult.apiChecksumMismatch
     }
+    if uniffi_iroh_checksum_constructor_ipv4addr_from_string() != 60777 {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if uniffi_iroh_checksum_constructor_ipv4addr_new() != 51336 {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if uniffi_iroh_checksum_constructor_ipv6addr_from_string() != 24533 {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if uniffi_iroh_checksum_constructor_ipv6addr_new() != 18364 {
+        return InitializationResult.apiChecksumMismatch
+    }
     if uniffi_iroh_checksum_constructor_irohnode_new() != 22562 {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if uniffi_iroh_checksum_constructor_socketaddr_from_v4() != 55134 {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if uniffi_iroh_checksum_constructor_socketaddr_from_v6() != 51100 {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if uniffi_iroh_checksum_constructor_socketaddrv4_from_string() != 16157 {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if uniffi_iroh_checksum_constructor_socketaddrv4_new() != 12651 {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if uniffi_iroh_checksum_constructor_socketaddrv6_from_string() != 22443 {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if uniffi_iroh_checksum_constructor_socketaddrv6_new() != 46347 {
         return InitializationResult.apiChecksumMismatch
     }
     if uniffi_iroh_checksum_method_subscribecallback_event() != 18725 {

--- a/README.md
+++ b/README.md
@@ -77,6 +77,64 @@ Install `uniffi-bindgen-go`:
 cargo install uniffi-bindgen-go --git https://github.com/dignifiedquire/uniffi-bindgen-go --branch upgarde-uniffi-24
 ```
 
+## Testing
+Please include tests when you add new pieces of the API to the ffi bindings
+
+### python
+
+#### pytest
+We use [`pytest`](https://docs.pytest.org/en/7.1.x/contents.html) to test the python api.
+
+Ensure you have the correct virtualenv active, then run `pip install pytest`
+
+Run the tests by using `python -m pytest` in order to correctly include all of the iroh bindings.
+
+#### translations
+Uniffi translates the rust to python in a systematic way. The biggest discrepency between the rust and python syntax are around how new objects are constructed
+
+- constructor methods w/ `new` name:
+    `Ipv4Addr::new(127, 0, 0, 1)` in rust would be `Ipv4Addr(127, 0, 0, 1)` in python
+- constructor methods with any other name in rust:
+    `SocketAddr::from_ipv4(..)` in rust would be `SocketAddr.from_ipv4(..)` in python
+- method names will stay the same:
+     `SocketAddr.as_ipv4` in rust will be called `SocketAddr.as_ipv4` in python
+- unit enums will have the same names:
+    `SocketAddrType::V4` in rust will be `SocketAddrType.V4` in python
+- methods that return `Result` in rust will potentially throw exceptions on error in python
+
+#### test file
+Create a test file for each rust module that you create, and test all pieces of the API in that module in the python test file. The file should be named "[MODULENAME]\_test.py". For example, the `iroh::net` ffi bindings crate should have a corresponding "net\_test.py" file. 
+
+### go 
+
+#### go test 
+Read the [Running](#running) section to ensure you include all the pieces necessary for running `go` commands (in this case, `go tests ./...`)
+
+#### translations
+Uniffi translates the rust to go in a systematic way. The biggest discrepency between the rust and go syntax are around how new objects are constructed. Here are the main differences
+
+- constructor methods w/ the name `new` in rust:
+    `Ipv4Addr::new(127, 0, 0, 1)` in rust would be `NewIpv4Addr(127, 0, 0, 1)` in go
+- constructor methods that have any other name in rust:
+    `SocketAddr::from_string(..)` in rust would be `SocketAddrFromString(..)` in go
+- method names become PascalCase:
+    `SocketAddr.as_ipv4` in rust will be called `SocketAddr.AsIpv4` in go 
+- unit enums: 
+    `SocketAddrType::V4` in rust will be `SocketAddrV4` in go 
+- methods that return `Result` in rust:
+    `Ipv4Addr::from_string(..)` returns `Result<String, IrohError>` in rust
+    `Ipv4AddrFromString(..)` returns `String, IrohError` in go
+    as an example:
+    ```go
+        ipv4Addr, err := Ipv4AddrFromString("127.0.0.1")
+        if err != nil {
+            // handle error here
+        }
+    ```
+
+#### test file
+Create a test file for each rust module that you create, and test all pieces of the API in that module in the go test file. The file should be named "[MODULENAME]\_test.go". For example, the `iroh::net` ffi bindings crate should have a corresponding "net\_test.go" file. 
+
 ## Development
 
 - This uses https://mozilla.github.io/uniffi-rs/ for building the interface

--- a/README.md
+++ b/README.md
@@ -78,82 +78,8 @@ Install `uniffi-bindgen-go`:
 cargo install uniffi-bindgen-go --git https://github.com/dignifiedquire/uniffi-bindgen-go --branch upgarde-uniffi-24
 ```
 
-## Development
-
-- This uses https://mozilla.github.io/uniffi-rs/ for building the interface
-
-### translating the iroh API into iroh ffi bindings
-Use these general guidelines when translating the rust API featured in the rust
-`iroh` library with the API we detail in this crate:
-- `PathBuf` -> `String`
-- `Bytes`, `[u8]`, etc -> Vec<u8>
-- Any methods that stream files or have `Reader` inputs or outputs should instead expect to read from or write to a file. Also, see if it's logical for any structs or enums that have a method to return a `Reader` to instead have `size` method, so that the user can investigate the size of the data before attempting to save it or load it in memory.
-- Any methods that return a `Stream` of structs (such as a `list` method), should return a `Vec` instead. You should also add a comment that warns the user that this method will load all the entries into memory.
-- Any methods that return progress or events should instead take a call back. Check out the `Doc::subscribe` method and the `SubscribeCallback` trait for how this should be implemented
-- Most methods that return a `Result` should likely get their own unique `IrohError`s, follow the pattern layed out in `error.rs`.
-- Except for unit enums, every struct and enum should be represented in the `udl` file as an interface. It should be expected that the foreign language use constructor methods in order to create structs, and use setters and getters to manipulate the struct, rather than having access to the internal fields themselves.
-- Anything that can be represented as a string, should have a `to_string` and `from_string` method, eg `NamespaceId`, `DocTicket`
-- Enums that have enum variants which contain data should look at the `SocketAddr` or `LiveEvent` enums for the expected translation.
-
-## Testing
-Please include tests when you add new pieces of the API to the ffi bindings
-
-### python
-
-#### pytest
-We use [`pytest`](https://docs.pytest.org/en/7.1.x/contents.html) to test the python api.
-
-Ensure you have the correct virtualenv active, then run `pip install pytest`
-
-Run the tests by using `python -m pytest` in order to correctly include all of the iroh bindings.
-
-#### translations
-Uniffi translates the rust to python in a systematic way. The biggest discrepency between the rust and python syntax are around how new objects are constructed
-
-- constructor methods w/ `new` name:
-    `Ipv4Addr::new(127, 0, 0, 1)` in rust would be `Ipv4Addr(127, 0, 0, 1)` in python
-- constructor methods with any other name in rust:
-    `SocketAddr::from_ipv4(..)` in rust would be `SocketAddr.from_ipv4(..)` in python
-- method names will stay the same:
-     `SocketAddr.as_ipv4` in rust will be called `SocketAddr.as_ipv4` in python
-- unit enums will have the same names:
-    `SocketAddrType::V4` in rust will be `SocketAddrType.V4` in python
-- methods that return `Result` in rust will potentially throw exceptions on error in python
-
-#### test file
-Create a test file for each rust module that you create, and test all pieces of the API in that module in the python test file. The file should be named "[MODULENAME]\_test.py". For example, the `iroh::net` ffi bindings crate should have a corresponding "net\_test.py" file. 
-
-### go 
-
-#### go test 
-Read the [Running](#running) section to ensure you include all the pieces necessary for running `go` commands (in this case, `go tests ./...`)
-
-#### translations
-Uniffi translates the rust to go in a systematic way. The biggest discrepency between the rust and go syntax are around how new objects are constructed. Here are the main differences
-
-- constructor methods w/ the name `new` in rust:
-    `Ipv4Addr::new(127, 0, 0, 1)` in rust would be `NewIpv4Addr(127, 0, 0, 1)` in go
-- constructor methods that have any other name in rust:
-    `SocketAddr::from_string(..)` in rust would be `SocketAddrFromString(..)` in go
-- method names become PascalCase:
-    `SocketAddr.as_ipv4` in rust will be called `SocketAddr.AsIpv4` in go 
-- unit enums: 
-    `SocketAddrType::V4` in rust will be `SocketAddrV4` in go 
-- methods that return `Result` in rust:
-    `Ipv4Addr::from_string(..)` returns `Result<String, IrohError>` in rust
-    `Ipv4AddrFromString(..)` returns `String, IrohError` in go
-    as an example:
-    ```go
-        ipv4Addr, err := Ipv4AddrFromString("127.0.0.1")
-        if err != nil {
-            // handle error here
-        }
-    ```
-
-#### test file
-Create a test file for each rust module that you create, and test all pieces of the API in that module in the go test file. The file should be named "[MODULENAME]\_test.go". For example, the `iroh::net` ffi bindings crate should have a corresponding "net\_test.go" file. 
-
-
+# Developers
+Check our our [DEVELOPERS.md](DEVELOPERS.md) for guides on how to translate from the iroh rust API to the iroh FFI API, as well as how to set up testing for golang and python.
 
 # License
 

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,3 +1,10 @@
 module github.com/n0-computer/iroh-ffi
 
 go 1.19
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/testify v1.8.4 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go/go.sum
+++ b/go/go.sum
@@ -1,0 +1,9 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go/iroh/iroh.go
+++ b/go/iroh/iroh.go
@@ -510,6 +510,42 @@ func uniffiCheckChecksums() {
 	}
 	{
 		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_iroh_checksum_method_ipv4addr_octets(uniffiStatus)
+		})
+		if checksum != 17752 {
+			// If this happens try cleaning and rebuilding your project
+			panic("iroh: uniffi_iroh_checksum_method_ipv4addr_octets: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_iroh_checksum_method_ipv4addr_to_string(uniffiStatus)
+		})
+		if checksum != 5658 {
+			// If this happens try cleaning and rebuilding your project
+			panic("iroh: uniffi_iroh_checksum_method_ipv4addr_to_string: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_iroh_checksum_method_ipv6addr_segments(uniffiStatus)
+		})
+		if checksum != 41182 {
+			// If this happens try cleaning and rebuilding your project
+			panic("iroh: uniffi_iroh_checksum_method_ipv6addr_segments: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_iroh_checksum_method_ipv6addr_to_string(uniffiStatus)
+		})
+		if checksum != 46637 {
+			// If this happens try cleaning and rebuilding your project
+			panic("iroh: uniffi_iroh_checksum_method_ipv6addr_to_string: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_iroh_checksum_method_irohnode_author_list(uniffiStatus)
 		})
 		if checksum != 12499 {
@@ -699,6 +735,87 @@ func uniffiCheckChecksums() {
 	}
 	{
 		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_iroh_checksum_method_socketaddr_type(uniffiStatus)
+		})
+		if checksum != 50972 {
+			// If this happens try cleaning and rebuilding your project
+			panic("iroh: uniffi_iroh_checksum_method_socketaddr_type: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_iroh_checksum_method_socketaddr_v4(uniffiStatus)
+		})
+		if checksum != 62655 {
+			// If this happens try cleaning and rebuilding your project
+			panic("iroh: uniffi_iroh_checksum_method_socketaddr_v4: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_iroh_checksum_method_socketaddr_v6(uniffiStatus)
+		})
+		if checksum != 50034 {
+			// If this happens try cleaning and rebuilding your project
+			panic("iroh: uniffi_iroh_checksum_method_socketaddr_v6: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_iroh_checksum_method_socketaddrv4_ip(uniffiStatus)
+		})
+		if checksum != 54004 {
+			// If this happens try cleaning and rebuilding your project
+			panic("iroh: uniffi_iroh_checksum_method_socketaddrv4_ip: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_iroh_checksum_method_socketaddrv4_port(uniffiStatus)
+		})
+		if checksum != 34504 {
+			// If this happens try cleaning and rebuilding your project
+			panic("iroh: uniffi_iroh_checksum_method_socketaddrv4_port: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_iroh_checksum_method_socketaddrv4_to_string(uniffiStatus)
+		})
+		if checksum != 43672 {
+			// If this happens try cleaning and rebuilding your project
+			panic("iroh: uniffi_iroh_checksum_method_socketaddrv4_to_string: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_iroh_checksum_method_socketaddrv6_ip(uniffiStatus)
+		})
+		if checksum != 49803 {
+			// If this happens try cleaning and rebuilding your project
+			panic("iroh: uniffi_iroh_checksum_method_socketaddrv6_ip: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_iroh_checksum_method_socketaddrv6_port(uniffiStatus)
+		})
+		if checksum != 39562 {
+			// If this happens try cleaning and rebuilding your project
+			panic("iroh: uniffi_iroh_checksum_method_socketaddrv6_port: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_iroh_checksum_method_socketaddrv6_to_string(uniffiStatus)
+		})
+		if checksum != 14154 {
+			// If this happens try cleaning and rebuilding your project
+			panic("iroh: uniffi_iroh_checksum_method_socketaddrv6_to_string: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_iroh_checksum_constructor_docticket_from_string(uniffiStatus)
 		})
 		if checksum != 40262 {
@@ -708,11 +825,101 @@ func uniffiCheckChecksums() {
 	}
 	{
 		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_iroh_checksum_constructor_ipv4addr_from_string(uniffiStatus)
+		})
+		if checksum != 60777 {
+			// If this happens try cleaning and rebuilding your project
+			panic("iroh: uniffi_iroh_checksum_constructor_ipv4addr_from_string: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_iroh_checksum_constructor_ipv4addr_new(uniffiStatus)
+		})
+		if checksum != 51336 {
+			// If this happens try cleaning and rebuilding your project
+			panic("iroh: uniffi_iroh_checksum_constructor_ipv4addr_new: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_iroh_checksum_constructor_ipv6addr_from_string(uniffiStatus)
+		})
+		if checksum != 24533 {
+			// If this happens try cleaning and rebuilding your project
+			panic("iroh: uniffi_iroh_checksum_constructor_ipv6addr_from_string: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_iroh_checksum_constructor_ipv6addr_new(uniffiStatus)
+		})
+		if checksum != 18364 {
+			// If this happens try cleaning and rebuilding your project
+			panic("iroh: uniffi_iroh_checksum_constructor_ipv6addr_new: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_iroh_checksum_constructor_irohnode_new(uniffiStatus)
 		})
 		if checksum != 22562 {
 			// If this happens try cleaning and rebuilding your project
 			panic("iroh: uniffi_iroh_checksum_constructor_irohnode_new: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_iroh_checksum_constructor_socketaddr_from_v4(uniffiStatus)
+		})
+		if checksum != 55134 {
+			// If this happens try cleaning and rebuilding your project
+			panic("iroh: uniffi_iroh_checksum_constructor_socketaddr_from_v4: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_iroh_checksum_constructor_socketaddr_from_v6(uniffiStatus)
+		})
+		if checksum != 51100 {
+			// If this happens try cleaning and rebuilding your project
+			panic("iroh: uniffi_iroh_checksum_constructor_socketaddr_from_v6: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_iroh_checksum_constructor_socketaddrv4_from_string(uniffiStatus)
+		})
+		if checksum != 16157 {
+			// If this happens try cleaning and rebuilding your project
+			panic("iroh: uniffi_iroh_checksum_constructor_socketaddrv4_from_string: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_iroh_checksum_constructor_socketaddrv4_new(uniffiStatus)
+		})
+		if checksum != 12651 {
+			// If this happens try cleaning and rebuilding your project
+			panic("iroh: uniffi_iroh_checksum_constructor_socketaddrv4_new: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_iroh_checksum_constructor_socketaddrv6_from_string(uniffiStatus)
+		})
+		if checksum != 22443 {
+			// If this happens try cleaning and rebuilding your project
+			panic("iroh: uniffi_iroh_checksum_constructor_socketaddrv6_from_string: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_iroh_checksum_constructor_socketaddrv6_new(uniffiStatus)
+		})
+		if checksum != 46347 {
+			// If this happens try cleaning and rebuilding your project
+			panic("iroh: uniffi_iroh_checksum_constructor_socketaddrv6_new: UniFFI API checksum mismatch")
 		}
 	}
 	{
@@ -1438,6 +1645,174 @@ func (_ FfiDestroyerHash) Destroy(value *Hash) {
 	value.Destroy()
 }
 
+type Ipv4Addr struct {
+	ffiObject FfiObject
+}
+
+func NewIpv4Addr(a uint8, b uint8, c uint8, d uint8) *Ipv4Addr {
+	return FfiConverterIpv4AddrINSTANCE.Lift(rustCall(func(_uniffiStatus *C.RustCallStatus) unsafe.Pointer {
+		return C.uniffi_iroh_fn_constructor_ipv4addr_new(FfiConverterUint8INSTANCE.Lower(a), FfiConverterUint8INSTANCE.Lower(b), FfiConverterUint8INSTANCE.Lower(c), FfiConverterUint8INSTANCE.Lower(d), _uniffiStatus)
+	}))
+}
+
+func Ipv4AddrFromString(str string) (*Ipv4Addr, error) {
+	_uniffiRV, _uniffiErr := rustCallWithError(FfiConverterTypeIrohError{}, func(_uniffiStatus *C.RustCallStatus) unsafe.Pointer {
+		return C.uniffi_iroh_fn_constructor_ipv4addr_from_string(FfiConverterStringINSTANCE.Lower(str), _uniffiStatus)
+	})
+	if _uniffiErr != nil {
+		var _uniffiDefaultValue *Ipv4Addr
+		return _uniffiDefaultValue, _uniffiErr
+	} else {
+		return FfiConverterIpv4AddrINSTANCE.Lift(_uniffiRV), _uniffiErr
+	}
+}
+
+func (_self *Ipv4Addr) Octets() []uint8 {
+	_pointer := _self.ffiObject.incrementPointer("*Ipv4Addr")
+	defer _self.ffiObject.decrementPointer()
+	return FfiConverterSequenceUint8INSTANCE.Lift(rustCall(func(_uniffiStatus *C.RustCallStatus) RustBufferI {
+		return C.uniffi_iroh_fn_method_ipv4addr_octets(
+			_pointer, _uniffiStatus)
+	}))
+}
+
+func (_self *Ipv4Addr) ToString() string {
+	_pointer := _self.ffiObject.incrementPointer("*Ipv4Addr")
+	defer _self.ffiObject.decrementPointer()
+	return FfiConverterStringINSTANCE.Lift(rustCall(func(_uniffiStatus *C.RustCallStatus) RustBufferI {
+		return C.uniffi_iroh_fn_method_ipv4addr_to_string(
+			_pointer, _uniffiStatus)
+	}))
+}
+
+func (object *Ipv4Addr) Destroy() {
+	runtime.SetFinalizer(object, nil)
+	object.ffiObject.destroy()
+}
+
+type FfiConverterIpv4Addr struct{}
+
+var FfiConverterIpv4AddrINSTANCE = FfiConverterIpv4Addr{}
+
+func (c FfiConverterIpv4Addr) Lift(pointer unsafe.Pointer) *Ipv4Addr {
+	result := &Ipv4Addr{
+		newFfiObject(
+			pointer,
+			func(pointer unsafe.Pointer, status *C.RustCallStatus) {
+				C.uniffi_iroh_fn_free_ipv4addr(pointer, status)
+			}),
+	}
+	runtime.SetFinalizer(result, (*Ipv4Addr).Destroy)
+	return result
+}
+
+func (c FfiConverterIpv4Addr) Read(reader io.Reader) *Ipv4Addr {
+	return c.Lift(unsafe.Pointer(uintptr(readUint64(reader))))
+}
+
+func (c FfiConverterIpv4Addr) Lower(value *Ipv4Addr) unsafe.Pointer {
+	// TODO: this is bad - all synchronization from ObjectRuntime.go is discarded here,
+	// because the pointer will be decremented immediately after this function returns,
+	// and someone will be left holding onto a non-locked pointer.
+	pointer := value.ffiObject.incrementPointer("*Ipv4Addr")
+	defer value.ffiObject.decrementPointer()
+	return pointer
+}
+
+func (c FfiConverterIpv4Addr) Write(writer io.Writer, value *Ipv4Addr) {
+	writeUint64(writer, uint64(uintptr(c.Lower(value))))
+}
+
+type FfiDestroyerIpv4Addr struct{}
+
+func (_ FfiDestroyerIpv4Addr) Destroy(value *Ipv4Addr) {
+	value.Destroy()
+}
+
+type Ipv6Addr struct {
+	ffiObject FfiObject
+}
+
+func NewIpv6Addr(a uint16, b uint16, c uint16, d uint16, e uint16, f uint16, g uint16, h uint16) *Ipv6Addr {
+	return FfiConverterIpv6AddrINSTANCE.Lift(rustCall(func(_uniffiStatus *C.RustCallStatus) unsafe.Pointer {
+		return C.uniffi_iroh_fn_constructor_ipv6addr_new(FfiConverterUint16INSTANCE.Lower(a), FfiConverterUint16INSTANCE.Lower(b), FfiConverterUint16INSTANCE.Lower(c), FfiConverterUint16INSTANCE.Lower(d), FfiConverterUint16INSTANCE.Lower(e), FfiConverterUint16INSTANCE.Lower(f), FfiConverterUint16INSTANCE.Lower(g), FfiConverterUint16INSTANCE.Lower(h), _uniffiStatus)
+	}))
+}
+
+func Ipv6AddrFromString(str string) (*Ipv6Addr, error) {
+	_uniffiRV, _uniffiErr := rustCallWithError(FfiConverterTypeIrohError{}, func(_uniffiStatus *C.RustCallStatus) unsafe.Pointer {
+		return C.uniffi_iroh_fn_constructor_ipv6addr_from_string(FfiConverterStringINSTANCE.Lower(str), _uniffiStatus)
+	})
+	if _uniffiErr != nil {
+		var _uniffiDefaultValue *Ipv6Addr
+		return _uniffiDefaultValue, _uniffiErr
+	} else {
+		return FfiConverterIpv6AddrINSTANCE.Lift(_uniffiRV), _uniffiErr
+	}
+}
+
+func (_self *Ipv6Addr) Segments() []uint16 {
+	_pointer := _self.ffiObject.incrementPointer("*Ipv6Addr")
+	defer _self.ffiObject.decrementPointer()
+	return FfiConverterSequenceUint16INSTANCE.Lift(rustCall(func(_uniffiStatus *C.RustCallStatus) RustBufferI {
+		return C.uniffi_iroh_fn_method_ipv6addr_segments(
+			_pointer, _uniffiStatus)
+	}))
+}
+
+func (_self *Ipv6Addr) ToString() string {
+	_pointer := _self.ffiObject.incrementPointer("*Ipv6Addr")
+	defer _self.ffiObject.decrementPointer()
+	return FfiConverterStringINSTANCE.Lift(rustCall(func(_uniffiStatus *C.RustCallStatus) RustBufferI {
+		return C.uniffi_iroh_fn_method_ipv6addr_to_string(
+			_pointer, _uniffiStatus)
+	}))
+}
+
+func (object *Ipv6Addr) Destroy() {
+	runtime.SetFinalizer(object, nil)
+	object.ffiObject.destroy()
+}
+
+type FfiConverterIpv6Addr struct{}
+
+var FfiConverterIpv6AddrINSTANCE = FfiConverterIpv6Addr{}
+
+func (c FfiConverterIpv6Addr) Lift(pointer unsafe.Pointer) *Ipv6Addr {
+	result := &Ipv6Addr{
+		newFfiObject(
+			pointer,
+			func(pointer unsafe.Pointer, status *C.RustCallStatus) {
+				C.uniffi_iroh_fn_free_ipv6addr(pointer, status)
+			}),
+	}
+	runtime.SetFinalizer(result, (*Ipv6Addr).Destroy)
+	return result
+}
+
+func (c FfiConverterIpv6Addr) Read(reader io.Reader) *Ipv6Addr {
+	return c.Lift(unsafe.Pointer(uintptr(readUint64(reader))))
+}
+
+func (c FfiConverterIpv6Addr) Lower(value *Ipv6Addr) unsafe.Pointer {
+	// TODO: this is bad - all synchronization from ObjectRuntime.go is discarded here,
+	// because the pointer will be decremented immediately after this function returns,
+	// and someone will be left holding onto a non-locked pointer.
+	pointer := value.ffiObject.incrementPointer("*Ipv6Addr")
+	defer value.ffiObject.decrementPointer()
+	return pointer
+}
+
+func (c FfiConverterIpv6Addr) Write(writer io.Writer, value *Ipv6Addr) {
+	writeUint64(writer, uint64(uintptr(c.Lower(value))))
+}
+
+type FfiDestroyerIpv6Addr struct{}
+
+func (_ FfiDestroyerIpv6Addr) Destroy(value *Ipv6Addr) {
+	value.Destroy()
+}
+
 type IrohNode struct {
 	ffiObject FfiObject
 }
@@ -1891,11 +2266,295 @@ func (_ FfiDestroyerPublicKey) Destroy(value *PublicKey) {
 	value.Destroy()
 }
 
+type SocketAddr struct {
+	ffiObject FfiObject
+}
+
+func SocketAddrFromV4(ipv4 *Ipv4Addr, port uint16) *SocketAddr {
+	return FfiConverterSocketAddrINSTANCE.Lift(rustCall(func(_uniffiStatus *C.RustCallStatus) unsafe.Pointer {
+		return C.uniffi_iroh_fn_constructor_socketaddr_from_v4(FfiConverterIpv4AddrINSTANCE.Lower(ipv4), FfiConverterUint16INSTANCE.Lower(port), _uniffiStatus)
+	}))
+}
+func SocketAddrFromV6(ipv6 *Ipv6Addr, port uint16) *SocketAddr {
+	return FfiConverterSocketAddrINSTANCE.Lift(rustCall(func(_uniffiStatus *C.RustCallStatus) unsafe.Pointer {
+		return C.uniffi_iroh_fn_constructor_socketaddr_from_v6(FfiConverterIpv6AddrINSTANCE.Lower(ipv6), FfiConverterUint16INSTANCE.Lower(port), _uniffiStatus)
+	}))
+}
+
+func (_self *SocketAddr) Type() SocketAddrType {
+	_pointer := _self.ffiObject.incrementPointer("*SocketAddr")
+	defer _self.ffiObject.decrementPointer()
+	return FfiConverterTypeSocketAddrTypeINSTANCE.Lift(rustCall(func(_uniffiStatus *C.RustCallStatus) RustBufferI {
+		return C.uniffi_iroh_fn_method_socketaddr_type(
+			_pointer, _uniffiStatus)
+	}))
+}
+
+func (_self *SocketAddr) V4() (*SocketAddrV4, error) {
+	_pointer := _self.ffiObject.incrementPointer("*SocketAddr")
+	defer _self.ffiObject.decrementPointer()
+	_uniffiRV, _uniffiErr := rustCallWithError(FfiConverterTypeIrohError{}, func(_uniffiStatus *C.RustCallStatus) unsafe.Pointer {
+		return C.uniffi_iroh_fn_method_socketaddr_v4(
+			_pointer, _uniffiStatus)
+	})
+	if _uniffiErr != nil {
+		var _uniffiDefaultValue *SocketAddrV4
+		return _uniffiDefaultValue, _uniffiErr
+	} else {
+		return FfiConverterSocketAddrV4INSTANCE.Lift(_uniffiRV), _uniffiErr
+	}
+}
+
+func (_self *SocketAddr) V6() (*SocketAddrV6, error) {
+	_pointer := _self.ffiObject.incrementPointer("*SocketAddr")
+	defer _self.ffiObject.decrementPointer()
+	_uniffiRV, _uniffiErr := rustCallWithError(FfiConverterTypeIrohError{}, func(_uniffiStatus *C.RustCallStatus) unsafe.Pointer {
+		return C.uniffi_iroh_fn_method_socketaddr_v6(
+			_pointer, _uniffiStatus)
+	})
+	if _uniffiErr != nil {
+		var _uniffiDefaultValue *SocketAddrV6
+		return _uniffiDefaultValue, _uniffiErr
+	} else {
+		return FfiConverterSocketAddrV6INSTANCE.Lift(_uniffiRV), _uniffiErr
+	}
+}
+
+func (object *SocketAddr) Destroy() {
+	runtime.SetFinalizer(object, nil)
+	object.ffiObject.destroy()
+}
+
+type FfiConverterSocketAddr struct{}
+
+var FfiConverterSocketAddrINSTANCE = FfiConverterSocketAddr{}
+
+func (c FfiConverterSocketAddr) Lift(pointer unsafe.Pointer) *SocketAddr {
+	result := &SocketAddr{
+		newFfiObject(
+			pointer,
+			func(pointer unsafe.Pointer, status *C.RustCallStatus) {
+				C.uniffi_iroh_fn_free_socketaddr(pointer, status)
+			}),
+	}
+	runtime.SetFinalizer(result, (*SocketAddr).Destroy)
+	return result
+}
+
+func (c FfiConverterSocketAddr) Read(reader io.Reader) *SocketAddr {
+	return c.Lift(unsafe.Pointer(uintptr(readUint64(reader))))
+}
+
+func (c FfiConverterSocketAddr) Lower(value *SocketAddr) unsafe.Pointer {
+	// TODO: this is bad - all synchronization from ObjectRuntime.go is discarded here,
+	// because the pointer will be decremented immediately after this function returns,
+	// and someone will be left holding onto a non-locked pointer.
+	pointer := value.ffiObject.incrementPointer("*SocketAddr")
+	defer value.ffiObject.decrementPointer()
+	return pointer
+}
+
+func (c FfiConverterSocketAddr) Write(writer io.Writer, value *SocketAddr) {
+	writeUint64(writer, uint64(uintptr(c.Lower(value))))
+}
+
+type FfiDestroyerSocketAddr struct{}
+
+func (_ FfiDestroyerSocketAddr) Destroy(value *SocketAddr) {
+	value.Destroy()
+}
+
+type SocketAddrV4 struct {
+	ffiObject FfiObject
+}
+
+func NewSocketAddrV4(ipv4 *Ipv4Addr, port uint16) *SocketAddrV4 {
+	return FfiConverterSocketAddrV4INSTANCE.Lift(rustCall(func(_uniffiStatus *C.RustCallStatus) unsafe.Pointer {
+		return C.uniffi_iroh_fn_constructor_socketaddrv4_new(FfiConverterIpv4AddrINSTANCE.Lower(ipv4), FfiConverterUint16INSTANCE.Lower(port), _uniffiStatus)
+	}))
+}
+
+func SocketAddrV4FromString(str string) (*SocketAddrV4, error) {
+	_uniffiRV, _uniffiErr := rustCallWithError(FfiConverterTypeIrohError{}, func(_uniffiStatus *C.RustCallStatus) unsafe.Pointer {
+		return C.uniffi_iroh_fn_constructor_socketaddrv4_from_string(FfiConverterStringINSTANCE.Lower(str), _uniffiStatus)
+	})
+	if _uniffiErr != nil {
+		var _uniffiDefaultValue *SocketAddrV4
+		return _uniffiDefaultValue, _uniffiErr
+	} else {
+		return FfiConverterSocketAddrV4INSTANCE.Lift(_uniffiRV), _uniffiErr
+	}
+}
+
+func (_self *SocketAddrV4) Ip() *Ipv4Addr {
+	_pointer := _self.ffiObject.incrementPointer("*SocketAddrV4")
+	defer _self.ffiObject.decrementPointer()
+	return FfiConverterIpv4AddrINSTANCE.Lift(rustCall(func(_uniffiStatus *C.RustCallStatus) unsafe.Pointer {
+		return C.uniffi_iroh_fn_method_socketaddrv4_ip(
+			_pointer, _uniffiStatus)
+	}))
+}
+
+func (_self *SocketAddrV4) Port() uint16 {
+	_pointer := _self.ffiObject.incrementPointer("*SocketAddrV4")
+	defer _self.ffiObject.decrementPointer()
+	return FfiConverterUint16INSTANCE.Lift(rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
+		return C.uniffi_iroh_fn_method_socketaddrv4_port(
+			_pointer, _uniffiStatus)
+	}))
+}
+
+func (_self *SocketAddrV4) ToString() string {
+	_pointer := _self.ffiObject.incrementPointer("*SocketAddrV4")
+	defer _self.ffiObject.decrementPointer()
+	return FfiConverterStringINSTANCE.Lift(rustCall(func(_uniffiStatus *C.RustCallStatus) RustBufferI {
+		return C.uniffi_iroh_fn_method_socketaddrv4_to_string(
+			_pointer, _uniffiStatus)
+	}))
+}
+
+func (object *SocketAddrV4) Destroy() {
+	runtime.SetFinalizer(object, nil)
+	object.ffiObject.destroy()
+}
+
+type FfiConverterSocketAddrV4 struct{}
+
+var FfiConverterSocketAddrV4INSTANCE = FfiConverterSocketAddrV4{}
+
+func (c FfiConverterSocketAddrV4) Lift(pointer unsafe.Pointer) *SocketAddrV4 {
+	result := &SocketAddrV4{
+		newFfiObject(
+			pointer,
+			func(pointer unsafe.Pointer, status *C.RustCallStatus) {
+				C.uniffi_iroh_fn_free_socketaddrv4(pointer, status)
+			}),
+	}
+	runtime.SetFinalizer(result, (*SocketAddrV4).Destroy)
+	return result
+}
+
+func (c FfiConverterSocketAddrV4) Read(reader io.Reader) *SocketAddrV4 {
+	return c.Lift(unsafe.Pointer(uintptr(readUint64(reader))))
+}
+
+func (c FfiConverterSocketAddrV4) Lower(value *SocketAddrV4) unsafe.Pointer {
+	// TODO: this is bad - all synchronization from ObjectRuntime.go is discarded here,
+	// because the pointer will be decremented immediately after this function returns,
+	// and someone will be left holding onto a non-locked pointer.
+	pointer := value.ffiObject.incrementPointer("*SocketAddrV4")
+	defer value.ffiObject.decrementPointer()
+	return pointer
+}
+
+func (c FfiConverterSocketAddrV4) Write(writer io.Writer, value *SocketAddrV4) {
+	writeUint64(writer, uint64(uintptr(c.Lower(value))))
+}
+
+type FfiDestroyerSocketAddrV4 struct{}
+
+func (_ FfiDestroyerSocketAddrV4) Destroy(value *SocketAddrV4) {
+	value.Destroy()
+}
+
+type SocketAddrV6 struct {
+	ffiObject FfiObject
+}
+
+func NewSocketAddrV6(ipv6 *Ipv6Addr, port uint16) *SocketAddrV6 {
+	return FfiConverterSocketAddrV6INSTANCE.Lift(rustCall(func(_uniffiStatus *C.RustCallStatus) unsafe.Pointer {
+		return C.uniffi_iroh_fn_constructor_socketaddrv6_new(FfiConverterIpv6AddrINSTANCE.Lower(ipv6), FfiConverterUint16INSTANCE.Lower(port), _uniffiStatus)
+	}))
+}
+
+func SocketAddrV6FromString(str string) (*SocketAddrV6, error) {
+	_uniffiRV, _uniffiErr := rustCallWithError(FfiConverterTypeIrohError{}, func(_uniffiStatus *C.RustCallStatus) unsafe.Pointer {
+		return C.uniffi_iroh_fn_constructor_socketaddrv6_from_string(FfiConverterStringINSTANCE.Lower(str), _uniffiStatus)
+	})
+	if _uniffiErr != nil {
+		var _uniffiDefaultValue *SocketAddrV6
+		return _uniffiDefaultValue, _uniffiErr
+	} else {
+		return FfiConverterSocketAddrV6INSTANCE.Lift(_uniffiRV), _uniffiErr
+	}
+}
+
+func (_self *SocketAddrV6) Ip() *Ipv6Addr {
+	_pointer := _self.ffiObject.incrementPointer("*SocketAddrV6")
+	defer _self.ffiObject.decrementPointer()
+	return FfiConverterIpv6AddrINSTANCE.Lift(rustCall(func(_uniffiStatus *C.RustCallStatus) unsafe.Pointer {
+		return C.uniffi_iroh_fn_method_socketaddrv6_ip(
+			_pointer, _uniffiStatus)
+	}))
+}
+
+func (_self *SocketAddrV6) Port() uint16 {
+	_pointer := _self.ffiObject.incrementPointer("*SocketAddrV6")
+	defer _self.ffiObject.decrementPointer()
+	return FfiConverterUint16INSTANCE.Lift(rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
+		return C.uniffi_iroh_fn_method_socketaddrv6_port(
+			_pointer, _uniffiStatus)
+	}))
+}
+
+func (_self *SocketAddrV6) ToString() string {
+	_pointer := _self.ffiObject.incrementPointer("*SocketAddrV6")
+	defer _self.ffiObject.decrementPointer()
+	return FfiConverterStringINSTANCE.Lift(rustCall(func(_uniffiStatus *C.RustCallStatus) RustBufferI {
+		return C.uniffi_iroh_fn_method_socketaddrv6_to_string(
+			_pointer, _uniffiStatus)
+	}))
+}
+
+func (object *SocketAddrV6) Destroy() {
+	runtime.SetFinalizer(object, nil)
+	object.ffiObject.destroy()
+}
+
+type FfiConverterSocketAddrV6 struct{}
+
+var FfiConverterSocketAddrV6INSTANCE = FfiConverterSocketAddrV6{}
+
+func (c FfiConverterSocketAddrV6) Lift(pointer unsafe.Pointer) *SocketAddrV6 {
+	result := &SocketAddrV6{
+		newFfiObject(
+			pointer,
+			func(pointer unsafe.Pointer, status *C.RustCallStatus) {
+				C.uniffi_iroh_fn_free_socketaddrv6(pointer, status)
+			}),
+	}
+	runtime.SetFinalizer(result, (*SocketAddrV6).Destroy)
+	return result
+}
+
+func (c FfiConverterSocketAddrV6) Read(reader io.Reader) *SocketAddrV6 {
+	return c.Lift(unsafe.Pointer(uintptr(readUint64(reader))))
+}
+
+func (c FfiConverterSocketAddrV6) Lower(value *SocketAddrV6) unsafe.Pointer {
+	// TODO: this is bad - all synchronization from ObjectRuntime.go is discarded here,
+	// because the pointer will be decremented immediately after this function returns,
+	// and someone will be left holding onto a non-locked pointer.
+	pointer := value.ffiObject.incrementPointer("*SocketAddrV6")
+	defer value.ffiObject.decrementPointer()
+	return pointer
+}
+
+func (c FfiConverterSocketAddrV6) Write(writer io.Writer, value *SocketAddrV6) {
+	writeUint64(writer, uint64(uintptr(c.Lower(value))))
+}
+
+type FfiDestroyerSocketAddrV6 struct{}
+
+func (_ FfiDestroyerSocketAddrV6) Destroy(value *SocketAddrV6) {
+	value.Destroy()
+}
+
 type ConnectionInfo struct {
 	Id         uint64
 	PublicKey  *PublicKey
 	DerpRegion *uint16
-	Addrs      []SocketAddr
+	Addrs      []*SocketAddr
 	Latencies  []*float64
 	ConnType   ConnectionType
 	Latency    *float64
@@ -1905,7 +2564,7 @@ func (r *ConnectionInfo) Destroy() {
 	FfiDestroyerUint64{}.Destroy(r.Id)
 	FfiDestroyerPublicKey{}.Destroy(r.PublicKey)
 	FfiDestroyerOptionalUint16{}.Destroy(r.DerpRegion)
-	FfiDestroyerSequenceTypeSocketAddr{}.Destroy(r.Addrs)
+	FfiDestroyerSequenceSocketAddr{}.Destroy(r.Addrs)
 	FfiDestroyerSequenceOptionalFloat64{}.Destroy(r.Latencies)
 	FfiDestroyerTypeConnectionType{}.Destroy(r.ConnType)
 	FfiDestroyerOptionalFloat64{}.Destroy(r.Latency)
@@ -1924,7 +2583,7 @@ func (c FfiConverterTypeConnectionInfo) Read(reader io.Reader) ConnectionInfo {
 		FfiConverterUint64INSTANCE.Read(reader),
 		FfiConverterPublicKeyINSTANCE.Read(reader),
 		FfiConverterOptionalUint16INSTANCE.Read(reader),
-		FfiConverterSequenceTypeSocketAddrINSTANCE.Read(reader),
+		FfiConverterSequenceSocketAddrINSTANCE.Read(reader),
 		FfiConverterSequenceOptionalFloat64INSTANCE.Read(reader),
 		FfiConverterTypeConnectionTypeINSTANCE.Read(reader),
 		FfiConverterOptionalFloat64INSTANCE.Read(reader),
@@ -1939,7 +2598,7 @@ func (c FfiConverterTypeConnectionInfo) Write(writer io.Writer, value Connection
 	FfiConverterUint64INSTANCE.Write(writer, value.Id)
 	FfiConverterPublicKeyINSTANCE.Write(writer, value.PublicKey)
 	FfiConverterOptionalUint16INSTANCE.Write(writer, value.DerpRegion)
-	FfiConverterSequenceTypeSocketAddrINSTANCE.Write(writer, value.Addrs)
+	FfiConverterSequenceSocketAddrINSTANCE.Write(writer, value.Addrs)
 	FfiConverterSequenceOptionalFloat64INSTANCE.Write(writer, value.Latencies)
 	FfiConverterTypeConnectionTypeINSTANCE.Write(writer, value.ConnType)
 	FfiConverterOptionalFloat64INSTANCE.Write(writer, value.Latency)
@@ -2131,11 +2790,13 @@ type ConnectionType interface {
 	Destroy()
 }
 type ConnectionTypeDirect struct {
-	Addr SocketAddr
+	Addr string
+	Port uint16
 }
 
 func (e ConnectionTypeDirect) Destroy() {
-	FfiDestroyerTypeSocketAddr{}.Destroy(e.Addr)
+	FfiDestroyerString{}.Destroy(e.Addr)
+	FfiDestroyerUint16{}.Destroy(e.Port)
 }
 
 type ConnectionTypeRelay struct {
@@ -2168,7 +2829,8 @@ func (FfiConverterTypeConnectionType) Read(reader io.Reader) ConnectionType {
 	switch id {
 	case 1:
 		return ConnectionTypeDirect{
-			FfiConverterTypeSocketAddrINSTANCE.Read(reader),
+			FfiConverterStringINSTANCE.Read(reader),
+			FfiConverterUint16INSTANCE.Read(reader),
 		}
 	case 2:
 		return ConnectionTypeRelay{
@@ -2185,7 +2847,8 @@ func (FfiConverterTypeConnectionType) Write(writer io.Writer, value ConnectionTy
 	switch variant_value := value.(type) {
 	case ConnectionTypeDirect:
 		writeInt32(writer, 1)
-		FfiConverterTypeSocketAddrINSTANCE.Write(writer, variant_value.Addr)
+		FfiConverterStringINSTANCE.Write(writer, variant_value.Addr)
+		FfiConverterUint16INSTANCE.Write(writer, variant_value.Port)
 	case ConnectionTypeRelay:
 		writeInt32(writer, 2)
 		FfiConverterUint16INSTANCE.Write(writer, variant_value.Port)
@@ -2257,6 +2920,11 @@ var ErrIrohErrorDocTicket = fmt.Errorf("IrohErrorDocTicket")
 var ErrIrohErrorUniffi = fmt.Errorf("IrohErrorUniffi")
 var ErrIrohErrorConnection = fmt.Errorf("IrohErrorConnection")
 var ErrIrohErrorBlob = fmt.Errorf("IrohErrorBlob")
+var ErrIrohErrorIpv4Addr = fmt.Errorf("IrohErrorIpv4Addr")
+var ErrIrohErrorIpv6Addr = fmt.Errorf("IrohErrorIpv6Addr")
+var ErrIrohErrorSocketAddrV4 = fmt.Errorf("IrohErrorSocketAddrV4")
+var ErrIrohErrorSocketAddrV6 = fmt.Errorf("IrohErrorSocketAddrV6")
+var ErrIrohErrorSocketAddr = fmt.Errorf("IrohErrorSocketAddr")
 
 // Variant structs
 type IrohErrorRuntime struct {
@@ -2475,6 +3143,141 @@ func (self IrohErrorBlob) Is(target error) bool {
 	return target == ErrIrohErrorBlob
 }
 
+type IrohErrorIpv4Addr struct {
+	Description string
+}
+
+func NewIrohErrorIpv4Addr(
+	description string,
+) *IrohError {
+	return &IrohError{
+		err: &IrohErrorIpv4Addr{
+			Description: description,
+		},
+	}
+}
+
+func (err IrohErrorIpv4Addr) Error() string {
+	return fmt.Sprint("Ipv4Addr",
+		": ",
+
+		"Description=",
+		err.Description,
+	)
+}
+
+func (self IrohErrorIpv4Addr) Is(target error) bool {
+	return target == ErrIrohErrorIpv4Addr
+}
+
+type IrohErrorIpv6Addr struct {
+	Description string
+}
+
+func NewIrohErrorIpv6Addr(
+	description string,
+) *IrohError {
+	return &IrohError{
+		err: &IrohErrorIpv6Addr{
+			Description: description,
+		},
+	}
+}
+
+func (err IrohErrorIpv6Addr) Error() string {
+	return fmt.Sprint("Ipv6Addr",
+		": ",
+
+		"Description=",
+		err.Description,
+	)
+}
+
+func (self IrohErrorIpv6Addr) Is(target error) bool {
+	return target == ErrIrohErrorIpv6Addr
+}
+
+type IrohErrorSocketAddrV4 struct {
+	Description string
+}
+
+func NewIrohErrorSocketAddrV4(
+	description string,
+) *IrohError {
+	return &IrohError{
+		err: &IrohErrorSocketAddrV4{
+			Description: description,
+		},
+	}
+}
+
+func (err IrohErrorSocketAddrV4) Error() string {
+	return fmt.Sprint("SocketAddrV4",
+		": ",
+
+		"Description=",
+		err.Description,
+	)
+}
+
+func (self IrohErrorSocketAddrV4) Is(target error) bool {
+	return target == ErrIrohErrorSocketAddrV4
+}
+
+type IrohErrorSocketAddrV6 struct {
+	Description string
+}
+
+func NewIrohErrorSocketAddrV6(
+	description string,
+) *IrohError {
+	return &IrohError{
+		err: &IrohErrorSocketAddrV6{
+			Description: description,
+		},
+	}
+}
+
+func (err IrohErrorSocketAddrV6) Error() string {
+	return fmt.Sprint("SocketAddrV6",
+		": ",
+
+		"Description=",
+		err.Description,
+	)
+}
+
+func (self IrohErrorSocketAddrV6) Is(target error) bool {
+	return target == ErrIrohErrorSocketAddrV6
+}
+
+type IrohErrorSocketAddr struct {
+	Description string
+}
+
+func NewIrohErrorSocketAddr(
+	description string,
+) *IrohError {
+	return &IrohError{
+		err: &IrohErrorSocketAddr{
+			Description: description,
+		},
+	}
+}
+
+func (err IrohErrorSocketAddr) Error() string {
+	return fmt.Sprint("SocketAddr",
+		": ",
+
+		"Description=",
+		err.Description,
+	)
+}
+
+func (self IrohErrorSocketAddr) Is(target error) bool {
+	return target == ErrIrohErrorSocketAddr
+}
+
 type FfiConverterTypeIrohError struct{}
 
 var FfiConverterTypeIrohErrorINSTANCE = FfiConverterTypeIrohError{}
@@ -2523,6 +3326,26 @@ func (c FfiConverterTypeIrohError) Read(reader io.Reader) error {
 		return &IrohError{&IrohErrorBlob{
 			Description: FfiConverterStringINSTANCE.Read(reader),
 		}}
+	case 9:
+		return &IrohError{&IrohErrorIpv4Addr{
+			Description: FfiConverterStringINSTANCE.Read(reader),
+		}}
+	case 10:
+		return &IrohError{&IrohErrorIpv6Addr{
+			Description: FfiConverterStringINSTANCE.Read(reader),
+		}}
+	case 11:
+		return &IrohError{&IrohErrorSocketAddrV4{
+			Description: FfiConverterStringINSTANCE.Read(reader),
+		}}
+	case 12:
+		return &IrohError{&IrohErrorSocketAddrV6{
+			Description: FfiConverterStringINSTANCE.Read(reader),
+		}}
+	case 13:
+		return &IrohError{&IrohErrorSocketAddr{
+			Description: FfiConverterStringINSTANCE.Read(reader),
+		}}
 	default:
 		panic(fmt.Sprintf("Unknown error code %d in FfiConverterTypeIrohError.Read()", errorID))
 	}
@@ -2553,6 +3376,21 @@ func (c FfiConverterTypeIrohError) Write(writer io.Writer, value *IrohError) {
 		FfiConverterStringINSTANCE.Write(writer, variantValue.Description)
 	case *IrohErrorBlob:
 		writeInt32(writer, 8)
+		FfiConverterStringINSTANCE.Write(writer, variantValue.Description)
+	case *IrohErrorIpv4Addr:
+		writeInt32(writer, 9)
+		FfiConverterStringINSTANCE.Write(writer, variantValue.Description)
+	case *IrohErrorIpv6Addr:
+		writeInt32(writer, 10)
+		FfiConverterStringINSTANCE.Write(writer, variantValue.Description)
+	case *IrohErrorSocketAddrV4:
+		writeInt32(writer, 11)
+		FfiConverterStringINSTANCE.Write(writer, variantValue.Description)
+	case *IrohErrorSocketAddrV6:
+		writeInt32(writer, 12)
+		FfiConverterStringINSTANCE.Write(writer, variantValue.Description)
+	case *IrohErrorSocketAddr:
+		writeInt32(writer, 13)
 		FfiConverterStringINSTANCE.Write(writer, variantValue.Description)
 	default:
 		_ = variantValue
@@ -2694,82 +3532,36 @@ func (_ FfiDestroyerTypeOrigin) Destroy(value Origin) {
 	value.Destroy()
 }
 
-type SocketAddr interface {
-	Destroy()
-}
-type SocketAddrV4 struct {
-	A uint8
-	B uint8
-	C uint8
-	D uint8
-}
+type SocketAddrType uint
 
-func (e SocketAddrV4) Destroy() {
-	FfiDestroyerUint8{}.Destroy(e.A)
-	FfiDestroyerUint8{}.Destroy(e.B)
-	FfiDestroyerUint8{}.Destroy(e.C)
-	FfiDestroyerUint8{}.Destroy(e.D)
+const (
+	SocketAddrTypeV4 SocketAddrType = 1
+	SocketAddrTypeV6 SocketAddrType = 2
+)
+
+type FfiConverterTypeSocketAddrType struct{}
+
+var FfiConverterTypeSocketAddrTypeINSTANCE = FfiConverterTypeSocketAddrType{}
+
+func (c FfiConverterTypeSocketAddrType) Lift(rb RustBufferI) SocketAddrType {
+	return LiftFromRustBuffer[SocketAddrType](c, rb)
 }
 
-type SocketAddrV6 struct {
-	Addr []byte
+func (c FfiConverterTypeSocketAddrType) Lower(value SocketAddrType) RustBuffer {
+	return LowerIntoRustBuffer[SocketAddrType](c, value)
 }
-
-func (e SocketAddrV6) Destroy() {
-	FfiDestroyerBytes{}.Destroy(e.Addr)
-}
-
-type FfiConverterTypeSocketAddr struct{}
-
-var FfiConverterTypeSocketAddrINSTANCE = FfiConverterTypeSocketAddr{}
-
-func (c FfiConverterTypeSocketAddr) Lift(rb RustBufferI) SocketAddr {
-	return LiftFromRustBuffer[SocketAddr](c, rb)
-}
-
-func (c FfiConverterTypeSocketAddr) Lower(value SocketAddr) RustBuffer {
-	return LowerIntoRustBuffer[SocketAddr](c, value)
-}
-func (FfiConverterTypeSocketAddr) Read(reader io.Reader) SocketAddr {
+func (FfiConverterTypeSocketAddrType) Read(reader io.Reader) SocketAddrType {
 	id := readInt32(reader)
-	switch id {
-	case 1:
-		return SocketAddrV4{
-			FfiConverterUint8INSTANCE.Read(reader),
-			FfiConverterUint8INSTANCE.Read(reader),
-			FfiConverterUint8INSTANCE.Read(reader),
-			FfiConverterUint8INSTANCE.Read(reader),
-		}
-	case 2:
-		return SocketAddrV6{
-			FfiConverterBytesINSTANCE.Read(reader),
-		}
-	default:
-		panic(fmt.Sprintf("invalid enum value %v in FfiConverterTypeSocketAddr.Read()", id))
-	}
+	return SocketAddrType(id)
 }
 
-func (FfiConverterTypeSocketAddr) Write(writer io.Writer, value SocketAddr) {
-	switch variant_value := value.(type) {
-	case SocketAddrV4:
-		writeInt32(writer, 1)
-		FfiConverterUint8INSTANCE.Write(writer, variant_value.A)
-		FfiConverterUint8INSTANCE.Write(writer, variant_value.B)
-		FfiConverterUint8INSTANCE.Write(writer, variant_value.C)
-		FfiConverterUint8INSTANCE.Write(writer, variant_value.D)
-	case SocketAddrV6:
-		writeInt32(writer, 2)
-		FfiConverterBytesINSTANCE.Write(writer, variant_value.Addr)
-	default:
-		_ = variant_value
-		panic(fmt.Sprintf("invalid enum value `%v` in FfiConverterTypeSocketAddr.Write", value))
-	}
+func (FfiConverterTypeSocketAddrType) Write(writer io.Writer, value SocketAddrType) {
+	writeInt32(writer, int32(value))
 }
 
-type FfiDestroyerTypeSocketAddr struct{}
+type FfiDestroyerTypeSocketAddrType struct{}
 
-func (_ FfiDestroyerTypeSocketAddr) Destroy(value SocketAddr) {
-	value.Destroy()
+func (_ FfiDestroyerTypeSocketAddrType) Destroy(value SocketAddrType) {
 }
 
 type SyncReason uint
@@ -3103,6 +3895,92 @@ func (_ FfiDestroyerOptionalTypeConnectionInfo) Destroy(value *ConnectionInfo) {
 	}
 }
 
+type FfiConverterSequenceUint8 struct{}
+
+var FfiConverterSequenceUint8INSTANCE = FfiConverterSequenceUint8{}
+
+func (c FfiConverterSequenceUint8) Lift(rb RustBufferI) []uint8 {
+	return LiftFromRustBuffer[[]uint8](c, rb)
+}
+
+func (c FfiConverterSequenceUint8) Read(reader io.Reader) []uint8 {
+	length := readInt32(reader)
+	if length == 0 {
+		return nil
+	}
+	result := make([]uint8, 0, length)
+	for i := int32(0); i < length; i++ {
+		result = append(result, FfiConverterUint8INSTANCE.Read(reader))
+	}
+	return result
+}
+
+func (c FfiConverterSequenceUint8) Lower(value []uint8) RustBuffer {
+	return LowerIntoRustBuffer[[]uint8](c, value)
+}
+
+func (c FfiConverterSequenceUint8) Write(writer io.Writer, value []uint8) {
+	if len(value) > math.MaxInt32 {
+		panic("[]uint8 is too large to fit into Int32")
+	}
+
+	writeInt32(writer, int32(len(value)))
+	for _, item := range value {
+		FfiConverterUint8INSTANCE.Write(writer, item)
+	}
+}
+
+type FfiDestroyerSequenceUint8 struct{}
+
+func (FfiDestroyerSequenceUint8) Destroy(sequence []uint8) {
+	for _, value := range sequence {
+		FfiDestroyerUint8{}.Destroy(value)
+	}
+}
+
+type FfiConverterSequenceUint16 struct{}
+
+var FfiConverterSequenceUint16INSTANCE = FfiConverterSequenceUint16{}
+
+func (c FfiConverterSequenceUint16) Lift(rb RustBufferI) []uint16 {
+	return LiftFromRustBuffer[[]uint16](c, rb)
+}
+
+func (c FfiConverterSequenceUint16) Read(reader io.Reader) []uint16 {
+	length := readInt32(reader)
+	if length == 0 {
+		return nil
+	}
+	result := make([]uint16, 0, length)
+	for i := int32(0); i < length; i++ {
+		result = append(result, FfiConverterUint16INSTANCE.Read(reader))
+	}
+	return result
+}
+
+func (c FfiConverterSequenceUint16) Lower(value []uint16) RustBuffer {
+	return LowerIntoRustBuffer[[]uint16](c, value)
+}
+
+func (c FfiConverterSequenceUint16) Write(writer io.Writer, value []uint16) {
+	if len(value) > math.MaxInt32 {
+		panic("[]uint16 is too large to fit into Int32")
+	}
+
+	writeInt32(writer, int32(len(value)))
+	for _, item := range value {
+		FfiConverterUint16INSTANCE.Write(writer, item)
+	}
+}
+
+type FfiDestroyerSequenceUint16 struct{}
+
+func (FfiDestroyerSequenceUint16) Destroy(sequence []uint16) {
+	for _, value := range sequence {
+		FfiDestroyerUint16{}.Destroy(value)
+	}
+}
+
 type FfiConverterSequenceAuthorId struct{}
 
 var FfiConverterSequenceAuthorIdINSTANCE = FfiConverterSequenceAuthorId{}
@@ -3275,6 +4153,49 @@ func (FfiDestroyerSequenceNamespaceId) Destroy(sequence []*NamespaceId) {
 	}
 }
 
+type FfiConverterSequenceSocketAddr struct{}
+
+var FfiConverterSequenceSocketAddrINSTANCE = FfiConverterSequenceSocketAddr{}
+
+func (c FfiConverterSequenceSocketAddr) Lift(rb RustBufferI) []*SocketAddr {
+	return LiftFromRustBuffer[[]*SocketAddr](c, rb)
+}
+
+func (c FfiConverterSequenceSocketAddr) Read(reader io.Reader) []*SocketAddr {
+	length := readInt32(reader)
+	if length == 0 {
+		return nil
+	}
+	result := make([]*SocketAddr, 0, length)
+	for i := int32(0); i < length; i++ {
+		result = append(result, FfiConverterSocketAddrINSTANCE.Read(reader))
+	}
+	return result
+}
+
+func (c FfiConverterSequenceSocketAddr) Lower(value []*SocketAddr) RustBuffer {
+	return LowerIntoRustBuffer[[]*SocketAddr](c, value)
+}
+
+func (c FfiConverterSequenceSocketAddr) Write(writer io.Writer, value []*SocketAddr) {
+	if len(value) > math.MaxInt32 {
+		panic("[]*SocketAddr is too large to fit into Int32")
+	}
+
+	writeInt32(writer, int32(len(value)))
+	for _, item := range value {
+		FfiConverterSocketAddrINSTANCE.Write(writer, item)
+	}
+}
+
+type FfiDestroyerSequenceSocketAddr struct{}
+
+func (FfiDestroyerSequenceSocketAddr) Destroy(sequence []*SocketAddr) {
+	for _, value := range sequence {
+		FfiDestroyerSocketAddr{}.Destroy(value)
+	}
+}
+
 type FfiConverterSequenceTypeConnectionInfo struct{}
 
 var FfiConverterSequenceTypeConnectionInfoINSTANCE = FfiConverterSequenceTypeConnectionInfo{}
@@ -3315,49 +4236,6 @@ type FfiDestroyerSequenceTypeConnectionInfo struct{}
 func (FfiDestroyerSequenceTypeConnectionInfo) Destroy(sequence []ConnectionInfo) {
 	for _, value := range sequence {
 		FfiDestroyerTypeConnectionInfo{}.Destroy(value)
-	}
-}
-
-type FfiConverterSequenceTypeSocketAddr struct{}
-
-var FfiConverterSequenceTypeSocketAddrINSTANCE = FfiConverterSequenceTypeSocketAddr{}
-
-func (c FfiConverterSequenceTypeSocketAddr) Lift(rb RustBufferI) []SocketAddr {
-	return LiftFromRustBuffer[[]SocketAddr](c, rb)
-}
-
-func (c FfiConverterSequenceTypeSocketAddr) Read(reader io.Reader) []SocketAddr {
-	length := readInt32(reader)
-	if length == 0 {
-		return nil
-	}
-	result := make([]SocketAddr, 0, length)
-	for i := int32(0); i < length; i++ {
-		result = append(result, FfiConverterTypeSocketAddrINSTANCE.Read(reader))
-	}
-	return result
-}
-
-func (c FfiConverterSequenceTypeSocketAddr) Lower(value []SocketAddr) RustBuffer {
-	return LowerIntoRustBuffer[[]SocketAddr](c, value)
-}
-
-func (c FfiConverterSequenceTypeSocketAddr) Write(writer io.Writer, value []SocketAddr) {
-	if len(value) > math.MaxInt32 {
-		panic("[]SocketAddr is too large to fit into Int32")
-	}
-
-	writeInt32(writer, int32(len(value)))
-	for _, item := range value {
-		FfiConverterTypeSocketAddrINSTANCE.Write(writer, item)
-	}
-}
-
-type FfiDestroyerSequenceTypeSocketAddr struct{}
-
-func (FfiDestroyerSequenceTypeSocketAddr) Destroy(sequence []SocketAddr) {
-	for _, value := range sequence {
-		FfiDestroyerTypeSocketAddr{}.Destroy(value)
 	}
 }
 

--- a/go/iroh/iroh.go
+++ b/go/iroh/iroh.go
@@ -735,29 +735,29 @@ func uniffiCheckChecksums() {
 	}
 	{
 		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_iroh_checksum_method_socketaddr_as_ipv4(uniffiStatus)
+		})
+		if checksum != 903 {
+			// If this happens try cleaning and rebuilding your project
+			panic("iroh: uniffi_iroh_checksum_method_socketaddr_as_ipv4: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_iroh_checksum_method_socketaddr_as_ipv6(uniffiStatus)
+		})
+		if checksum != 23303 {
+			// If this happens try cleaning and rebuilding your project
+			panic("iroh: uniffi_iroh_checksum_method_socketaddr_as_ipv6: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_iroh_checksum_method_socketaddr_type(uniffiStatus)
 		})
 		if checksum != 50972 {
 			// If this happens try cleaning and rebuilding your project
 			panic("iroh: uniffi_iroh_checksum_method_socketaddr_type: UniFFI API checksum mismatch")
-		}
-	}
-	{
-		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
-			return C.uniffi_iroh_checksum_method_socketaddr_v4(uniffiStatus)
-		})
-		if checksum != 62655 {
-			// If this happens try cleaning and rebuilding your project
-			panic("iroh: uniffi_iroh_checksum_method_socketaddr_v4: UniFFI API checksum mismatch")
-		}
-	}
-	{
-		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
-			return C.uniffi_iroh_checksum_method_socketaddr_v6(uniffiStatus)
-		})
-		if checksum != 50034 {
-			// If this happens try cleaning and rebuilding your project
-			panic("iroh: uniffi_iroh_checksum_method_socketaddr_v6: UniFFI API checksum mismatch")
 		}
 	}
 	{
@@ -870,20 +870,20 @@ func uniffiCheckChecksums() {
 	}
 	{
 		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
-			return C.uniffi_iroh_checksum_constructor_socketaddr_from_v4(uniffiStatus)
+			return C.uniffi_iroh_checksum_constructor_socketaddr_from_ipv4(uniffiStatus)
 		})
-		if checksum != 55134 {
+		if checksum != 48670 {
 			// If this happens try cleaning and rebuilding your project
-			panic("iroh: uniffi_iroh_checksum_constructor_socketaddr_from_v4: UniFFI API checksum mismatch")
+			panic("iroh: uniffi_iroh_checksum_constructor_socketaddr_from_ipv4: UniFFI API checksum mismatch")
 		}
 	}
 	{
 		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
-			return C.uniffi_iroh_checksum_constructor_socketaddr_from_v6(uniffiStatus)
+			return C.uniffi_iroh_checksum_constructor_socketaddr_from_ipv6(uniffiStatus)
 		})
-		if checksum != 51100 {
+		if checksum != 45955 {
 			// If this happens try cleaning and rebuilding your project
-			panic("iroh: uniffi_iroh_checksum_constructor_socketaddr_from_v6: UniFFI API checksum mismatch")
+			panic("iroh: uniffi_iroh_checksum_constructor_socketaddr_from_ipv6: UniFFI API checksum mismatch")
 		}
 	}
 	{
@@ -2270,31 +2270,22 @@ type SocketAddr struct {
 	ffiObject FfiObject
 }
 
-func SocketAddrFromV4(ipv4 *Ipv4Addr, port uint16) *SocketAddr {
+func SocketAddrFromIpv4(ipv4 *Ipv4Addr, port uint16) *SocketAddr {
 	return FfiConverterSocketAddrINSTANCE.Lift(rustCall(func(_uniffiStatus *C.RustCallStatus) unsafe.Pointer {
-		return C.uniffi_iroh_fn_constructor_socketaddr_from_v4(FfiConverterIpv4AddrINSTANCE.Lower(ipv4), FfiConverterUint16INSTANCE.Lower(port), _uniffiStatus)
+		return C.uniffi_iroh_fn_constructor_socketaddr_from_ipv4(FfiConverterIpv4AddrINSTANCE.Lower(ipv4), FfiConverterUint16INSTANCE.Lower(port), _uniffiStatus)
 	}))
 }
-func SocketAddrFromV6(ipv6 *Ipv6Addr, port uint16) *SocketAddr {
+func SocketAddrFromIpv6(ipv6 *Ipv6Addr, port uint16) *SocketAddr {
 	return FfiConverterSocketAddrINSTANCE.Lift(rustCall(func(_uniffiStatus *C.RustCallStatus) unsafe.Pointer {
-		return C.uniffi_iroh_fn_constructor_socketaddr_from_v6(FfiConverterIpv6AddrINSTANCE.Lower(ipv6), FfiConverterUint16INSTANCE.Lower(port), _uniffiStatus)
+		return C.uniffi_iroh_fn_constructor_socketaddr_from_ipv6(FfiConverterIpv6AddrINSTANCE.Lower(ipv6), FfiConverterUint16INSTANCE.Lower(port), _uniffiStatus)
 	}))
 }
 
-func (_self *SocketAddr) Type() SocketAddrType {
-	_pointer := _self.ffiObject.incrementPointer("*SocketAddr")
-	defer _self.ffiObject.decrementPointer()
-	return FfiConverterTypeSocketAddrTypeINSTANCE.Lift(rustCall(func(_uniffiStatus *C.RustCallStatus) RustBufferI {
-		return C.uniffi_iroh_fn_method_socketaddr_type(
-			_pointer, _uniffiStatus)
-	}))
-}
-
-func (_self *SocketAddr) V4() (*SocketAddrV4, error) {
+func (_self *SocketAddr) AsIpv4() (*SocketAddrV4, error) {
 	_pointer := _self.ffiObject.incrementPointer("*SocketAddr")
 	defer _self.ffiObject.decrementPointer()
 	_uniffiRV, _uniffiErr := rustCallWithError(FfiConverterTypeIrohError{}, func(_uniffiStatus *C.RustCallStatus) unsafe.Pointer {
-		return C.uniffi_iroh_fn_method_socketaddr_v4(
+		return C.uniffi_iroh_fn_method_socketaddr_as_ipv4(
 			_pointer, _uniffiStatus)
 	})
 	if _uniffiErr != nil {
@@ -2305,11 +2296,11 @@ func (_self *SocketAddr) V4() (*SocketAddrV4, error) {
 	}
 }
 
-func (_self *SocketAddr) V6() (*SocketAddrV6, error) {
+func (_self *SocketAddr) AsIpv6() (*SocketAddrV6, error) {
 	_pointer := _self.ffiObject.incrementPointer("*SocketAddr")
 	defer _self.ffiObject.decrementPointer()
 	_uniffiRV, _uniffiErr := rustCallWithError(FfiConverterTypeIrohError{}, func(_uniffiStatus *C.RustCallStatus) unsafe.Pointer {
-		return C.uniffi_iroh_fn_method_socketaddr_v6(
+		return C.uniffi_iroh_fn_method_socketaddr_as_ipv6(
 			_pointer, _uniffiStatus)
 	})
 	if _uniffiErr != nil {
@@ -2318,6 +2309,15 @@ func (_self *SocketAddr) V6() (*SocketAddrV6, error) {
 	} else {
 		return FfiConverterSocketAddrV6INSTANCE.Lift(_uniffiRV), _uniffiErr
 	}
+}
+
+func (_self *SocketAddr) Type() SocketAddrType {
+	_pointer := _self.ffiObject.incrementPointer("*SocketAddr")
+	defer _self.ffiObject.decrementPointer()
+	return FfiConverterTypeSocketAddrTypeINSTANCE.Lift(rustCall(func(_uniffiStatus *C.RustCallStatus) RustBufferI {
+		return C.uniffi_iroh_fn_method_socketaddr_type(
+			_pointer, _uniffiStatus)
+	}))
 }
 
 func (object *SocketAddr) Destroy() {

--- a/go/iroh/iroh.h
+++ b/go/iroh/iroh.h
@@ -65,6 +65,12 @@ int8_t uniffiForeignExecutorCallbackiroh(uint64_t, uint32_t, RustTaskCallback, v
 
 // Callbacks for UniFFI Futures
 typedef void (*UniFfiFutureCallbackuint8_t)(const void *, uint8_t, RustCallStatus);
+typedef void (*UniFfiFutureCallbackuint16_t)(const void *, uint16_t, RustCallStatus);
+typedef void (*UniFfiFutureCallbackRustArcPtr)(const void *, void*, RustCallStatus);
+typedef void (*UniFfiFutureCallbackRustArcPtr)(const void *, void*, RustCallStatus);
+typedef void (*UniFfiFutureCallbackRustArcPtr)(const void *, void*, RustCallStatus);
+typedef void (*UniFfiFutureCallbackRustArcPtr)(const void *, void*, RustCallStatus);
+typedef void (*UniFfiFutureCallbackRustArcPtr)(const void *, void*, RustCallStatus);
 typedef void (*UniFfiFutureCallbackRustArcPtr)(const void *, void*, RustCallStatus);
 typedef void (*UniFfiFutureCallbackRustArcPtr)(const void *, void*, RustCallStatus);
 typedef void (*UniFfiFutureCallbackRustArcPtr)(const void *, void*, RustCallStatus);
@@ -186,6 +192,66 @@ RustBuffer uniffi_iroh_fn_method_hash_to_bytes(
 );
 
 RustBuffer uniffi_iroh_fn_method_hash_to_string(
+	void* ptr,
+	RustCallStatus* out_status
+);
+
+void uniffi_iroh_fn_free_ipv4addr(
+	void* ptr,
+	RustCallStatus* out_status
+);
+
+void* uniffi_iroh_fn_constructor_ipv4addr_from_string(
+	RustBuffer str,
+	RustCallStatus* out_status
+);
+
+void* uniffi_iroh_fn_constructor_ipv4addr_new(
+	uint8_t a,
+	uint8_t b,
+	uint8_t c,
+	uint8_t d,
+	RustCallStatus* out_status
+);
+
+RustBuffer uniffi_iroh_fn_method_ipv4addr_octets(
+	void* ptr,
+	RustCallStatus* out_status
+);
+
+RustBuffer uniffi_iroh_fn_method_ipv4addr_to_string(
+	void* ptr,
+	RustCallStatus* out_status
+);
+
+void uniffi_iroh_fn_free_ipv6addr(
+	void* ptr,
+	RustCallStatus* out_status
+);
+
+void* uniffi_iroh_fn_constructor_ipv6addr_from_string(
+	RustBuffer str,
+	RustCallStatus* out_status
+);
+
+void* uniffi_iroh_fn_constructor_ipv6addr_new(
+	uint16_t a,
+	uint16_t b,
+	uint16_t c,
+	uint16_t d,
+	uint16_t e,
+	uint16_t f,
+	uint16_t g,
+	uint16_t h,
+	RustCallStatus* out_status
+);
+
+RustBuffer uniffi_iroh_fn_method_ipv6addr_segments(
+	void* ptr,
+	RustCallStatus* out_status
+);
+
+RustBuffer uniffi_iroh_fn_method_ipv6addr_to_string(
 	void* ptr,
 	RustCallStatus* out_status
 );
@@ -323,6 +389,100 @@ RustBuffer uniffi_iroh_fn_method_publickey_to_string(
 	RustCallStatus* out_status
 );
 
+void uniffi_iroh_fn_free_socketaddr(
+	void* ptr,
+	RustCallStatus* out_status
+);
+
+void* uniffi_iroh_fn_constructor_socketaddr_from_v4(
+	void* ipv4,
+	uint16_t port,
+	RustCallStatus* out_status
+);
+
+void* uniffi_iroh_fn_constructor_socketaddr_from_v6(
+	void* ipv6,
+	uint16_t port,
+	RustCallStatus* out_status
+);
+
+RustBuffer uniffi_iroh_fn_method_socketaddr_type(
+	void* ptr,
+	RustCallStatus* out_status
+);
+
+void* uniffi_iroh_fn_method_socketaddr_v4(
+	void* ptr,
+	RustCallStatus* out_status
+);
+
+void* uniffi_iroh_fn_method_socketaddr_v6(
+	void* ptr,
+	RustCallStatus* out_status
+);
+
+void uniffi_iroh_fn_free_socketaddrv4(
+	void* ptr,
+	RustCallStatus* out_status
+);
+
+void* uniffi_iroh_fn_constructor_socketaddrv4_from_string(
+	RustBuffer str,
+	RustCallStatus* out_status
+);
+
+void* uniffi_iroh_fn_constructor_socketaddrv4_new(
+	void* ipv4,
+	uint16_t port,
+	RustCallStatus* out_status
+);
+
+void* uniffi_iroh_fn_method_socketaddrv4_ip(
+	void* ptr,
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_iroh_fn_method_socketaddrv4_port(
+	void* ptr,
+	RustCallStatus* out_status
+);
+
+RustBuffer uniffi_iroh_fn_method_socketaddrv4_to_string(
+	void* ptr,
+	RustCallStatus* out_status
+);
+
+void uniffi_iroh_fn_free_socketaddrv6(
+	void* ptr,
+	RustCallStatus* out_status
+);
+
+void* uniffi_iroh_fn_constructor_socketaddrv6_from_string(
+	RustBuffer str,
+	RustCallStatus* out_status
+);
+
+void* uniffi_iroh_fn_constructor_socketaddrv6_new(
+	void* ipv6,
+	uint16_t port,
+	RustCallStatus* out_status
+);
+
+void* uniffi_iroh_fn_method_socketaddrv6_ip(
+	void* ptr,
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_iroh_fn_method_socketaddrv6_port(
+	void* ptr,
+	RustCallStatus* out_status
+);
+
+RustBuffer uniffi_iroh_fn_method_socketaddrv6_to_string(
+	void* ptr,
+	RustCallStatus* out_status
+);
+
 void uniffi_iroh_fn_init_callback_subscribecallback(
 	ForeignCallback callback_stub,
 	RustCallStatus* out_status
@@ -430,6 +590,22 @@ uint16_t uniffi_iroh_checksum_method_hash_to_string(
 	RustCallStatus* out_status
 );
 
+uint16_t uniffi_iroh_checksum_method_ipv4addr_octets(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_iroh_checksum_method_ipv4addr_to_string(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_iroh_checksum_method_ipv6addr_segments(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_iroh_checksum_method_ipv6addr_to_string(
+	RustCallStatus* out_status
+);
+
 uint16_t uniffi_iroh_checksum_method_irohnode_author_list(
 	RustCallStatus* out_status
 );
@@ -514,11 +690,87 @@ uint16_t uniffi_iroh_checksum_method_publickey_to_string(
 	RustCallStatus* out_status
 );
 
+uint16_t uniffi_iroh_checksum_method_socketaddr_type(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_iroh_checksum_method_socketaddr_v4(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_iroh_checksum_method_socketaddr_v6(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_iroh_checksum_method_socketaddrv4_ip(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_iroh_checksum_method_socketaddrv4_port(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_iroh_checksum_method_socketaddrv4_to_string(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_iroh_checksum_method_socketaddrv6_ip(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_iroh_checksum_method_socketaddrv6_port(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_iroh_checksum_method_socketaddrv6_to_string(
+	RustCallStatus* out_status
+);
+
 uint16_t uniffi_iroh_checksum_constructor_docticket_from_string(
 	RustCallStatus* out_status
 );
 
+uint16_t uniffi_iroh_checksum_constructor_ipv4addr_from_string(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_iroh_checksum_constructor_ipv4addr_new(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_iroh_checksum_constructor_ipv6addr_from_string(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_iroh_checksum_constructor_ipv6addr_new(
+	RustCallStatus* out_status
+);
+
 uint16_t uniffi_iroh_checksum_constructor_irohnode_new(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_iroh_checksum_constructor_socketaddr_from_v4(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_iroh_checksum_constructor_socketaddr_from_v6(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_iroh_checksum_constructor_socketaddrv4_from_string(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_iroh_checksum_constructor_socketaddrv4_new(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_iroh_checksum_constructor_socketaddrv6_from_string(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_iroh_checksum_constructor_socketaddrv6_new(
 	RustCallStatus* out_status
 );
 
@@ -534,6 +786,7 @@ uint32_t ffi_iroh_uniffi_contract_version(
 int32_t iroh_cgo_SubscribeCallback(uint64_t, int32_t, uint8_t *, int32_t, RustBuffer *);
 void uniffiFutureCallbackHandlerVoid(void *, uint8_t, RustCallStatus);
 void uniffiFutureCallbackHandlerVoidTypeIrohError(void *, uint8_t, RustCallStatus);
+void uniffiFutureCallbackHandlerUint16(void *, uint16_t, RustCallStatus);
 void uniffiFutureCallbackHandlerString(void *, RustBuffer, RustCallStatus);
 void uniffiFutureCallbackHandlerBytes(void *, RustBuffer, RustCallStatus);
 void uniffiFutureCallbackHandlerBytesTypeIrohError(void *, RustBuffer, RustCallStatus);
@@ -544,13 +797,25 @@ void uniffiFutureCallbackHandlerDocTicketTypeIrohError(void *, void*, RustCallSt
 void uniffiFutureCallbackHandlerEntry(void *, void*, RustCallStatus);
 void uniffiFutureCallbackHandlerHash(void *, void*, RustCallStatus);
 void uniffiFutureCallbackHandlerHashTypeIrohError(void *, void*, RustCallStatus);
+void uniffiFutureCallbackHandlerIpv4Addr(void *, void*, RustCallStatus);
+void uniffiFutureCallbackHandlerIpv4AddrTypeIrohError(void *, void*, RustCallStatus);
+void uniffiFutureCallbackHandlerIpv6Addr(void *, void*, RustCallStatus);
+void uniffiFutureCallbackHandlerIpv6AddrTypeIrohError(void *, void*, RustCallStatus);
 void uniffiFutureCallbackHandlerIrohNodeTypeIrohError(void *, void*, RustCallStatus);
 void uniffiFutureCallbackHandlerPublicKey(void *, void*, RustCallStatus);
+void uniffiFutureCallbackHandlerSocketAddr(void *, void*, RustCallStatus);
+void uniffiFutureCallbackHandlerSocketAddrV4(void *, void*, RustCallStatus);
+void uniffiFutureCallbackHandlerSocketAddrV4TypeIrohError(void *, void*, RustCallStatus);
+void uniffiFutureCallbackHandlerSocketAddrV6(void *, void*, RustCallStatus);
+void uniffiFutureCallbackHandlerSocketAddrV6TypeIrohError(void *, void*, RustCallStatus);
 void uniffiFutureCallbackHandlerTypeInsertRemoteEvent(void *, RustBuffer, RustCallStatus);
 void uniffiFutureCallbackHandlerTypeLiveStatusTypeIrohError(void *, RustBuffer, RustCallStatus);
 void uniffiFutureCallbackHandlerTypeSyncEvent(void *, RustBuffer, RustCallStatus);
 void uniffiFutureCallbackHandlerTypeLiveEventType(void *, RustBuffer, RustCallStatus);
+void uniffiFutureCallbackHandlerTypeSocketAddrType(void *, RustBuffer, RustCallStatus);
 void uniffiFutureCallbackHandlerOptionalTypeConnectionInfoTypeIrohError(void *, RustBuffer, RustCallStatus);
+void uniffiFutureCallbackHandlerSequenceUint8(void *, RustBuffer, RustCallStatus);
+void uniffiFutureCallbackHandlerSequenceUint16(void *, RustBuffer, RustCallStatus);
 void uniffiFutureCallbackHandlerSequenceAuthorIdTypeIrohError(void *, RustBuffer, RustCallStatus);
 void uniffiFutureCallbackHandlerSequenceEntryTypeIrohError(void *, RustBuffer, RustCallStatus);
 void uniffiFutureCallbackHandlerSequenceHashTypeIrohError(void *, RustBuffer, RustCallStatus);

--- a/go/iroh/iroh.h
+++ b/go/iroh/iroh.h
@@ -394,29 +394,29 @@ void uniffi_iroh_fn_free_socketaddr(
 	RustCallStatus* out_status
 );
 
-void* uniffi_iroh_fn_constructor_socketaddr_from_v4(
+void* uniffi_iroh_fn_constructor_socketaddr_from_ipv4(
 	void* ipv4,
 	uint16_t port,
 	RustCallStatus* out_status
 );
 
-void* uniffi_iroh_fn_constructor_socketaddr_from_v6(
+void* uniffi_iroh_fn_constructor_socketaddr_from_ipv6(
 	void* ipv6,
 	uint16_t port,
 	RustCallStatus* out_status
 );
 
+void* uniffi_iroh_fn_method_socketaddr_as_ipv4(
+	void* ptr,
+	RustCallStatus* out_status
+);
+
+void* uniffi_iroh_fn_method_socketaddr_as_ipv6(
+	void* ptr,
+	RustCallStatus* out_status
+);
+
 RustBuffer uniffi_iroh_fn_method_socketaddr_type(
-	void* ptr,
-	RustCallStatus* out_status
-);
-
-void* uniffi_iroh_fn_method_socketaddr_v4(
-	void* ptr,
-	RustCallStatus* out_status
-);
-
-void* uniffi_iroh_fn_method_socketaddr_v6(
 	void* ptr,
 	RustCallStatus* out_status
 );
@@ -690,15 +690,15 @@ uint16_t uniffi_iroh_checksum_method_publickey_to_string(
 	RustCallStatus* out_status
 );
 
+uint16_t uniffi_iroh_checksum_method_socketaddr_as_ipv4(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_iroh_checksum_method_socketaddr_as_ipv6(
+	RustCallStatus* out_status
+);
+
 uint16_t uniffi_iroh_checksum_method_socketaddr_type(
-	RustCallStatus* out_status
-);
-
-uint16_t uniffi_iroh_checksum_method_socketaddr_v4(
-	RustCallStatus* out_status
-);
-
-uint16_t uniffi_iroh_checksum_method_socketaddr_v6(
 	RustCallStatus* out_status
 );
 
@@ -750,11 +750,11 @@ uint16_t uniffi_iroh_checksum_constructor_irohnode_new(
 	RustCallStatus* out_status
 );
 
-uint16_t uniffi_iroh_checksum_constructor_socketaddr_from_v4(
+uint16_t uniffi_iroh_checksum_constructor_socketaddr_from_ipv4(
 	RustCallStatus* out_status
 );
 
-uint16_t uniffi_iroh_checksum_constructor_socketaddr_from_v6(
+uint16_t uniffi_iroh_checksum_constructor_socketaddr_from_ipv6(
 	RustCallStatus* out_status
 );
 

--- a/go/net_test.go
+++ b/go/net_test.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/n0-computer/iroh-ffi/iroh"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestIpv4Addr tests all IPv4Addr constructors and methods
+func TestIpv4Addr(t *testing.T) {
+	// create ipv4 addr from the constructor
+	fromCons := iroh.NewIpv4Addr(10, 10, 10, 10)
+
+	// create ipv4 addr from a string
+	ipStr := "10.10.10.10"
+	fromStr, err := iroh.Ipv4AddrFromString(ipStr)
+	assert.Nil(t, err)
+
+	// ensure the strings are what we expect,
+	assert.Equal(t, fromCons.ToString(), ipStr)
+	assert.Equal(t, fromStr.ToString(), ipStr)
+	//
+	// ensure octets are what we expect
+	octets := []byte{10, 10, 10, 10}
+	assert.Equal(t, fromCons.Octets(), octets)
+	assert.Equal(t, fromStr.Octets(), octets)
+}
+
+// TestIpv6Addr tests all IPv6Addr constructors and methods
+func TestIpv6Addr(t *testing.T) {
+	// create ipv6 addr from the constructor
+	fromCons := iroh.NewIpv6Addr(10000, 10000, 10000, 10000, 10000, 10000, 10000, 10000)
+	//
+	// create ipv6 addr from a string
+	ipStr := "2710:2710:2710:2710:2710:2710:2710:2710"
+	fromStr, err := iroh.Ipv6AddrFromString(ipStr)
+	assert.Nil(t, err)
+	//
+	// ensure strings are what we expect,
+	assert.Equal(t, fromCons.ToString(), ipStr)
+	assert.Equal(t, fromStr.ToString(), ipStr)
+	//
+	// ensure segments are what we expect
+	segments := []uint16{10000, 10000, 10000, 10000, 10000, 10000, 10000, 10000}
+	assert.Equal(t, fromCons.Segments(), segments)
+	assert.Equal(t, fromStr.Segments(), segments)
+}
+
+// TestSocketAddrV4 tests all SocketAddrV4 constructors and methods
+func TestSocketAddrV4(t *testing.T) {
+	// create an addr and a port
+	ipv4, err := iroh.Ipv4AddrFromString("127.0.0.1")
+	assert.Nil(t, err)
+	var port uint16 = 3000
+	socketAddrStr := "127.0.0.1:3000"
+	ipStr := "127.0.0.1"
+
+	// create a socket addrs
+	fromCons := iroh.NewSocketAddrV4(ipv4, port)
+	fromStr, err := iroh.SocketAddrV4FromString(socketAddrStr)
+	assert.Nil(t, err)
+
+	// test the ip addr and port are as expected
+	assert.Equal(t, fromCons.Ip().ToString(), ipStr)
+	assert.Equal(t, fromCons.Port(), port)
+
+	assert.Equal(t, fromStr.Ip().ToString(), ipStr)
+	assert.Equal(t, fromStr.Port(), port)
+
+	// test that the ToString works as expected
+	assert.Equal(t, fromCons.ToString(), socketAddrStr)
+	assert.Equal(t, fromStr.ToString(), socketAddrStr)
+}
+
+// TestSocketAddrV6 tests all SocketAddrV6 constructors and methods
+func TestSocketAddrV6(t *testing.T) {
+	// create an addr and a port
+	ipv6, err := iroh.Ipv6AddrFromString("::1")
+	assert.Nil(t, err)
+	var port uint16 = 3000
+	socketAddrStr := "[::1]:3000"
+	ipStr := "::1"
+
+	// create a socket addrs
+	fromCons := iroh.NewSocketAddrV6(ipv6, port)
+	fromStr, err := iroh.SocketAddrV6FromString(socketAddrStr)
+	assert.Nil(t, err)
+
+	// test the ip addr and port are as expected
+	assert.Equal(t, fromCons.Ip().ToString(), ipStr)
+	assert.Equal(t, fromCons.Port(), port)
+
+	assert.Equal(t, fromStr.Ip().ToString(), ipStr)
+	assert.Equal(t, fromStr.Port(), port)
+
+	// test that the ToString works as expected
+	assert.Equal(t, fromCons.ToString(), socketAddrStr)
+	assert.Equal(t, fromStr.ToString(), socketAddrStr)
+}
+
+// TestSocketAddr tests all SocketAddr constructors and methods
+func TestSocketAddr(t *testing.T) {
+	// create a ip addrs & port
+	ipv4Ip, err := iroh.Ipv4AddrFromString("127.0.0.1")
+	assert.Nil(t, err)
+	ipv6Ip, err := iroh.Ipv6AddrFromString("::1")
+	assert.Nil(t, err)
+	var port uint16 = 3000
+
+	// create socket addrs
+	ipv4 := iroh.SocketAddrFromIpv4(ipv4Ip, port)
+	ipv6 := iroh.SocketAddrFromIpv6(ipv6Ip, port)
+
+	// ensure the types are as expected
+	assert.Equal(t, ipv4.Type(), iroh.SocketAddrTypeV4)
+	assert.Equal(t, ipv6.Type(), iroh.SocketAddrTypeV6)
+
+	// ensure we can get the addrs out properly
+	ipv4Addr, err := ipv4.AsIpv4()
+	assert.Nil(t, err)
+
+	ipv6Addr, err := ipv6.AsIpv6()
+	assert.Nil(t, err)
+
+	// ensure they are as expected
+	assert.Equal(t, ipv4Addr.Ip().ToString(), ipv4Ip.ToString())
+	assert.Equal(t, ipv6Addr.Ip().ToString(), ipv6Ip.ToString())
+	assert.Equal(t, ipv4Addr.Port(), port)
+	assert.Equal(t, ipv6Addr.Port(), port)
+}

--- a/python/net_test.py
+++ b/python/net_test.py
@@ -1,0 +1,112 @@
+# tests that correspond to the `src/net.rs` rust api
+# install pytest in your virtualenv by using pip install pytest
+# run the tests using `python -m pytest`
+from iroh import Ipv4Addr, Ipv6Addr, SocketAddrV4, SocketAddrV6, SocketAddr, SocketAddrType
+
+def test_ipv4_addr():
+    #
+    # create ipv4 addr from the constructor
+    from_cons = Ipv4Addr(10,10,10,10)
+    #
+    # create ipv4 addr from a string
+    ip_str = "10.10.10.10"
+    from_str = Ipv4Addr.from_string(ip_str)
+    #
+    # ensure the strings are what we expect, 
+    assert from_cons.to_string() == ip_str
+    assert from_str.to_string() == ip_str
+    #
+    # ensure octets are what we expect
+    octets = [10,10,10,10]
+    assert from_cons.octets() == [10,10,10,10]
+    assert from_str.octets() == [10,10,10,10]
+
+def test_ipv6_addr():
+    #
+    # create ipv6 addr from the constructor
+    from_cons = Ipv6Addr(10000,10000,10000,10000,10000,10000,10000,10000)
+    #
+    # create ipv6 addr from a string
+    ip_str = "2710:2710:2710:2710:2710:2710:2710:2710"
+    from_str = Ipv6Addr.from_string(ip_str)
+    #
+    # ensure strings are what we expect, 
+    assert from_cons.to_string() == ip_str
+    assert from_str.to_string() == ip_str
+    #
+    # ensure segments are what we expect
+    segments = [10000,10000,10000,10000,10000,10000,10000,10000]
+    assert from_cons.segments() == segments
+    assert from_str.segments() ==  segments
+
+def test_socket_addr_v4():
+    #
+    # create an addr and a port
+    ipv4 = Ipv4Addr.from_string("127.0.0.1")
+    port = 3000
+    socket_addr_str = "127.0.0.1:3000"
+    ip_str = "127.0.0.1"
+    #
+    # create a socket addrs
+    from_cons = SocketAddrV4(ipv4, port)
+    from_str = SocketAddrV4.from_string(socket_addr_str)
+    #
+    # test the ip addr and port are as expected
+    assert from_cons.ip().to_string() == ip_str
+    assert from_cons.port() == port
+    #
+    assert from_str.ip().to_string() == ip_str
+    assert from_str.port() == port
+    #
+    # test that the to_string works as expected
+    assert from_cons.to_string() == socket_addr_str
+    assert from_str.to_string() == socket_addr_str
+
+def test_socket_addr_v6():
+    #
+    # create an addr and a port
+    ipv6 = Ipv6Addr.from_string("::1")
+    port = 3000
+    socket_addr_str = "[::1]:3000"
+    ip_str = "::1"
+    #
+    # create a socket addrs
+    from_cons = SocketAddrV6(ipv6, port)
+    from_str = SocketAddrV6.from_string(socket_addr_str)
+    #
+    # test the ip addr and port are as expected
+    assert from_cons.ip().to_string() == ip_str
+    assert from_cons.port() == port
+    #
+    assert from_str.ip().to_string() == ip_str
+    assert from_str.port() == port
+    #
+    # test that the to_string works as expected
+    assert from_cons.to_string() == socket_addr_str
+    assert from_str.to_string() == socket_addr_str
+
+def test_socket_addr():
+    #
+    # create a ip addrs & port
+    ipv4_ip = Ipv4Addr.from_string("127.0.0.1")
+    ipv6_ip = Ipv6Addr.from_string("::1")
+    port = 3000
+    #
+    # create socket addrs
+    ipv4 = SocketAddr.from_ipv4(ipv4_ip, port)
+    ipv6 = SocketAddr.from_ipv6(ipv6_ip, port)
+    #
+    # ensure the types are as expected
+    assert ipv4.type() == SocketAddrType.V4
+    assert ipv6.type() == SocketAddrType.V6
+    #
+    # ensure we can get the addrs out properly
+    ipv4_addr = ipv4.as_ipv4()
+    ipv6_addr = ipv6.as_ipv6()
+    #
+    # ensure they are as expected
+    assert ipv4_addr.ip().to_string() == ipv4_ip.to_string()
+    assert ipv6_addr.ip().to_string() == ipv6_ip.to_string()
+    assert ipv4_addr.port() == port 
+    assert ipv6_addr.port() == port
+

--- a/src/error.rs
+++ b/src/error.rs
@@ -19,6 +19,16 @@ pub enum IrohError {
     Connection { description: String },
     #[error("blob: {description}")]
     Blob { description: String },
+    #[error("Ipv4Addr error: {description}")]
+    Ipv4Addr { description: String },
+    #[error("SocketAddrV4 error: {description}")]
+    SocketAddrV4 { description: String },
+    #[error("Ipv6Addr error: {description}")]
+    Ipv6Addr { description: String },
+    #[error("SocketAddrV6 error: {description}")]
+    SocketAddrV6 { description: String },
+    #[error("SocketAddr error: {description}")]
+    SocketAddr { description: String },
 }
 
 impl IrohError {
@@ -60,6 +70,36 @@ impl IrohError {
 
     pub fn blob(error: impl Display) -> Self {
         IrohError::Blob {
+            description: error.to_string(),
+        }
+    }
+
+    pub fn ipv4_addr(error: impl Display) -> Self {
+        IrohError::Ipv4Addr {
+            description: error.to_string(),
+        }
+    }
+
+    pub fn ipv6_addr(error: impl Display) -> Self {
+        IrohError::Ipv6Addr {
+            description: error.to_string(),
+        }
+    }
+
+    pub fn socket_addr_v4(error: impl Display) -> Self {
+        IrohError::SocketAddrV4 {
+            description: error.to_string(),
+        }
+    }
+
+    pub fn socket_addr_v6(error: impl Display) -> Self {
+        IrohError::SocketAddrV6 {
+            description: error.to_string(),
+        }
+    }
+
+    pub fn socket_addr(error: impl Display) -> Self {
+        IrohError::SocketAddr {
             description: error.to_string(),
         }
     }

--- a/src/iroh.udl
+++ b/src/iroh.udl
@@ -166,15 +166,60 @@ dictionary ConnectionInfo {
 
 [Enum]
 interface ConnectionType{
-  Direct(SocketAddr addr);
+  Direct(string addr, u16 port);
   Relay(u16 port);
   None();
 };
 
-[Enum]
+enum SocketAddrType {
+  "V4",
+  "V6",
+};
+
+interface Ipv4Addr {
+  constructor(u8 a, u8 b, u8 c, u8 d);
+  [Name=from_string, Throws=IrohError]
+  constructor(string str);
+  string to_string();
+  sequence<u8> octets(); 
+};
+
+interface SocketAddrV4 {
+  constructor(Ipv4Addr ipv4, u16 port);
+  [Name=from_string, Throws=IrohError]
+  constructor(string str);
+  string to_string();
+  Ipv4Addr ip(); 
+  u16 port();
+};
+
+interface Ipv6Addr {
+  constructor(u16 a, u16 b, u16 c, u16 d, u16 e, u16 f, u16 g, u16 h);
+  [Name=from_string, Throws=IrohError]
+  constructor(string str);
+  string to_string();
+  sequence<u16> segments(); 
+};
+
+interface SocketAddrV6 {
+  constructor(Ipv6Addr ipv6, u16 port);
+  [Name=from_string, Throws=IrohError]
+  constructor(string str);
+  string to_string();
+  Ipv6Addr ip(); 
+  u16 port();
+};
+
 interface SocketAddr {
-  V4(u8 a, u8 b, u8 c, u8 d);
-  V6(bytes addr);
+  [Name=from_v4]
+  constructor(Ipv4Addr ipv4, u16 port);
+  [Name=from_v6]
+  constructor(Ipv6Addr ipv6, u16 port);
+  SocketAddrType type();
+  [Throws=IrohError]
+  SocketAddrV4 v4();
+  [Throws=IrohError]
+  SocketAddrV6 v6();
 };
 
 interface PublicKey {
@@ -192,4 +237,9 @@ interface IrohError {
   Uniffi(string description);
   Connection(string description);
   Blob(string description);
+  Ipv4Addr(string description);
+  Ipv6Addr(string description);
+  SocketAddrV4(string description);
+  SocketAddrV6(string description);
+  SocketAddr(string description);
 };

--- a/src/iroh.udl
+++ b/src/iroh.udl
@@ -211,15 +211,15 @@ interface SocketAddrV6 {
 };
 
 interface SocketAddr {
-  [Name=from_v4]
+  [Name=from_ipv4]
   constructor(Ipv4Addr ipv4, u16 port);
-  [Name=from_v6]
+  [Name=from_ipv6]
   constructor(Ipv6Addr ipv6, u16 port);
   SocketAddrType type();
   [Throws=IrohError]
-  SocketAddrV4 v4();
+  SocketAddrV4 as_ipv4();
   [Throws=IrohError]
-  SocketAddrV6 v6();
+  SocketAddrV6 as_ipv6();
 };
 
 interface PublicKey {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,9 @@
 mod error;
+mod net;
 mod node;
 
 pub use self::error::IrohError;
+pub use self::net::*;
 pub use self::node::*;
 
 uniffi::include_scaffolding!("iroh");

--- a/src/net.rs
+++ b/src/net.rs
@@ -25,14 +25,14 @@ impl From<std::net::SocketAddr> for SocketAddr {
 
 impl SocketAddr {
     /// Create an Ipv4 SocketAddr
-    pub fn from_v4(ipv4: Arc<Ipv4Addr>, port: u16) -> Self {
+    pub fn from_ipv4(ipv4: Arc<Ipv4Addr>, port: u16) -> Self {
         SocketAddr::V4 {
             addr: SocketAddrV4::new(ipv4, port),
         }
     }
 
     /// Create an Ipv6 SocketAddr
-    pub fn from_v6(ipv6: Arc<Ipv6Addr>, port: u16) -> Self {
+    pub fn from_ipv6(ipv6: Arc<Ipv6Addr>, port: u16) -> Self {
         SocketAddr::V6 {
             addr: SocketAddrV6::new(ipv6, port),
         }
@@ -47,7 +47,7 @@ impl SocketAddr {
     }
 
     /// Get the IPv4 SocketAddr representation
-    pub fn v4(&self) -> Result<Arc<SocketAddrV4>, IrohError> {
+    pub fn as_ipv4(&self) -> Result<Arc<SocketAddrV4>, IrohError> {
         match self {
             SocketAddr::V4 { addr } => Ok(Arc::new(addr.clone())),
             SocketAddr::V6 { .. } => Err(IrohError::SocketAddr {
@@ -57,7 +57,7 @@ impl SocketAddr {
     }
 
     /// Get the IPv6 SocketAddr representation
-    pub fn v6(&self) -> Result<Arc<SocketAddrV6>, IrohError> {
+    pub fn as_ipv6(&self) -> Result<Arc<SocketAddrV6>, IrohError> {
         match self {
             SocketAddr::V4 { .. } => Err(IrohError::SocketAddr {
                 description: "Called SocketAddr:v6() on an Ipv4 socket addr".to_string(),

--- a/src/net.rs
+++ b/src/net.rs
@@ -1,0 +1,218 @@
+use std::str::FromStr;
+use std::sync::Arc;
+
+use crate::IrohError;
+
+/// An internet socket address, either Ipv4 or Ipv6
+#[derive(Debug, Clone)]
+pub enum SocketAddr {
+    V4 { addr: SocketAddrV4 },
+    V6 { addr: SocketAddrV6 },
+}
+
+impl From<std::net::SocketAddr> for SocketAddr {
+    fn from(value: std::net::SocketAddr) -> Self {
+        match value {
+            std::net::SocketAddr::V4(addr) => SocketAddr::V4 {
+                addr: SocketAddrV4::new(Ipv4Addr(*addr.ip()).into(), addr.port()),
+            },
+            std::net::SocketAddr::V6(addr) => SocketAddr::V6 {
+                addr: SocketAddrV6::new(Ipv6Addr(*addr.ip()).into(), addr.port()),
+            },
+        }
+    }
+}
+
+impl SocketAddr {
+    /// Create an Ipv4 SocketAddr
+    pub fn from_v4(ipv4: Arc<Ipv4Addr>, port: u16) -> Self {
+        SocketAddr::V4 {
+            addr: SocketAddrV4::new(ipv4, port),
+        }
+    }
+
+    /// Create an Ipv6 SocketAddr
+    pub fn from_v6(ipv6: Arc<Ipv6Addr>, port: u16) -> Self {
+        SocketAddr::V6 {
+            addr: SocketAddrV6::new(ipv6, port),
+        }
+    }
+
+    /// The type of SocketAddr
+    pub fn r#type(&self) -> SocketAddrType {
+        match self {
+            SocketAddr::V4 { .. } => SocketAddrType::V4,
+            SocketAddr::V6 { .. } => SocketAddrType::V6,
+        }
+    }
+
+    /// Get the IPv4 SocketAddr representation
+    pub fn v4(&self) -> Result<Arc<SocketAddrV4>, IrohError> {
+        match self {
+            SocketAddr::V4 { addr } => Ok(Arc::new(addr.clone())),
+            SocketAddr::V6 { .. } => Err(IrohError::SocketAddr {
+                description: "Called SocketAddr:v4() on an Ipv6 socket addr".to_string(),
+            }),
+        }
+    }
+
+    /// Get the IPv6 SocketAddr representation
+    pub fn v6(&self) -> Result<Arc<SocketAddrV6>, IrohError> {
+        match self {
+            SocketAddr::V4 { .. } => Err(IrohError::SocketAddr {
+                description: "Called SocketAddr:v6() on an Ipv4 socket addr".to_string(),
+            }),
+            SocketAddr::V6 { addr } => Ok(Arc::new(addr.clone())),
+        }
+    }
+}
+
+/// Ipv4 address
+#[derive(Debug, Clone)]
+pub struct Ipv4Addr(std::net::Ipv4Addr);
+
+impl From<std::net::Ipv4Addr> for Ipv4Addr {
+    fn from(value: std::net::Ipv4Addr) -> Self {
+        Ipv4Addr(value)
+    }
+}
+
+impl Ipv4Addr {
+    /// Create a new Ipv4 addr from 4 eight-bit octets
+    pub fn new(a: u8, b: u8, c: u8, d: u8) -> Self {
+        Ipv4Addr(std::net::Ipv4Addr::new(a, b, c, d))
+    }
+
+    /// Create a new Ipv4 addr from a String
+    pub fn from_string(str: String) -> Result<Self, IrohError> {
+        let addr = std::net::Ipv4Addr::from_str(&str).map_err(|e| IrohError::Ipv4Addr {
+            description: e.to_string(),
+        })?;
+        Ok(Ipv4Addr(addr))
+    }
+
+    /// A string representation of an Ipv4Addr
+    pub fn to_string(&self) -> String {
+        self.0.to_string()
+    }
+
+    /// Get the 4 octets as bytes
+    pub fn octets(&self) -> Vec<u8> {
+        self.0.octets().to_vec()
+    }
+}
+
+/// An Ipv4 socket address
+#[derive(Debug, Clone)]
+pub struct SocketAddrV4(std::net::SocketAddrV4);
+
+impl From<std::net::SocketAddrV4> for SocketAddrV4 {
+    fn from(value: std::net::SocketAddrV4) -> Self {
+        SocketAddrV4(value)
+    }
+}
+
+impl SocketAddrV4 {
+    /// Create a new socket address from an [`Ipv4Addr`] and a port number
+    pub fn new(ipv4: Arc<Ipv4Addr>, port: u16) -> Self {
+        SocketAddrV4(std::net::SocketAddrV4::new(ipv4.0, port))
+    }
+
+    /// Create a new Ipv4 addr from a String
+    pub fn from_string(str: String) -> Result<Self, IrohError> {
+        let addr = std::net::SocketAddrV4::from_str(&str).map_err(|e| IrohError::SocketAddrV4 {
+            description: e.to_string(),
+        })?;
+        Ok(SocketAddrV4(addr))
+    }
+
+    /// A string representation of an Ipv4Addr
+    pub fn to_string(&self) -> String {
+        self.0.to_string()
+    }
+
+    /// Returns the IP address associated with this socket address
+    pub fn ip(&self) -> Arc<Ipv4Addr> {
+        Arc::new(Ipv4Addr(*self.0.ip()))
+    }
+
+    /// Returns the port number associated with this socket address
+    pub fn port(&self) -> u16 {
+        self.0.port()
+    }
+}
+
+/// Ipv6 address
+#[derive(Debug, Clone)]
+pub struct Ipv6Addr(std::net::Ipv6Addr);
+
+impl Ipv6Addr {
+    /// Create a new Ipv6 addr from 8 16-bit segments
+    pub fn new(a: u16, b: u16, c: u16, d: u16, e: u16, f: u16, g: u16, h: u16) -> Self {
+        Ipv6Addr(std::net::Ipv6Addr::new(a, b, c, d, e, f, g, h))
+    }
+
+    /// Create a new Ipv6 addr from a String
+    pub fn from_string(str: String) -> Result<Self, IrohError> {
+        let addr = std::net::Ipv6Addr::from_str(&str).map_err(|e| IrohError::Ipv6Addr {
+            description: e.to_string(),
+        })?;
+        Ok(Ipv6Addr(addr))
+    }
+    /// A string representation of an Ipv6Addr
+    pub fn to_string(&self) -> String {
+        self.0.to_string()
+    }
+
+    /// Get the 8 sixteen-bit segments as an array
+    pub fn segments(&self) -> Vec<u16> {
+        self.0.segments().to_vec()
+    }
+}
+
+/// An Ipv6 socket address
+#[derive(Debug, Clone)]
+pub struct SocketAddrV6(std::net::SocketAddrV6);
+
+impl From<std::net::SocketAddrV6> for SocketAddrV6 {
+    fn from(value: std::net::SocketAddrV6) -> Self {
+        SocketAddrV6(value)
+    }
+}
+
+impl SocketAddrV6 {
+    /// Create a new socket address from an [`Ipv6Addr`] and a port number
+    pub fn new(ipv6: Arc<Ipv6Addr>, port: u16) -> Self {
+        SocketAddrV6(std::net::SocketAddrV6::new(ipv6.0, port, 0, 0))
+    }
+
+    /// Create a new Ipv6 addr from a String
+    pub fn from_string(str: String) -> Result<Self, IrohError> {
+        let addr = std::net::SocketAddrV6::from_str(&str).map_err(|e| IrohError::SocketAddrV6 {
+            description: e.to_string(),
+        })?;
+        Ok(SocketAddrV6(addr))
+    }
+
+    /// A string representation of an Ipv6Addr
+    pub fn to_string(&self) -> String {
+        self.0.to_string()
+    }
+
+    /// Returns the IP address associated with this socket address
+    pub fn ip(&self) -> Arc<Ipv6Addr> {
+        Arc::new(Ipv6Addr(*self.0.ip()))
+    }
+
+    /// Returns the port number associated with this socket address
+    pub fn port(&self) -> u16 {
+        self.0.port()
+    }
+}
+
+/// Type of SocketAddr
+#[derive(Debug, Clone)]
+pub enum SocketAddrType {
+    V4,
+    V6,
+}


### PR DESCRIPTION
- Add `SocketAddr`, `Ipv4Addr`, `Ipv6Addr`, `SocketAddrV4`, and `SocketAddrV6` to the api to maintain type safety. These also act as a very good "first example" on how to handle translations between the rust API and the ffi API.
- Added instructions on the expected translations to the README.md. closes #54
- Added python tests
- Added go tests
- Added instructions on how to structure and run the go and python tests