### PR TITLE
feat: restore `Entry::content_hash` & `Entry::content_len`

### DIFF
--- a/Iroh.xcframework/ios-arm64/Iroh.framework/Headers/irohFFI.h
+++ b/Iroh.xcframework/ios-arm64/Iroh.framework/Headers/irohFFI.h
@@ -185,6 +185,10 @@ void uniffi_iroh_fn_free_entry(void*_Nonnull ptr, RustCallStatus *_Nonnull out_s
 );
 void*_Nonnull uniffi_iroh_fn_method_entry_author(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
+void*_Nonnull uniffi_iroh_fn_method_entry_content_hash(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+uint64_t uniffi_iroh_fn_method_entry_content_len(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
 RustBuffer uniffi_iroh_fn_method_entry_key(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
 void*_Nonnull uniffi_iroh_fn_method_entry_namespace(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
@@ -237,9 +241,9 @@ void uniffi_iroh_fn_free_irohnode(void*_Nonnull ptr, RustCallStatus *_Nonnull ou
 );
 void*_Nonnull uniffi_iroh_fn_constructor_irohnode_new(RustBuffer path, RustCallStatus *_Nonnull out_status
 );
-RustBuffer uniffi_iroh_fn_method_irohnode_author_list(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+void*_Nonnull uniffi_iroh_fn_method_irohnode_author_create(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
-void*_Nonnull uniffi_iroh_fn_method_irohnode_author_new(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+RustBuffer uniffi_iroh_fn_method_irohnode_author_list(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
 RustBuffer uniffi_iroh_fn_method_irohnode_blobs_add_bytes(void*_Nonnull ptr, RustBuffer bytes, void*_Nonnull tag, RustCallStatus *_Nonnull out_status
 );
@@ -265,11 +269,11 @@ RustBuffer uniffi_iroh_fn_method_irohnode_connection_info(void*_Nonnull ptr, voi
 );
 RustBuffer uniffi_iroh_fn_method_irohnode_connections(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
+void*_Nonnull uniffi_iroh_fn_method_irohnode_doc_create(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
 void*_Nonnull uniffi_iroh_fn_method_irohnode_doc_join(void*_Nonnull ptr, void*_Nonnull ticket, RustCallStatus *_Nonnull out_status
 );
 RustBuffer uniffi_iroh_fn_method_irohnode_doc_list(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
-);
-void*_Nonnull uniffi_iroh_fn_method_irohnode_doc_new(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
 RustBuffer uniffi_iroh_fn_method_irohnode_node_id(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
@@ -325,15 +329,19 @@ RustBuffer uniffi_iroh_fn_method_publickey_to_string(void*_Nonnull ptr, RustCall
 );
 void uniffi_iroh_fn_free_query(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
-void*_Nonnull uniffi_iroh_fn_constructor_query_all(RustBuffer sort_by, RustBuffer direction, RustBuffer offset, RustBuffer limit, RustCallStatus *_Nonnull out_status
+void*_Nonnull uniffi_iroh_fn_constructor_query_all(RustBuffer opts, RustCallStatus *_Nonnull out_status
 );
-void*_Nonnull uniffi_iroh_fn_constructor_query_author(void*_Nonnull author, RustBuffer sort_by, RustBuffer direction, RustBuffer offset, RustBuffer limit, RustCallStatus *_Nonnull out_status
+void*_Nonnull uniffi_iroh_fn_constructor_query_author(void*_Nonnull author, RustBuffer opts, RustCallStatus *_Nonnull out_status
 );
-void*_Nonnull uniffi_iroh_fn_constructor_query_key_exact(RustBuffer key, RustBuffer sort_by, RustBuffer direction, RustBuffer offset, RustBuffer limit, RustCallStatus *_Nonnull out_status
+void*_Nonnull uniffi_iroh_fn_constructor_query_author_key_exact(void*_Nonnull author, RustBuffer key, RustCallStatus *_Nonnull out_status
 );
-void*_Nonnull uniffi_iroh_fn_constructor_query_key_prefix(RustBuffer prefix, RustBuffer sort_by, RustBuffer direction, RustBuffer offset, RustBuffer limit, RustCallStatus *_Nonnull out_status
+void*_Nonnull uniffi_iroh_fn_constructor_query_author_key_prefix(void*_Nonnull author, RustBuffer prefix, RustBuffer opts, RustCallStatus *_Nonnull out_status
 );
-void*_Nonnull uniffi_iroh_fn_constructor_query_single_latest_per_key(RustBuffer direction, RustBuffer offset, RustBuffer limit, RustCallStatus *_Nonnull out_status
+void*_Nonnull uniffi_iroh_fn_constructor_query_key_exact(RustBuffer key, RustBuffer opts, RustCallStatus *_Nonnull out_status
+);
+void*_Nonnull uniffi_iroh_fn_constructor_query_key_prefix(RustBuffer prefix, RustBuffer opts, RustCallStatus *_Nonnull out_status
+);
+void*_Nonnull uniffi_iroh_fn_constructor_query_single_latest_per_key(RustBuffer opts, RustCallStatus *_Nonnull out_status
 );
 RustBuffer uniffi_iroh_fn_method_query_limit(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
@@ -547,6 +555,12 @@ uint16_t uniffi_iroh_checksum_method_downloadprogress_type(void
 uint16_t uniffi_iroh_checksum_method_entry_author(void
     
 );
+uint16_t uniffi_iroh_checksum_method_entry_content_hash(void
+    
+);
+uint16_t uniffi_iroh_checksum_method_entry_content_len(void
+    
+);
 uint16_t uniffi_iroh_checksum_method_entry_key(void
     
 );
@@ -586,10 +600,10 @@ uint16_t uniffi_iroh_checksum_method_ipv6addr_segments(void
 uint16_t uniffi_iroh_checksum_method_ipv6addr_to_string(void
     
 );
-uint16_t uniffi_iroh_checksum_method_irohnode_author_list(void
+uint16_t uniffi_iroh_checksum_method_irohnode_author_create(void
     
 );
-uint16_t uniffi_iroh_checksum_method_irohnode_author_new(void
+uint16_t uniffi_iroh_checksum_method_irohnode_author_list(void
     
 );
 uint16_t uniffi_iroh_checksum_method_irohnode_blobs_add_bytes(void
@@ -628,13 +642,13 @@ uint16_t uniffi_iroh_checksum_method_irohnode_connection_info(void
 uint16_t uniffi_iroh_checksum_method_irohnode_connections(void
     
 );
+uint16_t uniffi_iroh_checksum_method_irohnode_doc_create(void
+    
+);
 uint16_t uniffi_iroh_checksum_method_irohnode_doc_join(void
     
 );
 uint16_t uniffi_iroh_checksum_method_irohnode_doc_list(void
-    
-);
-uint16_t uniffi_iroh_checksum_method_irohnode_doc_new(void
     
 );
 uint16_t uniffi_iroh_checksum_method_irohnode_node_id(void
@@ -806,6 +820,12 @@ uint16_t uniffi_iroh_checksum_constructor_query_all(void
     
 );
 uint16_t uniffi_iroh_checksum_constructor_query_author(void
+    
+);
+uint16_t uniffi_iroh_checksum_constructor_query_author_key_exact(void
+    
+);
+uint16_t uniffi_iroh_checksum_constructor_query_author_key_prefix(void
     
 );
 uint16_t uniffi_iroh_checksum_constructor_query_key_exact(void

--- a/Iroh.xcframework/ios-arm64_x86_64-simulator/Iroh.framework/Headers/irohFFI.h
+++ b/Iroh.xcframework/ios-arm64_x86_64-simulator/Iroh.framework/Headers/irohFFI.h
@@ -185,6 +185,10 @@ void uniffi_iroh_fn_free_entry(void*_Nonnull ptr, RustCallStatus *_Nonnull out_s
 );
 void*_Nonnull uniffi_iroh_fn_method_entry_author(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
+void*_Nonnull uniffi_iroh_fn_method_entry_content_hash(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+uint64_t uniffi_iroh_fn_method_entry_content_len(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
 RustBuffer uniffi_iroh_fn_method_entry_key(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
 void*_Nonnull uniffi_iroh_fn_method_entry_namespace(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
@@ -237,9 +241,9 @@ void uniffi_iroh_fn_free_irohnode(void*_Nonnull ptr, RustCallStatus *_Nonnull ou
 );
 void*_Nonnull uniffi_iroh_fn_constructor_irohnode_new(RustBuffer path, RustCallStatus *_Nonnull out_status
 );
-RustBuffer uniffi_iroh_fn_method_irohnode_author_list(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+void*_Nonnull uniffi_iroh_fn_method_irohnode_author_create(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
-void*_Nonnull uniffi_iroh_fn_method_irohnode_author_new(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+RustBuffer uniffi_iroh_fn_method_irohnode_author_list(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
 RustBuffer uniffi_iroh_fn_method_irohnode_blobs_add_bytes(void*_Nonnull ptr, RustBuffer bytes, void*_Nonnull tag, RustCallStatus *_Nonnull out_status
 );
@@ -265,11 +269,11 @@ RustBuffer uniffi_iroh_fn_method_irohnode_connection_info(void*_Nonnull ptr, voi
 );
 RustBuffer uniffi_iroh_fn_method_irohnode_connections(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
+void*_Nonnull uniffi_iroh_fn_method_irohnode_doc_create(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
 void*_Nonnull uniffi_iroh_fn_method_irohnode_doc_join(void*_Nonnull ptr, void*_Nonnull ticket, RustCallStatus *_Nonnull out_status
 );
 RustBuffer uniffi_iroh_fn_method_irohnode_doc_list(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
-);
-void*_Nonnull uniffi_iroh_fn_method_irohnode_doc_new(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
 RustBuffer uniffi_iroh_fn_method_irohnode_node_id(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
@@ -325,15 +329,19 @@ RustBuffer uniffi_iroh_fn_method_publickey_to_string(void*_Nonnull ptr, RustCall
 );
 void uniffi_iroh_fn_free_query(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
-void*_Nonnull uniffi_iroh_fn_constructor_query_all(RustBuffer sort_by, RustBuffer direction, RustBuffer offset, RustBuffer limit, RustCallStatus *_Nonnull out_status
+void*_Nonnull uniffi_iroh_fn_constructor_query_all(RustBuffer opts, RustCallStatus *_Nonnull out_status
 );
-void*_Nonnull uniffi_iroh_fn_constructor_query_author(void*_Nonnull author, RustBuffer sort_by, RustBuffer direction, RustBuffer offset, RustBuffer limit, RustCallStatus *_Nonnull out_status
+void*_Nonnull uniffi_iroh_fn_constructor_query_author(void*_Nonnull author, RustBuffer opts, RustCallStatus *_Nonnull out_status
 );
-void*_Nonnull uniffi_iroh_fn_constructor_query_key_exact(RustBuffer key, RustBuffer sort_by, RustBuffer direction, RustBuffer offset, RustBuffer limit, RustCallStatus *_Nonnull out_status
+void*_Nonnull uniffi_iroh_fn_constructor_query_author_key_exact(void*_Nonnull author, RustBuffer key, RustCallStatus *_Nonnull out_status
 );
-void*_Nonnull uniffi_iroh_fn_constructor_query_key_prefix(RustBuffer prefix, RustBuffer sort_by, RustBuffer direction, RustBuffer offset, RustBuffer limit, RustCallStatus *_Nonnull out_status
+void*_Nonnull uniffi_iroh_fn_constructor_query_author_key_prefix(void*_Nonnull author, RustBuffer prefix, RustBuffer opts, RustCallStatus *_Nonnull out_status
 );
-void*_Nonnull uniffi_iroh_fn_constructor_query_single_latest_per_key(RustBuffer direction, RustBuffer offset, RustBuffer limit, RustCallStatus *_Nonnull out_status
+void*_Nonnull uniffi_iroh_fn_constructor_query_key_exact(RustBuffer key, RustBuffer opts, RustCallStatus *_Nonnull out_status
+);
+void*_Nonnull uniffi_iroh_fn_constructor_query_key_prefix(RustBuffer prefix, RustBuffer opts, RustCallStatus *_Nonnull out_status
+);
+void*_Nonnull uniffi_iroh_fn_constructor_query_single_latest_per_key(RustBuffer opts, RustCallStatus *_Nonnull out_status
 );
 RustBuffer uniffi_iroh_fn_method_query_limit(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
@@ -547,6 +555,12 @@ uint16_t uniffi_iroh_checksum_method_downloadprogress_type(void
 uint16_t uniffi_iroh_checksum_method_entry_author(void
     
 );
+uint16_t uniffi_iroh_checksum_method_entry_content_hash(void
+    
+);
+uint16_t uniffi_iroh_checksum_method_entry_content_len(void
+    
+);
 uint16_t uniffi_iroh_checksum_method_entry_key(void
     
 );
@@ -586,10 +600,10 @@ uint16_t uniffi_iroh_checksum_method_ipv6addr_segments(void
 uint16_t uniffi_iroh_checksum_method_ipv6addr_to_string(void
     
 );
-uint16_t uniffi_iroh_checksum_method_irohnode_author_list(void
+uint16_t uniffi_iroh_checksum_method_irohnode_author_create(void
     
 );
-uint16_t uniffi_iroh_checksum_method_irohnode_author_new(void
+uint16_t uniffi_iroh_checksum_method_irohnode_author_list(void
     
 );
 uint16_t uniffi_iroh_checksum_method_irohnode_blobs_add_bytes(void
@@ -628,13 +642,13 @@ uint16_t uniffi_iroh_checksum_method_irohnode_connection_info(void
 uint16_t uniffi_iroh_checksum_method_irohnode_connections(void
     
 );
+uint16_t uniffi_iroh_checksum_method_irohnode_doc_create(void
+    
+);
 uint16_t uniffi_iroh_checksum_method_irohnode_doc_join(void
     
 );
 uint16_t uniffi_iroh_checksum_method_irohnode_doc_list(void
-    
-);
-uint16_t uniffi_iroh_checksum_method_irohnode_doc_new(void
     
 );
 uint16_t uniffi_iroh_checksum_method_irohnode_node_id(void
@@ -806,6 +820,12 @@ uint16_t uniffi_iroh_checksum_constructor_query_all(void
     
 );
 uint16_t uniffi_iroh_checksum_constructor_query_author(void
+    
+);
+uint16_t uniffi_iroh_checksum_constructor_query_author_key_exact(void
+    
+);
+uint16_t uniffi_iroh_checksum_constructor_query_author_key_prefix(void
     
 );
 uint16_t uniffi_iroh_checksum_constructor_query_key_exact(void

--- a/go/doc_test.go
+++ b/go/doc_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"os"
 	"testing"
 
 	"github.com/n0-computer/iroh-ffi/iroh"
@@ -118,52 +119,88 @@ func TestDocTicket(t *testing.T) {
 /// TestQuery tests all the Query builders
 func TestQuery(t *testing.T) {
 	// all
-	var offset uint64 = 10
-	var limit uint64 = 10
-	all := iroh.QueryAll(iroh.SortByKeyAuthor, iroh.SortDirectionAsc, &offset, &limit)
-	assert.Equal(t, offset, all.Offset())
-	assert.Equal(t, limit, *all.Limit())
+	opts := iroh.QueryOptions{
+		SortBy:    iroh.SortByKeyAuthor,
+		Direction: iroh.SortDirectionAsc,
+		Offset:    10,
+		Limit:     10,
+	}
+	all := iroh.QueryAll(&opts)
+	assert.Equal(t, opts.Offset, all.Offset())
+	assert.Equal(t, opts.Limit, *all.Limit())
 
 	// single_latest_per_key
-	single_latest_per_key := iroh.QuerySingleLatestPerKey(iroh.SortDirectionDesc, nil, nil)
-	offset = 0
-	assert.Equal(t, offset, single_latest_per_key.Offset())
+	opts.Direction = iroh.SortDirectionDesc
+	opts.Offset = 0
+	opts.Limit = 0
+	single_latest_per_key := iroh.QuerySingleLatestPerKey(&opts)
+	assert.Equal(t, opts.Offset, single_latest_per_key.Offset())
 	assert.Nil(t, single_latest_per_key.Limit())
 
 	// author
 	id, err := iroh.AuthorIdFromString("mqtlzayyv4pb4xvnqnw5wxb2meivzq5ze6jihpa7fv5lfwdoya4q")
 	assert.Nil(t, err)
 
-	offset = 100
-	limit = 100
-	author := iroh.QueryAuthor(id, iroh.SortByAuthorKey,
-		iroh.SortDirectionAsc,
-		&offset,
-		nil,
-	)
-	assert.Equal(t, offset, author.Offset())
+	opts.SortBy = iroh.SortByAuthorKey
+	opts.Direction = iroh.SortDirectionAsc
+	opts.Offset = 100
+	opts.Limit = 0
+	author := iroh.QueryAuthor(id, &opts)
+	assert.Equal(t, opts.Offset, author.Offset())
 	assert.Nil(t, author.Limit())
 
 	// key_exact
+	opts.SortBy = iroh.SortByKeyAuthor
+	opts.Direction = iroh.SortDirectionDesc
+	opts.Offset = 0
+	opts.Limit = 10
 	key_exact := iroh.QueryKeyExact(
 		[]byte("key"),
-		iroh.SortByKeyAuthor,
-		iroh.SortDirectionDesc,
-		nil,
-		&limit,
+		&opts,
 	)
-	offset = 0
-	assert.Equal(t, offset, key_exact.Offset())
-	assert.Equal(t, limit, *key_exact.Limit())
+	assert.Equal(t, opts.Offset, key_exact.Offset())
+	assert.Equal(t, opts.Limit, *key_exact.Limit())
 
 	// key_prefix
 	key_prefix := iroh.QueryKeyPrefix(
 		[]byte("prefix"),
-		iroh.SortByKeyAuthor,
-		iroh.SortDirectionDesc,
-		nil,
-		&limit,
+		&opts,
 	)
-	assert.Equal(t, offset, key_prefix.Offset())
-	assert.Equal(t, limit, *key_prefix.Limit())
+	assert.Equal(t, opts.Offset, key_prefix.Offset())
+	assert.Equal(t, opts.Limit, *key_prefix.Limit())
+}
+
+/// TestDocEntryBasics tests the basic flow from doc to entry
+func TestDocEntryBasics(t *testing.T) {
+	// create node
+	dir, err := os.MkdirTemp("", "add_get_bytes")
+	assert.Nil(t, err)
+
+	defer os.RemoveAll(dir)
+
+	node, err := iroh.NewIrohNode(dir)
+	assert.Nil(t, err)
+
+	// create doc and author
+	doc, err := node.DocCreate()
+	assert.Nil(t, err)
+	author, err := node.AuthorCreate()
+	assert.Nil(t, err)
+
+	// create entry
+	val := []byte("hello world!")
+	key := []byte("foo")
+	hash, err := doc.SetBytes(author, key, val)
+	assert.Nil(t, err)
+
+	// get entry
+	query := iroh.QueryAuthorKeyExact(author, key)
+	maybe_entry, err := doc.GetOne(query)
+	assert.NotNil(t, maybe_entry)
+	entry := *maybe_entry
+	assert.Nil(t, err)
+	assert.True(t, hash.Equal(entry.ContentHash()))
+	got_val, err := doc.ReadToBytes(entry)
+	assert.Equal(t, val, got_val)
+	assert.Equal(t, uint64(len(val)), entry.ContentLen())
 }

--- a/go/iroh/iroh.go
+++ b/go/iroh/iroh.go
@@ -675,6 +675,24 @@ func uniffiCheckChecksums() {
 	}
 	{
 		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_iroh_checksum_method_entry_content_hash(uniffiStatus)
+		})
+		if checksum != 39306 {
+			// If this happens try cleaning and rebuilding your project
+			panic("iroh: uniffi_iroh_checksum_method_entry_content_hash: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_iroh_checksum_method_entry_content_len(uniffiStatus)
+		})
+		if checksum != 60107 {
+			// If this happens try cleaning and rebuilding your project
+			panic("iroh: uniffi_iroh_checksum_method_entry_content_len: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_iroh_checksum_method_entry_key(uniffiStatus)
 		})
 		if checksum != 19122 {
@@ -792,20 +810,20 @@ func uniffiCheckChecksums() {
 	}
 	{
 		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_iroh_checksum_method_irohnode_author_create(uniffiStatus)
+		})
+		if checksum != 31148 {
+			// If this happens try cleaning and rebuilding your project
+			panic("iroh: uniffi_iroh_checksum_method_irohnode_author_create: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_iroh_checksum_method_irohnode_author_list(uniffiStatus)
 		})
 		if checksum != 12499 {
 			// If this happens try cleaning and rebuilding your project
 			panic("iroh: uniffi_iroh_checksum_method_irohnode_author_list: UniFFI API checksum mismatch")
-		}
-	}
-	{
-		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
-			return C.uniffi_iroh_checksum_method_irohnode_author_new(uniffiStatus)
-		})
-		if checksum != 61553 {
-			// If this happens try cleaning and rebuilding your project
-			panic("iroh: uniffi_iroh_checksum_method_irohnode_author_new: UniFFI API checksum mismatch")
 		}
 	}
 	{
@@ -918,6 +936,15 @@ func uniffiCheckChecksums() {
 	}
 	{
 		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_iroh_checksum_method_irohnode_doc_create(uniffiStatus)
+		})
+		if checksum != 64213 {
+			// If this happens try cleaning and rebuilding your project
+			panic("iroh: uniffi_iroh_checksum_method_irohnode_doc_create: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_iroh_checksum_method_irohnode_doc_join(uniffiStatus)
 		})
 		if checksum != 30773 {
@@ -932,15 +959,6 @@ func uniffiCheckChecksums() {
 		if checksum != 44252 {
 			// If this happens try cleaning and rebuilding your project
 			panic("iroh: uniffi_iroh_checksum_method_irohnode_doc_list: UniFFI API checksum mismatch")
-		}
-	}
-	{
-		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
-			return C.uniffi_iroh_checksum_method_irohnode_doc_new(uniffiStatus)
-		})
-		if checksum != 34009 {
-			// If this happens try cleaning and rebuilding your project
-			panic("iroh: uniffi_iroh_checksum_method_irohnode_doc_new: UniFFI API checksum mismatch")
 		}
 	}
 	{
@@ -1442,7 +1460,7 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_iroh_checksum_constructor_query_all(uniffiStatus)
 		})
-		if checksum != 7812 {
+		if checksum != 18362 {
 			// If this happens try cleaning and rebuilding your project
 			panic("iroh: uniffi_iroh_checksum_constructor_query_all: UniFFI API checksum mismatch")
 		}
@@ -1451,16 +1469,34 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_iroh_checksum_constructor_query_author(uniffiStatus)
 		})
-		if checksum != 3352 {
+		if checksum != 6757 {
 			// If this happens try cleaning and rebuilding your project
 			panic("iroh: uniffi_iroh_checksum_constructor_query_author: UniFFI API checksum mismatch")
 		}
 	}
 	{
 		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_iroh_checksum_constructor_query_author_key_exact(uniffiStatus)
+		})
+		if checksum != 21618 {
+			// If this happens try cleaning and rebuilding your project
+			panic("iroh: uniffi_iroh_checksum_constructor_query_author_key_exact: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_iroh_checksum_constructor_query_author_key_prefix(uniffiStatus)
+		})
+		if checksum != 63753 {
+			// If this happens try cleaning and rebuilding your project
+			panic("iroh: uniffi_iroh_checksum_constructor_query_author_key_prefix: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_iroh_checksum_constructor_query_key_exact(uniffiStatus)
 		})
-		if checksum != 23311 {
+		if checksum != 32100 {
 			// If this happens try cleaning and rebuilding your project
 			panic("iroh: uniffi_iroh_checksum_constructor_query_key_exact: UniFFI API checksum mismatch")
 		}
@@ -1469,7 +1505,7 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_iroh_checksum_constructor_query_key_prefix(uniffiStatus)
 		})
-		if checksum != 13415 {
+		if checksum != 44412 {
 			// If this happens try cleaning and rebuilding your project
 			panic("iroh: uniffi_iroh_checksum_constructor_query_key_prefix: UniFFI API checksum mismatch")
 		}
@@ -1478,7 +1514,7 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_iroh_checksum_constructor_query_single_latest_per_key(uniffiStatus)
 		})
-		if checksum != 35940 {
+		if checksum != 42778 {
 			// If this happens try cleaning and rebuilding your project
 			panic("iroh: uniffi_iroh_checksum_constructor_query_single_latest_per_key: UniFFI API checksum mismatch")
 		}
@@ -2770,6 +2806,24 @@ func (_self *Entry) Author() *AuthorId {
 	}))
 }
 
+func (_self *Entry) ContentHash() *Hash {
+	_pointer := _self.ffiObject.incrementPointer("*Entry")
+	defer _self.ffiObject.decrementPointer()
+	return FfiConverterHashINSTANCE.Lift(rustCall(func(_uniffiStatus *C.RustCallStatus) unsafe.Pointer {
+		return C.uniffi_iroh_fn_method_entry_content_hash(
+			_pointer, _uniffiStatus)
+	}))
+}
+
+func (_self *Entry) ContentLen() uint64 {
+	_pointer := _self.ffiObject.incrementPointer("*Entry")
+	defer _self.ffiObject.decrementPointer()
+	return FfiConverterUint64INSTANCE.Lift(rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint64_t {
+		return C.uniffi_iroh_fn_method_entry_content_len(
+			_pointer, _uniffiStatus)
+	}))
+}
+
 func (_self *Entry) Key() []byte {
 	_pointer := _self.ffiObject.incrementPointer("*Entry")
 	defer _self.ffiObject.decrementPointer()
@@ -3167,6 +3221,21 @@ func NewIrohNode(path string) (*IrohNode, error) {
 	}
 }
 
+func (_self *IrohNode) AuthorCreate() (*AuthorId, error) {
+	_pointer := _self.ffiObject.incrementPointer("*IrohNode")
+	defer _self.ffiObject.decrementPointer()
+	_uniffiRV, _uniffiErr := rustCallWithError(FfiConverterTypeIrohError{}, func(_uniffiStatus *C.RustCallStatus) unsafe.Pointer {
+		return C.uniffi_iroh_fn_method_irohnode_author_create(
+			_pointer, _uniffiStatus)
+	})
+	if _uniffiErr != nil {
+		var _uniffiDefaultValue *AuthorId
+		return _uniffiDefaultValue, _uniffiErr
+	} else {
+		return FfiConverterAuthorIdINSTANCE.Lift(_uniffiRV), _uniffiErr
+	}
+}
+
 func (_self *IrohNode) AuthorList() ([]*AuthorId, error) {
 	_pointer := _self.ffiObject.incrementPointer("*IrohNode")
 	defer _self.ffiObject.decrementPointer()
@@ -3179,21 +3248,6 @@ func (_self *IrohNode) AuthorList() ([]*AuthorId, error) {
 		return _uniffiDefaultValue, _uniffiErr
 	} else {
 		return FfiConverterSequenceAuthorIdINSTANCE.Lift(_uniffiRV), _uniffiErr
-	}
-}
-
-func (_self *IrohNode) AuthorNew() (*AuthorId, error) {
-	_pointer := _self.ffiObject.incrementPointer("*IrohNode")
-	defer _self.ffiObject.decrementPointer()
-	_uniffiRV, _uniffiErr := rustCallWithError(FfiConverterTypeIrohError{}, func(_uniffiStatus *C.RustCallStatus) unsafe.Pointer {
-		return C.uniffi_iroh_fn_method_irohnode_author_new(
-			_pointer, _uniffiStatus)
-	})
-	if _uniffiErr != nil {
-		var _uniffiDefaultValue *AuthorId
-		return _uniffiDefaultValue, _uniffiErr
-	} else {
-		return FfiConverterAuthorIdINSTANCE.Lift(_uniffiRV), _uniffiErr
 	}
 }
 
@@ -3361,6 +3415,21 @@ func (_self *IrohNode) Connections() ([]ConnectionInfo, error) {
 	}
 }
 
+func (_self *IrohNode) DocCreate() (*Doc, error) {
+	_pointer := _self.ffiObject.incrementPointer("*IrohNode")
+	defer _self.ffiObject.decrementPointer()
+	_uniffiRV, _uniffiErr := rustCallWithError(FfiConverterTypeIrohError{}, func(_uniffiStatus *C.RustCallStatus) unsafe.Pointer {
+		return C.uniffi_iroh_fn_method_irohnode_doc_create(
+			_pointer, _uniffiStatus)
+	})
+	if _uniffiErr != nil {
+		var _uniffiDefaultValue *Doc
+		return _uniffiDefaultValue, _uniffiErr
+	} else {
+		return FfiConverterDocINSTANCE.Lift(_uniffiRV), _uniffiErr
+	}
+}
+
 func (_self *IrohNode) DocJoin(ticket *DocTicket) (*Doc, error) {
 	_pointer := _self.ffiObject.incrementPointer("*IrohNode")
 	defer _self.ffiObject.decrementPointer()
@@ -3388,21 +3457,6 @@ func (_self *IrohNode) DocList() ([]NamespaceAndCapability, error) {
 		return _uniffiDefaultValue, _uniffiErr
 	} else {
 		return FfiConverterSequenceTypeNamespaceAndCapabilityINSTANCE.Lift(_uniffiRV), _uniffiErr
-	}
-}
-
-func (_self *IrohNode) DocNew() (*Doc, error) {
-	_pointer := _self.ffiObject.incrementPointer("*IrohNode")
-	defer _self.ffiObject.decrementPointer()
-	_uniffiRV, _uniffiErr := rustCallWithError(FfiConverterTypeIrohError{}, func(_uniffiStatus *C.RustCallStatus) unsafe.Pointer {
-		return C.uniffi_iroh_fn_method_irohnode_doc_new(
-			_pointer, _uniffiStatus)
-	})
-	if _uniffiErr != nil {
-		var _uniffiDefaultValue *Doc
-		return _uniffiDefaultValue, _uniffiErr
-	} else {
-		return FfiConverterDocINSTANCE.Lift(_uniffiRV), _uniffiErr
 	}
 }
 
@@ -3855,29 +3909,39 @@ type Query struct {
 	ffiObject FfiObject
 }
 
-func QueryAll(sortBy SortBy, direction SortDirection, offset *uint64, limit *uint64) *Query {
+func QueryAll(opts *QueryOptions) *Query {
 	return FfiConverterQueryINSTANCE.Lift(rustCall(func(_uniffiStatus *C.RustCallStatus) unsafe.Pointer {
-		return C.uniffi_iroh_fn_constructor_query_all(FfiConverterTypeSortByINSTANCE.Lower(sortBy), FfiConverterTypeSortDirectionINSTANCE.Lower(direction), FfiConverterOptionalUint64INSTANCE.Lower(offset), FfiConverterOptionalUint64INSTANCE.Lower(limit), _uniffiStatus)
+		return C.uniffi_iroh_fn_constructor_query_all(FfiConverterOptionalTypeQueryOptionsINSTANCE.Lower(opts), _uniffiStatus)
 	}))
 }
-func QueryAuthor(author *AuthorId, sortBy SortBy, direction SortDirection, offset *uint64, limit *uint64) *Query {
+func QueryAuthor(author *AuthorId, opts *QueryOptions) *Query {
 	return FfiConverterQueryINSTANCE.Lift(rustCall(func(_uniffiStatus *C.RustCallStatus) unsafe.Pointer {
-		return C.uniffi_iroh_fn_constructor_query_author(FfiConverterAuthorIdINSTANCE.Lower(author), FfiConverterTypeSortByINSTANCE.Lower(sortBy), FfiConverterTypeSortDirectionINSTANCE.Lower(direction), FfiConverterOptionalUint64INSTANCE.Lower(offset), FfiConverterOptionalUint64INSTANCE.Lower(limit), _uniffiStatus)
+		return C.uniffi_iroh_fn_constructor_query_author(FfiConverterAuthorIdINSTANCE.Lower(author), FfiConverterOptionalTypeQueryOptionsINSTANCE.Lower(opts), _uniffiStatus)
 	}))
 }
-func QueryKeyExact(key []byte, sortBy SortBy, direction SortDirection, offset *uint64, limit *uint64) *Query {
+func QueryAuthorKeyExact(author *AuthorId, key []byte) *Query {
 	return FfiConverterQueryINSTANCE.Lift(rustCall(func(_uniffiStatus *C.RustCallStatus) unsafe.Pointer {
-		return C.uniffi_iroh_fn_constructor_query_key_exact(FfiConverterBytesINSTANCE.Lower(key), FfiConverterTypeSortByINSTANCE.Lower(sortBy), FfiConverterTypeSortDirectionINSTANCE.Lower(direction), FfiConverterOptionalUint64INSTANCE.Lower(offset), FfiConverterOptionalUint64INSTANCE.Lower(limit), _uniffiStatus)
+		return C.uniffi_iroh_fn_constructor_query_author_key_exact(FfiConverterAuthorIdINSTANCE.Lower(author), FfiConverterBytesINSTANCE.Lower(key), _uniffiStatus)
 	}))
 }
-func QueryKeyPrefix(prefix []byte, sortBy SortBy, direction SortDirection, offset *uint64, limit *uint64) *Query {
+func QueryAuthorKeyPrefix(author *AuthorId, prefix []byte, opts *QueryOptions) *Query {
 	return FfiConverterQueryINSTANCE.Lift(rustCall(func(_uniffiStatus *C.RustCallStatus) unsafe.Pointer {
-		return C.uniffi_iroh_fn_constructor_query_key_prefix(FfiConverterBytesINSTANCE.Lower(prefix), FfiConverterTypeSortByINSTANCE.Lower(sortBy), FfiConverterTypeSortDirectionINSTANCE.Lower(direction), FfiConverterOptionalUint64INSTANCE.Lower(offset), FfiConverterOptionalUint64INSTANCE.Lower(limit), _uniffiStatus)
+		return C.uniffi_iroh_fn_constructor_query_author_key_prefix(FfiConverterAuthorIdINSTANCE.Lower(author), FfiConverterBytesINSTANCE.Lower(prefix), FfiConverterOptionalTypeQueryOptionsINSTANCE.Lower(opts), _uniffiStatus)
 	}))
 }
-func QuerySingleLatestPerKey(direction SortDirection, offset *uint64, limit *uint64) *Query {
+func QueryKeyExact(key []byte, opts *QueryOptions) *Query {
 	return FfiConverterQueryINSTANCE.Lift(rustCall(func(_uniffiStatus *C.RustCallStatus) unsafe.Pointer {
-		return C.uniffi_iroh_fn_constructor_query_single_latest_per_key(FfiConverterTypeSortDirectionINSTANCE.Lower(direction), FfiConverterOptionalUint64INSTANCE.Lower(offset), FfiConverterOptionalUint64INSTANCE.Lower(limit), _uniffiStatus)
+		return C.uniffi_iroh_fn_constructor_query_key_exact(FfiConverterBytesINSTANCE.Lower(key), FfiConverterOptionalTypeQueryOptionsINSTANCE.Lower(opts), _uniffiStatus)
+	}))
+}
+func QueryKeyPrefix(prefix []byte, opts *QueryOptions) *Query {
+	return FfiConverterQueryINSTANCE.Lift(rustCall(func(_uniffiStatus *C.RustCallStatus) unsafe.Pointer {
+		return C.uniffi_iroh_fn_constructor_query_key_prefix(FfiConverterBytesINSTANCE.Lower(prefix), FfiConverterOptionalTypeQueryOptionsINSTANCE.Lower(opts), _uniffiStatus)
+	}))
+}
+func QuerySingleLatestPerKey(opts *QueryOptions) *Query {
+	return FfiConverterQueryINSTANCE.Lift(rustCall(func(_uniffiStatus *C.RustCallStatus) unsafe.Pointer {
+		return C.uniffi_iroh_fn_constructor_query_single_latest_per_key(FfiConverterOptionalTypeQueryOptionsINSTANCE.Lower(opts), _uniffiStatus)
 	}))
 }
 
@@ -5485,6 +5549,54 @@ func (_ FfiDestroyerTypeOpenState) Destroy(value OpenState) {
 	value.Destroy()
 }
 
+type QueryOptions struct {
+	SortBy    SortBy
+	Direction SortDirection
+	Offset    uint64
+	Limit     uint64
+}
+
+func (r *QueryOptions) Destroy() {
+	FfiDestroyerTypeSortBy{}.Destroy(r.SortBy)
+	FfiDestroyerTypeSortDirection{}.Destroy(r.Direction)
+	FfiDestroyerUint64{}.Destroy(r.Offset)
+	FfiDestroyerUint64{}.Destroy(r.Limit)
+}
+
+type FfiConverterTypeQueryOptions struct{}
+
+var FfiConverterTypeQueryOptionsINSTANCE = FfiConverterTypeQueryOptions{}
+
+func (c FfiConverterTypeQueryOptions) Lift(rb RustBufferI) QueryOptions {
+	return LiftFromRustBuffer[QueryOptions](c, rb)
+}
+
+func (c FfiConverterTypeQueryOptions) Read(reader io.Reader) QueryOptions {
+	return QueryOptions{
+		FfiConverterTypeSortByINSTANCE.Read(reader),
+		FfiConverterTypeSortDirectionINSTANCE.Read(reader),
+		FfiConverterUint64INSTANCE.Read(reader),
+		FfiConverterUint64INSTANCE.Read(reader),
+	}
+}
+
+func (c FfiConverterTypeQueryOptions) Lower(value QueryOptions) RustBuffer {
+	return LowerIntoRustBuffer[QueryOptions](c, value)
+}
+
+func (c FfiConverterTypeQueryOptions) Write(writer io.Writer, value QueryOptions) {
+	FfiConverterTypeSortByINSTANCE.Write(writer, value.SortBy)
+	FfiConverterTypeSortDirectionINSTANCE.Write(writer, value.Direction)
+	FfiConverterUint64INSTANCE.Write(writer, value.Offset)
+	FfiConverterUint64INSTANCE.Write(writer, value.Limit)
+}
+
+type FfiDestroyerTypeQueryOptions struct{}
+
+func (_ FfiDestroyerTypeQueryOptions) Destroy(value QueryOptions) {
+	value.Destroy()
+}
+
 type SyncEvent struct {
 	Peer     *PublicKey
 	Origin   Origin
@@ -6519,12 +6631,22 @@ type FfiDestroyerTypeLogLevel struct{}
 func (_ FfiDestroyerTypeLogLevel) Destroy(value LogLevel) {
 }
 
-type Origin uint
+type Origin interface {
+	Destroy()
+}
+type OriginConnect struct {
+	Reason SyncReason
+}
 
-const (
-	OriginConnect Origin = 1
-	OriginAccept  Origin = 2
-)
+func (e OriginConnect) Destroy() {
+	FfiDestroyerTypeSyncReason{}.Destroy(e.Reason)
+}
+
+type OriginAccept struct {
+}
+
+func (e OriginAccept) Destroy() {
+}
 
 type FfiConverterTypeOrigin struct{}
 
@@ -6539,16 +6661,35 @@ func (c FfiConverterTypeOrigin) Lower(value Origin) RustBuffer {
 }
 func (FfiConverterTypeOrigin) Read(reader io.Reader) Origin {
 	id := readInt32(reader)
-	return Origin(id)
+	switch id {
+	case 1:
+		return OriginConnect{
+			FfiConverterTypeSyncReasonINSTANCE.Read(reader),
+		}
+	case 2:
+		return OriginAccept{}
+	default:
+		panic(fmt.Sprintf("invalid enum value %v in FfiConverterTypeOrigin.Read()", id))
+	}
 }
 
 func (FfiConverterTypeOrigin) Write(writer io.Writer, value Origin) {
-	writeInt32(writer, int32(value))
+	switch variant_value := value.(type) {
+	case OriginConnect:
+		writeInt32(writer, 1)
+		FfiConverterTypeSyncReasonINSTANCE.Write(writer, variant_value.Reason)
+	case OriginAccept:
+		writeInt32(writer, 2)
+	default:
+		_ = variant_value
+		panic(fmt.Sprintf("invalid enum value `%v` in FfiConverterTypeOrigin.Write", value))
+	}
 }
 
 type FfiDestroyerTypeOrigin struct{}
 
 func (_ FfiDestroyerTypeOrigin) Destroy(value Origin) {
+	value.Destroy()
 }
 
 type ShareMode uint
@@ -6677,6 +6818,40 @@ func (FfiConverterTypeSortDirection) Write(writer io.Writer, value SortDirection
 type FfiDestroyerTypeSortDirection struct{}
 
 func (_ FfiDestroyerTypeSortDirection) Destroy(value SortDirection) {
+}
+
+type SyncReason uint
+
+const (
+	SyncReasonDirectJoin  SyncReason = 1
+	SyncReasonNewNeighbor SyncReason = 2
+	SyncReasonSyncReport  SyncReason = 3
+	SyncReasonResync      SyncReason = 4
+)
+
+type FfiConverterTypeSyncReason struct{}
+
+var FfiConverterTypeSyncReasonINSTANCE = FfiConverterTypeSyncReason{}
+
+func (c FfiConverterTypeSyncReason) Lift(rb RustBufferI) SyncReason {
+	return LiftFromRustBuffer[SyncReason](c, rb)
+}
+
+func (c FfiConverterTypeSyncReason) Lower(value SyncReason) RustBuffer {
+	return LowerIntoRustBuffer[SyncReason](c, value)
+}
+func (FfiConverterTypeSyncReason) Read(reader io.Reader) SyncReason {
+	id := readInt32(reader)
+	return SyncReason(id)
+}
+
+func (FfiConverterTypeSyncReason) Write(writer io.Writer, value SyncReason) {
+	writeInt32(writer, int32(value))
+}
+
+type FfiDestroyerTypeSyncReason struct{}
+
+func (_ FfiDestroyerTypeSyncReason) Destroy(value SyncReason) {
 }
 
 type uniffiCallbackResult C.int32_t
@@ -7230,6 +7405,43 @@ type FfiDestroyerOptionalTypeConnectionInfo struct{}
 func (_ FfiDestroyerOptionalTypeConnectionInfo) Destroy(value *ConnectionInfo) {
 	if value != nil {
 		FfiDestroyerTypeConnectionInfo{}.Destroy(*value)
+	}
+}
+
+type FfiConverterOptionalTypeQueryOptions struct{}
+
+var FfiConverterOptionalTypeQueryOptionsINSTANCE = FfiConverterOptionalTypeQueryOptions{}
+
+func (c FfiConverterOptionalTypeQueryOptions) Lift(rb RustBufferI) *QueryOptions {
+	return LiftFromRustBuffer[*QueryOptions](c, rb)
+}
+
+func (_ FfiConverterOptionalTypeQueryOptions) Read(reader io.Reader) *QueryOptions {
+	if readInt8(reader) == 0 {
+		return nil
+	}
+	temp := FfiConverterTypeQueryOptionsINSTANCE.Read(reader)
+	return &temp
+}
+
+func (c FfiConverterOptionalTypeQueryOptions) Lower(value *QueryOptions) RustBuffer {
+	return LowerIntoRustBuffer[*QueryOptions](c, value)
+}
+
+func (_ FfiConverterOptionalTypeQueryOptions) Write(writer io.Writer, value *QueryOptions) {
+	if value == nil {
+		writeInt8(writer, 0)
+	} else {
+		writeInt8(writer, 1)
+		FfiConverterTypeQueryOptionsINSTANCE.Write(writer, *value)
+	}
+}
+
+type FfiDestroyerOptionalTypeQueryOptions struct{}
+
+func (_ FfiDestroyerOptionalTypeQueryOptions) Destroy(value *QueryOptions) {
+	if value != nil {
+		FfiDestroyerTypeQueryOptions{}.Destroy(*value)
 	}
 }
 

--- a/go/iroh/iroh.h
+++ b/go/iroh/iroh.h
@@ -355,6 +355,16 @@ void* uniffi_iroh_fn_method_entry_author(
 	RustCallStatus* out_status
 );
 
+void* uniffi_iroh_fn_method_entry_content_hash(
+	void* ptr,
+	RustCallStatus* out_status
+);
+
+uint64_t uniffi_iroh_fn_method_entry_content_len(
+	void* ptr,
+	RustCallStatus* out_status
+);
+
 RustBuffer uniffi_iroh_fn_method_entry_key(
 	void* ptr,
 	RustCallStatus* out_status
@@ -498,12 +508,12 @@ void* uniffi_iroh_fn_constructor_irohnode_new(
 	RustCallStatus* out_status
 );
 
-RustBuffer uniffi_iroh_fn_method_irohnode_author_list(
+void* uniffi_iroh_fn_method_irohnode_author_create(
 	void* ptr,
 	RustCallStatus* out_status
 );
 
-void* uniffi_iroh_fn_method_irohnode_author_new(
+RustBuffer uniffi_iroh_fn_method_irohnode_author_list(
 	void* ptr,
 	RustCallStatus* out_status
 );
@@ -583,6 +593,11 @@ RustBuffer uniffi_iroh_fn_method_irohnode_connections(
 	RustCallStatus* out_status
 );
 
+void* uniffi_iroh_fn_method_irohnode_doc_create(
+	void* ptr,
+	RustCallStatus* out_status
+);
+
 void* uniffi_iroh_fn_method_irohnode_doc_join(
 	void* ptr,
 	void* ticket,
@@ -590,11 +605,6 @@ void* uniffi_iroh_fn_method_irohnode_doc_join(
 );
 
 RustBuffer uniffi_iroh_fn_method_irohnode_doc_list(
-	void* ptr,
-	RustCallStatus* out_status
-);
-
-void* uniffi_iroh_fn_method_irohnode_doc_new(
 	void* ptr,
 	RustCallStatus* out_status
 );
@@ -740,44 +750,43 @@ void uniffi_iroh_fn_free_query(
 );
 
 void* uniffi_iroh_fn_constructor_query_all(
-	RustBuffer sort_by,
-	RustBuffer direction,
-	RustBuffer offset,
-	RustBuffer limit,
+	RustBuffer opts,
 	RustCallStatus* out_status
 );
 
 void* uniffi_iroh_fn_constructor_query_author(
 	void* author,
-	RustBuffer sort_by,
-	RustBuffer direction,
-	RustBuffer offset,
-	RustBuffer limit,
+	RustBuffer opts,
+	RustCallStatus* out_status
+);
+
+void* uniffi_iroh_fn_constructor_query_author_key_exact(
+	void* author,
+	RustBuffer key,
+	RustCallStatus* out_status
+);
+
+void* uniffi_iroh_fn_constructor_query_author_key_prefix(
+	void* author,
+	RustBuffer prefix,
+	RustBuffer opts,
 	RustCallStatus* out_status
 );
 
 void* uniffi_iroh_fn_constructor_query_key_exact(
 	RustBuffer key,
-	RustBuffer sort_by,
-	RustBuffer direction,
-	RustBuffer offset,
-	RustBuffer limit,
+	RustBuffer opts,
 	RustCallStatus* out_status
 );
 
 void* uniffi_iroh_fn_constructor_query_key_prefix(
 	RustBuffer prefix,
-	RustBuffer sort_by,
-	RustBuffer direction,
-	RustBuffer offset,
-	RustBuffer limit,
+	RustBuffer opts,
 	RustCallStatus* out_status
 );
 
 void* uniffi_iroh_fn_constructor_query_single_latest_per_key(
-	RustBuffer direction,
-	RustBuffer offset,
-	RustBuffer limit,
+	RustBuffer opts,
 	RustCallStatus* out_status
 );
 
@@ -1181,6 +1190,14 @@ uint16_t uniffi_iroh_checksum_method_entry_author(
 	RustCallStatus* out_status
 );
 
+uint16_t uniffi_iroh_checksum_method_entry_content_hash(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_iroh_checksum_method_entry_content_len(
+	RustCallStatus* out_status
+);
+
 uint16_t uniffi_iroh_checksum_method_entry_key(
 	RustCallStatus* out_status
 );
@@ -1233,11 +1250,11 @@ uint16_t uniffi_iroh_checksum_method_ipv6addr_to_string(
 	RustCallStatus* out_status
 );
 
-uint16_t uniffi_iroh_checksum_method_irohnode_author_list(
+uint16_t uniffi_iroh_checksum_method_irohnode_author_create(
 	RustCallStatus* out_status
 );
 
-uint16_t uniffi_iroh_checksum_method_irohnode_author_new(
+uint16_t uniffi_iroh_checksum_method_irohnode_author_list(
 	RustCallStatus* out_status
 );
 
@@ -1289,15 +1306,15 @@ uint16_t uniffi_iroh_checksum_method_irohnode_connections(
 	RustCallStatus* out_status
 );
 
+uint16_t uniffi_iroh_checksum_method_irohnode_doc_create(
+	RustCallStatus* out_status
+);
+
 uint16_t uniffi_iroh_checksum_method_irohnode_doc_join(
 	RustCallStatus* out_status
 );
 
 uint16_t uniffi_iroh_checksum_method_irohnode_doc_list(
-	RustCallStatus* out_status
-);
-
-uint16_t uniffi_iroh_checksum_method_irohnode_doc_new(
 	RustCallStatus* out_status
 );
 
@@ -1526,6 +1543,14 @@ uint16_t uniffi_iroh_checksum_constructor_query_all(
 );
 
 uint16_t uniffi_iroh_checksum_constructor_query_author(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_iroh_checksum_constructor_query_author_key_exact(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_iroh_checksum_constructor_query_author_key_prefix(
 	RustCallStatus* out_status
 );
 

--- a/go/main.go
+++ b/go/main.go
@@ -31,12 +31,12 @@ func main() {
 		fmt.Printf("conn: %v\n", conn)
 	}
 
-	doc, err := node.DocNew()
+	doc, err := node.DocCreate()
 	if err != nil {
 		panic(err)
 	}
 	fmt.Printf("Created document %s\n", doc.Id().ToString())
-	author, err := node.AuthorNew()
+	author, err := node.AuthorCreate()
 	if err != nil {
 		panic(err)
 	}
@@ -59,7 +59,7 @@ func main() {
 	}
 	fmt.Printf("Inserted %s\n", hash.ToString())
 
-	entries, err := doc.GetMany(iroh.QueryAll(iroh.SortByKeyAuthor, iroh.SortDirectionAsc, nil, nil))
+	entries, err := doc.GetMany(iroh.QueryAll(nil))
 	if err != nil {
 		panic(err)
 	}
@@ -72,7 +72,7 @@ func main() {
 		fmt.Printf("Entry: %s: \"%s\"\n", string(entry.Key()), string(content))
 	}
 
-	doc, err = node.DocNew()
+	doc, err = node.DocCreate()
 	if err != nil {
 		panic(err)
 	}

--- a/src/doc.rs
+++ b/src/doc.rs
@@ -962,21 +962,12 @@ mod tests {
     fn test_doc_entry_basics() {
         let path = tempfile::tempdir().unwrap();
         let node = crate::IrohNode::new(path.path().to_string_lossy().into_owned()).unwrap();
-        let node_id = node.node_id();
-        println!("id: {}", node_id);
+
+        // create doc  and author
         let doc = node.doc_create().unwrap();
-        let doc_id = doc.id();
-        println!("doc_id: {}", doc_id);
-
-        let doc_ticket = doc.share(crate::doc::ShareMode::Write).unwrap();
-        let doc_ticket_string = doc_ticket.to_string();
-        let doc_ticket_back = DocTicket::from_string(doc_ticket_string.clone()).unwrap();
-        assert_eq!(doc_ticket.0.to_string(), doc_ticket_back.0.to_string());
-        println!("doc_ticket: {}", doc_ticket_string);
-        node.doc_join(doc_ticket).unwrap();
-
         let author = node.author_create().unwrap();
 
+        // add entry
         let val = b"hello world!".to_vec();
         let key = b"foo".to_vec();
         let hash = doc

--- a/src/doc.rs
+++ b/src/doc.rs
@@ -332,6 +332,16 @@ impl Entry {
     pub fn namespace(&self) -> Arc<NamespaceId> {
         Arc::new(NamespaceId(self.0.id().namespace()))
     }
+
+    /// Get the content_hash of this entry.
+    pub fn content_hash(&self) -> Arc<Hash> {
+        Arc::new(Hash(self.0.content_hash()))
+    }
+
+    /// Get the content_length of this entry.
+    pub fn content_len(&self) -> u64 {
+        self.0.content_len()
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -390,93 +400,163 @@ pub use iroh::sync::store::SortDirection;
 #[derive(Clone, Debug)]
 pub struct Query(iroh::sync::store::Query);
 
+/// Options for sorting and pagination for using [`Query`]s.
+#[derive(Clone, Debug, Default)]
+pub struct QueryOptions {
+    /// Sort by author or key first.
+    ///
+    /// Default is [`SortBy::AuthorKey`], so sorting first by author and then by key.
+    pub sort_by: SortBy,
+    /// Direction by which to sort the entries
+    ///
+    /// Default is [`SortDirection::Asc`]
+    pub direction: SortDirection,
+    /// Offset
+    pub offset: u64,
+    /// Limit to limit the pagination.
+    ///
+    /// When the limit is 0, the limit does not exist.
+    pub limit: u64,
+}
+
 impl Query {
     /// Query all records.
-    pub fn all(
-        sort_by: SortBy,
-        direction: SortDirection,
-        offset: Option<u64>,
-        limit: Option<u64>,
-    ) -> Self {
-        let mut builder = iroh::sync::store::Query::all().sort_by(sort_by, direction);
-        if let Some(offset) = offset {
-            builder = builder.offset(offset);
-        }
-        if let Some(limit) = limit {
-            builder = builder.limit(limit);
+    ///
+    /// If `opts` is `None`, the default values will be used:
+    ///     sort_by: SortBy::AuthorKey
+    ///     direction: SortDirection::Asc
+    ///     offset: None
+    ///     limit: None
+    pub fn all(opts: Option<QueryOptions>) -> Self {
+        let mut builder = iroh::sync::store::Query::all();
+
+        if let Some(opts) = opts {
+            if opts.offset != 0 {
+                builder = builder.offset(opts.offset);
+            }
+            if opts.limit != 0 {
+                builder = builder.limit(opts.limit);
+            }
+            builder = builder.sort_by(opts.sort_by, opts.direction);
         }
         Query(builder.build())
     }
 
     /// Query only the latest entry for each key, omitting older entries if the entry was written
     /// to by multiple authors.
-    pub fn single_latest_per_key(
-        direction: SortDirection,
-        offset: Option<u64>,
-        limit: Option<u64>,
-    ) -> Self {
-        let mut builder =
-            iroh::sync::store::Query::single_latest_per_key().sort_direction(direction);
-        if let Some(offset) = offset {
-            builder = builder.offset(offset);
-        }
-        if let Some(limit) = limit {
-            builder = builder.limit(limit);
+    ///
+    /// If `opts` is `None`, the default values will be used:
+    ///     direction: SortDirection::Asc
+    ///     offset: None
+    ///     limit: None
+    pub fn single_latest_per_key(opts: Option<QueryOptions>) -> Self {
+        let mut builder = iroh::sync::store::Query::single_latest_per_key();
+
+        if let Some(opts) = opts {
+            if opts.offset != 0 {
+                builder = builder.offset(opts.offset);
+            }
+            if opts.limit != 0 {
+                builder = builder.limit(opts.limit);
+            }
+            builder = builder.sort_direction(opts.direction);
         }
         Query(builder.build())
     }
 
     /// Create a [`Query::all`] query filtered by a single author.
-    pub fn author(
-        author: Arc<AuthorId>,
-        sort_by: SortBy,
-        direction: SortDirection,
-        offset: Option<u64>,
-        limit: Option<u64>,
-    ) -> Self {
-        let mut builder =
-            iroh::sync::store::Query::author((*author).0.clone()).sort_by(sort_by, direction);
-        if let Some(offset) = offset {
-            builder = builder.offset(offset);
-        }
-        if let Some(limit) = limit {
-            builder = builder.limit(limit);
+    ///
+    /// If `opts` is `None`, the default values will be used:
+    ///     sort_by: SortBy::AuthorKey
+    ///     direction: SortDirection::Asc
+    ///     offset: None
+    ///     limit: None
+    pub fn author(author: Arc<AuthorId>, opts: Option<QueryOptions>) -> Self {
+        let mut builder = iroh::sync::store::Query::author((*author).0.clone());
+
+        if let Some(opts) = opts {
+            if opts.offset != 0 {
+                builder = builder.offset(opts.offset);
+            }
+            if opts.limit != 0 {
+                builder = builder.limit(opts.limit);
+            }
+            builder = builder.sort_by(opts.sort_by, opts.direction);
         }
         Query(builder.build())
     }
 
     /// Create a [`Query::all`] query filtered by a single key.
-    pub fn key_exact(
-        key: Vec<u8>,
-        sort_by: SortBy,
-        direction: SortDirection,
-        offset: Option<u64>,
-        limit: Option<u64>,
-    ) -> Self {
-        let mut builder = iroh::sync::store::Query::key_exact(&key).sort_by(sort_by, direction);
-        if let Some(offset) = offset {
-            builder = builder.offset(offset);
+    ///
+    /// If `opts` is `None`, the default values will be used:
+    ///     sort_by: SortBy::AuthorKey
+    ///     direction: SortDirection::Asc
+    ///     offset: None
+    ///     limit: None
+    pub fn key_exact(key: Vec<u8>, opts: Option<QueryOptions>) -> Self {
+        let mut builder = iroh::sync::store::Query::key_exact(&key);
+
+        if let Some(opts) = opts {
+            if opts.offset != 0 {
+                builder = builder.offset(opts.offset);
+            }
+            if opts.limit != 0 {
+                builder = builder.limit(opts.limit);
+            }
+            builder = builder.sort_by(opts.sort_by, opts.direction);
         }
-        if let Some(limit) = limit {
-            builder = builder.limit(limit);
+        Query(builder.build())
+    }
+
+    /// Create a [`Query::all`] query filtered by a single key and author.
+    pub fn author_key_exact(author: Arc<AuthorId>, key: Vec<u8>) -> Self {
+        let builder = iroh::sync::store::Query::author((*author).0.clone()).key_exact(&key);
+        Query(builder.build())
+    }
+
+    /// Create a [`Query::all`] query filtered by a key prefix.
+    ///  
+    /// If `opts` is `None`, the default values will be used:
+    ///     sort_by: SortBy::AuthorKey
+    ///     direction: SortDirection::Asc
+    ///     offset: None
+    ///     limit: None
+    pub fn key_prefix(prefix: Vec<u8>, opts: Option<QueryOptions>) -> Self {
+        let mut builder = iroh::sync::store::Query::key_prefix(&prefix);
+
+        if let Some(opts) = opts {
+            if opts.offset != 0 {
+                builder = builder.offset(opts.offset);
+            }
+            if opts.limit != 0 {
+                builder = builder.limit(opts.limit);
+            }
+            builder = builder.sort_by(opts.sort_by, opts.direction);
         }
         Query(builder.build())
     }
 
     /// Create a [`Query::all`] query filtered by a key prefix.
-    pub fn key_prefix(
+    ///  
+    /// If `opts` is `None`, the default values will be used:
+    ///     direction: SortDirection::Asc
+    ///     offset: None
+    ///     limit: None
+    pub fn author_key_prefix(
+        author: Arc<AuthorId>,
         prefix: Vec<u8>,
-        sort_by: SortBy,
-        direction: SortDirection,
-        offset: Option<u64>,
-        limit: Option<u64>,
+        opts: Option<QueryOptions>,
     ) -> Self {
-        let mut builder = iroh::sync::store::Query::key_prefix(&prefix).sort_by(sort_by, direction);
-        if let Some(offset) = offset {
-            builder = builder.offset(offset);
-        }
-        if let Some(limit) = limit {
-            builder = builder.limit(limit);
+        let mut builder = iroh::sync::store::Query::author((*author).0.clone()).key_prefix(&prefix);
+
+        if let Some(opts) = opts {
+            if opts.offset != 0 {
+                builder = builder.offset(opts.offset);
+            }
+            if opts.limit != 0 {
+                builder = builder.limit(opts.limit);
+            }
+            builder = builder.sort_by(opts.sort_by, opts.direction);
         }
         Query(builder.build())
     }
@@ -686,34 +766,13 @@ impl From<iroh::sync_engine::SyncEvent> for SyncEvent {
     }
 }
 
-// TODO: iroh 0.8.0 release made this struct private. Re-implement when it's made public again
-/// Why we started a sync request
-// #[derive(Debug, Clone, Copy)]
-// pub enum SyncReason {
-//     /// Direct join request via API
-//     DirectJoin,
-//     /// Peer showed up as new neighbor in the gossip swarm
-//     NewNeighbor,
-// }
-
-// impl From<iroh::sync_engine::SyncReason> for SyncReason {
-//     fn from(value: iroh::sync_engine::SyncReason) -> Self {
-//         match value {
-//             iroh::sync_engine::SyncReason::DirectJoin => Self::DirectJoin,
-//             iroh::sync_engine::SyncReason::NewNeighbor => Self::NewNeighbor,
-//         }
-//     }
-// }
+pub use iroh::sync_engine::SyncReason;
 
 /// Why we performed a sync exchange
 #[derive(Debug, Clone)]
 pub enum Origin {
-    /// TODO: in iroh 0.8.0 `SyncReason` is private, until the next release when it can be made
     /// public, use a unit variant
-    // Connect {
-    //     reason: SyncReason,
-    // },
-    Connect,
+    Connect { reason: SyncReason },
     /// A peer connected to us and we accepted the exchange
     Accept,
 }
@@ -721,7 +780,9 @@ pub enum Origin {
 impl From<iroh::sync_engine::Origin> for Origin {
     fn from(value: iroh::sync_engine::Origin) -> Self {
         match value {
-            iroh::sync_engine::Origin::Connect(_) => Self::Connect,
+            iroh::sync_engine::Origin::Connect(reason) => Self::Connect {
+                reason: reason.into(),
+            },
             iroh::sync_engine::Origin::Accept => Self::Accept,
         }
     }
@@ -851,18 +912,24 @@ mod tests {
         assert!(doc_ticket.equal(doc_ticket_0.clone()));
         assert!(doc_ticket_0.equal(doc_ticket.into()));
     }
-
     #[test]
     fn test_query() {
+        let mut opts = QueryOptions::default();
+        opts.offset = 10;
+        opts.limit = 10;
         // all
-        let all = Query::all(SortBy::KeyAuthor, SortDirection::Asc, Some(10), Some(10));
+        let all = Query::all(Some(opts));
         assert_eq!(10, all.offset());
         assert_eq!(Some(10), all.limit());
 
-        let single_latest_per_key = Query::single_latest_per_key(SortDirection::Desc, None, None);
+        let mut opts = QueryOptions::default();
+        opts.direction = SortDirection::Desc;
+        let single_latest_per_key = Query::single_latest_per_key(Some(opts));
         assert_eq!(0, single_latest_per_key.offset());
         assert_eq!(None, single_latest_per_key.limit());
 
+        let mut opts = QueryOptions::default();
+        opts.offset = 100;
         let author = Query::author(
             Arc::new(
                 AuthorId::from_string(
@@ -870,32 +937,60 @@ mod tests {
                 )
                 .unwrap(),
             ),
-            SortBy::AuthorKey,
-            SortDirection::Asc,
-            Some(100),
-            None,
+            Some(opts),
         );
         assert_eq!(100, author.offset());
         assert_eq!(None, author.limit());
 
-        let key_exact = Query::key_exact(
-            b"key".to_vec(),
-            SortBy::KeyAuthor,
-            SortDirection::Desc,
-            None,
-            Some(100),
-        );
+        let mut opts = QueryOptions::default();
+        opts.limit = 100;
+        let key_exact = Query::key_exact(b"key".to_vec(), Some(opts));
         assert_eq!(0, key_exact.offset());
         assert_eq!(Some(100), key_exact.limit());
 
-        let key_prefix = Query::key_prefix(
-            b"prefix".to_vec(),
-            SortBy::KeyAuthor,
-            SortDirection::Desc,
-            None,
-            Some(100),
-        );
+        let opts = QueryOptions {
+            sort_by: SortBy::KeyAuthor,
+            direction: SortDirection::Desc,
+            offset: 0,
+            limit: 100,
+        };
+        let key_prefix = Query::key_prefix(b"prefix".to_vec(), Some(opts));
         assert_eq!(0, key_prefix.offset());
         assert_eq!(Some(100), key_prefix.limit());
+    }
+    #[test]
+    fn test_doc_entry_basics() {
+        let path = tempfile::tempdir().unwrap();
+        let node = crate::IrohNode::new(path.path().to_string_lossy().into_owned()).unwrap();
+        let node_id = node.node_id();
+        println!("id: {}", node_id);
+        let doc = node.doc_create().unwrap();
+        let doc_id = doc.id();
+        println!("doc_id: {}", doc_id);
+
+        let doc_ticket = doc.share(crate::doc::ShareMode::Write).unwrap();
+        let doc_ticket_string = doc_ticket.to_string();
+        let doc_ticket_back = DocTicket::from_string(doc_ticket_string.clone()).unwrap();
+        assert_eq!(doc_ticket.0.to_string(), doc_ticket_back.0.to_string());
+        println!("doc_ticket: {}", doc_ticket_string);
+        node.doc_join(doc_ticket).unwrap();
+
+        let author = node.author_create().unwrap();
+
+        let val = b"hello world!".to_vec();
+        let key = b"foo".to_vec();
+        let hash = doc
+            .set_bytes(author.clone(), key.clone(), val.clone())
+            .unwrap();
+
+        // get entry
+        let query = Query::author_key_exact(author, key.clone());
+        let entry = doc.get_one(query.into()).unwrap().unwrap();
+
+        assert!(hash.equal(entry.content_hash()));
+
+        let got_val = doc.read_to_bytes(entry.clone()).unwrap();
+        assert_eq!(val, got_val);
+        assert_eq!(val.len() as u64, entry.content_len());
     }
 }

--- a/src/iroh.udl
+++ b/src/iroh.udl
@@ -18,13 +18,13 @@ interface IrohNode {
   constructor(string path);
   string node_id();
   [Throws=IrohError]
-  Doc doc_new();
+  Doc doc_create();
   [Throws=IrohError]
   Doc doc_join(DocTicket ticket);
   [Throws=IrohError]
   sequence<NamespaceAndCapability> doc_list();
   [Throws=IrohError]
-  AuthorId author_new();
+  AuthorId author_create();
   [Throws=IrohError]
   sequence<AuthorId> author_list();
   [Throws=IrohError]
@@ -93,15 +93,19 @@ dictionary NamespaceAndCapability {
 
 interface Query {
   [Name=all]
-  constructor(SortBy sort_by, SortDirection direction, u64? offset, u64? limit);
+  constructor(QueryOptions? opts);
   [Name=single_latest_per_key]
-  constructor(SortDirection direction, u64? offset, u64? limit);
+  constructor(QueryOptions? opts);
   [Name=author]
-  constructor(AuthorId author, SortBy sort_by, SortDirection direction, u64? offset, u64? limit);
+  constructor(AuthorId author, QueryOptions? opts);
   [Name=key_exact]
-  constructor(bytes key, SortBy sort_by, SortDirection direction, u64? offset, u64? limit);
- [Name=key_prefix]
-  constructor(bytes prefix, SortBy sort_by, SortDirection direction, u64? offset, u64? limit);
+  constructor(bytes key, QueryOptions? opts);
+  [Name=author_key_exact]
+  constructor(AuthorId author, bytes key);
+  [Name=key_prefix]
+  constructor(bytes prefix, QueryOptions? opts);
+  [Name=author_key_prefix]
+  constructor(AuthorId author, bytes prefix, QueryOptions? opts);
   u64 offset();
   u64? limit();
 };
@@ -149,6 +153,8 @@ interface Entry {
   AuthorId author();
   bytes key();
   NamespaceId namespace();
+  Hash content_hash();
+  u64 content_len();
 };
 
 interface Hash {
@@ -234,8 +240,22 @@ dictionary SyncEvent {
 
 [Enum]
 interface Origin {
-  Connect();
+  Connect(SyncReason reason);
   Accept();
+};
+
+enum SyncReason {
+  "DirectJoin",
+  "NewNeighbor",
+  "SyncReport",
+  "Resync",
+};
+
+dictionary QueryOptions {
+  SortBy sort_by;
+  SortDirection direction;
+  u64 offset;
+  u64 limit;
 };
 
 dictionary ConnectionInfo {

--- a/src/node.rs
+++ b/src/node.rs
@@ -140,7 +140,7 @@ impl IrohNode {
         self.node.peer_id().to_string()
     }
 
-    pub fn doc_new(&self) -> Result<Arc<Doc>, Error> {
+    pub fn doc_create(&self) -> Result<Arc<Doc>, Error> {
         block_on(&self.async_runtime, async {
             let doc = self.sync_client.docs.create().await.map_err(Error::doc)?;
 
@@ -151,7 +151,7 @@ impl IrohNode {
         })
     }
 
-    pub fn author_new(&self) -> Result<Arc<AuthorId>, Error> {
+    pub fn author_create(&self) -> Result<Arc<AuthorId>, Error> {
         block_on(&self.async_runtime, async {
             let author = self
                 .sync_client
@@ -266,12 +266,12 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_doc_new() {
+    fn test_doc_create() {
         let path = tempfile::tempdir().unwrap();
         let node = IrohNode::new(path.path().to_string_lossy().into_owned()).unwrap();
         let node_id = node.node_id();
         println!("id: {}", node_id);
-        let doc = node.doc_new().unwrap();
+        let doc = node.doc_create().unwrap();
         let doc_id = doc.id();
         println!("doc_id: {}", doc_id);
 


### PR DESCRIPTION
I erroneously took out the way to get the `hash` from the entry, and this PR puts it back in!

This adds a breaking change that converts `IrohNode::doc_new` and `IrohNode::author_new` to `Iroh::doc_create` and `Iroh::author_create`, to reflect the iroh core API.