### PR TITLE
Adjust API to match `iroh` main, in prep for `0.13.0` release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -540,6 +540,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "concurrent-queue"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d16048cd947b08fa32c24458a22f5dc5e835264f689f4f5653210c69fd107363"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1028,9 +1037,14 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "2.5.3"
+version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+checksum = "67b215c49b2b248c855fb73579eb1f4f26c38ffdc12973e20e07b91d78d5646e"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "fallible-iterator"
@@ -1683,8 +1697,7 @@ checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 [[package]]
 name = "iroh"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3aea70a8acc645bc78c388f9412b4ae5f94ddeeea13c946b29af4c2db097c23"
+source = "git+https://github.com/n0-computer/iroh.git#aeee7186894ee6249aa58eac7001d87cb9edf4d7"
 dependencies = [
  "anyhow",
  "bao-tree",
@@ -1727,8 +1740,7 @@ dependencies = [
 [[package]]
 name = "iroh-base"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1b42ef43639a86a49132998f066810b702798818993e34565dd4eea835f626e"
+source = "git+https://github.com/n0-computer/iroh.git#aeee7186894ee6249aa58eac7001d87cb9edf4d7"
 dependencies = [
  "anyhow",
  "bao-tree",
@@ -1757,8 +1769,7 @@ dependencies = [
 [[package]]
 name = "iroh-bytes"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38213865ec542f82fc4d8a9748b5cdae92da1707c134428e9f60b1cd46ccbe39"
+source = "git+https://github.com/n0-computer/iroh.git#aeee7186894ee6249aa58eac7001d87cb9edf4d7"
 dependencies = [
  "anyhow",
  "bao-tree",
@@ -1772,8 +1783,11 @@ dependencies = [
  "hex",
  "iroh-base",
  "iroh-io",
+ "iroh-metrics",
+ "iroh-net",
  "num_cpus",
  "once_cell",
+ "parking_lot",
  "postcard",
  "quinn",
  "rand",
@@ -1820,8 +1834,7 @@ dependencies = [
 [[package]]
 name = "iroh-gossip"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74fcad132a6ff61ad83fc63203948919d2d77d58deac806bd08580f11e968a24"
+source = "git+https://github.com/n0-computer/iroh.git#aeee7186894ee6249aa58eac7001d87cb9edf4d7"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1862,8 +1875,7 @@ dependencies = [
 [[package]]
 name = "iroh-metrics"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92a3271df85ec2a18a358d36723039eeacb464d8764531c8fd9f822dac39410d"
+source = "git+https://github.com/n0-computer/iroh.git#aeee7186894ee6249aa58eac7001d87cb9edf4d7"
 dependencies = [
  "anyhow",
  "erased_set",
@@ -1883,8 +1895,7 @@ dependencies = [
 [[package]]
 name = "iroh-net"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0477847a7fe225f71fbdff7b0baccea8fc9c9b33e7755f4b28e19f075bd64499"
+source = "git+https://github.com/n0-computer/iroh.git#aeee7186894ee6249aa58eac7001d87cb9edf4d7"
 dependencies = [
  "aead",
  "anyhow",
@@ -1959,8 +1970,7 @@ dependencies = [
 [[package]]
 name = "iroh-sync"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e27f9c5bf0576ad2786c1e32ee046518144b8f221eef6578c882633b6e27985"
+source = "git+https://github.com/n0-computer/iroh.git#aeee7186894ee6249aa58eac7001d87cb9edf4d7"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2530,6 +2540,12 @@ dependencies = [
  "rand_core",
  "sha2",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
 
 [[package]]
 name = "parking_lot"
@@ -4663,9 +4679,9 @@ checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
 
 [[package]]
 name = "watchable"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff90d0baafb3c0abbeebec1a8a305b4211c356de1d953a0dd77aab006baa8a62"
+checksum = "45b42a2f611916b5965120a9cde2b60f2db4454826dd9ad5e6f47c24a5b3b259"
 dependencies = [
  "event-listener",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ anyhow = "1.0.69"
 blake3 = "1.3.3"
 bytes = "1"
 data-encoding = { version = "2.3.3" }
-iroh = { version = "0.12.0", default-features = false, features = [ "flat-db", "metrics" ] }
+iroh = { git="https://github.com/n0-computer/iroh.git", default-features = false, features = [ "flat-db", "metrics" ] }
 iroh-io = { version = "0.3.0" }
 libc = "0.2.141"
 multibase = { version = "0.9.1" }

--- a/Iroh.xcframework/ios-arm64/Iroh.framework/Headers/irohFFI.h
+++ b/Iroh.xcframework/ios-arm64/Iroh.framework/Headers/irohFFI.h
@@ -89,6 +89,12 @@ void uniffi_iroh_fn_free_blobdownloadrequest(void*_Nonnull ptr, RustCallStatus *
 );
 void*_Nonnull uniffi_iroh_fn_constructor_blobdownloadrequest_new(void*_Nonnull hash, RustBuffer format, void*_Nonnull node, void*_Nonnull tag, void*_Nonnull out, RustCallStatus *_Nonnull out_status
 );
+void uniffi_iroh_fn_free_collection(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+uint64_t uniffi_iroh_fn_method_collection_len(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+RustBuffer uniffi_iroh_fn_method_collection_links(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
 void uniffi_iroh_fn_free_connectiontype(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
 RustBuffer uniffi_iroh_fn_method_connectiontype_as_direct(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
@@ -267,6 +273,8 @@ RustBuffer uniffi_iroh_fn_method_irohnode_blobs_list(void*_Nonnull ptr, RustCall
 RustBuffer uniffi_iroh_fn_method_irohnode_blobs_list_collections(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
 RustBuffer uniffi_iroh_fn_method_irohnode_blobs_list_incomplete(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+RustBuffer uniffi_iroh_fn_method_irohnode_blobs_read_at_to_bytes(void*_Nonnull ptr, void*_Nonnull hash, uint64_t offset, RustBuffer len, RustCallStatus *_Nonnull out_status
 );
 RustBuffer uniffi_iroh_fn_method_irohnode_blobs_read_to_bytes(void*_Nonnull ptr, void*_Nonnull hash, RustCallStatus *_Nonnull out_status
 );
@@ -555,6 +563,12 @@ uint16_t uniffi_iroh_checksum_method_authorid_equal(void
 uint16_t uniffi_iroh_checksum_method_authorid_to_string(void
     
 );
+uint16_t uniffi_iroh_checksum_method_collection_len(void
+    
+);
+uint16_t uniffi_iroh_checksum_method_collection_links(void
+    
+);
 uint16_t uniffi_iroh_checksum_method_connectiontype_as_direct(void
     
 );
@@ -745,6 +759,9 @@ uint16_t uniffi_iroh_checksum_method_irohnode_blobs_list_collections(void
     
 );
 uint16_t uniffi_iroh_checksum_method_irohnode_blobs_list_incomplete(void
+    
+);
+uint16_t uniffi_iroh_checksum_method_irohnode_blobs_read_at_to_bytes(void
     
 );
 uint16_t uniffi_iroh_checksum_method_irohnode_blobs_read_to_bytes(void

--- a/Iroh.xcframework/ios-arm64_x86_64-simulator/Iroh.framework/Headers/irohFFI.h
+++ b/Iroh.xcframework/ios-arm64_x86_64-simulator/Iroh.framework/Headers/irohFFI.h
@@ -89,6 +89,12 @@ void uniffi_iroh_fn_free_blobdownloadrequest(void*_Nonnull ptr, RustCallStatus *
 );
 void*_Nonnull uniffi_iroh_fn_constructor_blobdownloadrequest_new(void*_Nonnull hash, RustBuffer format, void*_Nonnull node, void*_Nonnull tag, void*_Nonnull out, RustCallStatus *_Nonnull out_status
 );
+void uniffi_iroh_fn_free_collection(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+uint64_t uniffi_iroh_fn_method_collection_len(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+RustBuffer uniffi_iroh_fn_method_collection_links(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
 void uniffi_iroh_fn_free_connectiontype(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
 RustBuffer uniffi_iroh_fn_method_connectiontype_as_direct(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
@@ -267,6 +273,8 @@ RustBuffer uniffi_iroh_fn_method_irohnode_blobs_list(void*_Nonnull ptr, RustCall
 RustBuffer uniffi_iroh_fn_method_irohnode_blobs_list_collections(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
 RustBuffer uniffi_iroh_fn_method_irohnode_blobs_list_incomplete(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+RustBuffer uniffi_iroh_fn_method_irohnode_blobs_read_at_to_bytes(void*_Nonnull ptr, void*_Nonnull hash, uint64_t offset, RustBuffer len, RustCallStatus *_Nonnull out_status
 );
 RustBuffer uniffi_iroh_fn_method_irohnode_blobs_read_to_bytes(void*_Nonnull ptr, void*_Nonnull hash, RustCallStatus *_Nonnull out_status
 );
@@ -555,6 +563,12 @@ uint16_t uniffi_iroh_checksum_method_authorid_equal(void
 uint16_t uniffi_iroh_checksum_method_authorid_to_string(void
     
 );
+uint16_t uniffi_iroh_checksum_method_collection_len(void
+    
+);
+uint16_t uniffi_iroh_checksum_method_collection_links(void
+    
+);
 uint16_t uniffi_iroh_checksum_method_connectiontype_as_direct(void
     
 );
@@ -745,6 +759,9 @@ uint16_t uniffi_iroh_checksum_method_irohnode_blobs_list_collections(void
     
 );
 uint16_t uniffi_iroh_checksum_method_irohnode_blobs_list_incomplete(void
+    
+);
+uint16_t uniffi_iroh_checksum_method_irohnode_blobs_read_at_to_bytes(void
     
 );
 uint16_t uniffi_iroh_checksum_method_irohnode_blobs_read_to_bytes(void

--- a/iroh-go/iroh/iroh.h
+++ b/iroh-go/iroh/iroh.h
@@ -138,6 +138,21 @@ void* uniffi_iroh_fn_constructor_blobdownloadrequest_new(
 	RustCallStatus* out_status
 );
 
+void uniffi_iroh_fn_free_collection(
+	void* ptr,
+	RustCallStatus* out_status
+);
+
+uint64_t uniffi_iroh_fn_method_collection_len(
+	void* ptr,
+	RustCallStatus* out_status
+);
+
+RustBuffer uniffi_iroh_fn_method_collection_links(
+	void* ptr,
+	RustCallStatus* out_status
+);
+
 void uniffi_iroh_fn_free_connectiontype(
 	void* ptr,
 	RustCallStatus* out_status
@@ -612,6 +627,14 @@ RustBuffer uniffi_iroh_fn_method_irohnode_blobs_list_collections(
 
 RustBuffer uniffi_iroh_fn_method_irohnode_blobs_list_incomplete(
 	void* ptr,
+	RustCallStatus* out_status
+);
+
+RustBuffer uniffi_iroh_fn_method_irohnode_blobs_read_at_to_bytes(
+	void* ptr,
+	void* hash,
+	uint64_t offset,
+	RustBuffer len,
 	RustCallStatus* out_status
 );
 
@@ -1317,6 +1340,14 @@ uint16_t uniffi_iroh_checksum_method_authorid_to_string(
 	RustCallStatus* out_status
 );
 
+uint16_t uniffi_iroh_checksum_method_collection_len(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_iroh_checksum_method_collection_links(
+	RustCallStatus* out_status
+);
+
 uint16_t uniffi_iroh_checksum_method_connectiontype_as_direct(
 	RustCallStatus* out_status
 );
@@ -1570,6 +1601,10 @@ uint16_t uniffi_iroh_checksum_method_irohnode_blobs_list_collections(
 );
 
 uint16_t uniffi_iroh_checksum_method_irohnode_blobs_list_incomplete(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_iroh_checksum_method_irohnode_blobs_read_at_to_bytes(
 	RustCallStatus* out_status
 );
 

--- a/src/doc.rs
+++ b/src/doc.rs
@@ -538,7 +538,7 @@ impl TryFrom<NodeAddr> for iroh::net::magic_endpoint::NodeAddr {
         if let Some(derp_url) = value.derp_url() {
             let url = url::Url::parse(&derp_url).map_err(IrohError::url)?;
 
-            node_addr = node_addr.with_derp_url(url);
+            node_addr = node_addr.with_derp_url(url.into());
         }
         node_addr = node_addr.with_direct_addresses(addresses);
         Ok(node_addr)

--- a/src/iroh.udl
+++ b/src/iroh.udl
@@ -97,6 +97,13 @@ interface IrohNode {
   /// before calling [`Self::blobs_read_to_bytes`].
   [Throws=IrohError]
   bytes blobs_read_to_bytes(Hash hash);
+  /// Read all bytes of single blob at `offset` for length `len`.
+  ///
+  /// This allocates a buffer for the full length `len`. Use only if you know that the blob you're
+  /// reading is small. If not sure, use [`Self::blobs_size`] and check the size with
+  /// before calling [`Self::blobs_read_at_to_bytes`].
+  [Throws=IrohError]
+  bytes blobs_read_at_to_bytes(Hash hash, u64 offset, u64? len);
   /// Import a blob from a filesystem path.
   ///
   /// `path` should be an absolute path valid for the file system on which
@@ -140,6 +147,24 @@ interface IrohNode {
   /// Delete a tag.
   [Throws=IrohError]
   void tags_delete(bytes name);
+};
+
+/// A `Link` includes a name and a hash for a blob in a collection
+dictionary Link {
+    /// The name associated with this [`Hash`]
+    string name;
+    /// The [`Hash`] of the blob
+    Hash hash;
+};
+
+/// A collection of blobs
+///
+/// Note that the format is subject to change.
+interface Collection {
+  /// Returns a [`Link`] (the name and the hash), for each blob in the collection.
+  sequence<Link> links();
+  /// Returns the number of blobs in this collection
+  u64 len();
 };
 
 /// A response to a list collections request


### PR DESCRIPTION
- adds `Collection`
- adds `IrohNodeNode::blobs_read_at_to_bytes`
- adds `IrohNode::blobs_get_collection`

closes #93 