### PR TITLE
docs: add instructions on how to release iroh python

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -40,6 +40,7 @@ jobs:
           source $HOME/.cargo/env
           PATH=/opt/python/cp311-cp311/bin:$PATH
           export PATH
+          maturin --version
           maturin build --release --manylinux 2014
       - name: Upload wheel
         uses: actions/upload-artifact@v3
@@ -73,9 +74,10 @@ jobs:
           python-version: ${{ matrix.python }}
       - name: Install maturin & uniffi-bindgen
         run: |
-          pip install maturin uniffi-bindgen
+          pip install -U maturin uniffi-bindgen
       - name: Build wheel
         run: |
+          maturin --version
           maturin build --release
       - name: Upload wheel
         uses: actions/upload-artifact@v3
@@ -93,9 +95,10 @@ jobs:
           python-version: '3.11'
       - name: Install maturin & uniffi-bindgen
         run: |
-          pip install maturin uniffi-bindgen
+          pip install -U maturin uniffi-bindgen
       - name: Build wheel
         run: |
+          maturin --version
           maturin build --release
       - name: Upload wheel
         uses: actions/upload-artifact@v3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1735,7 +1735,7 @@ checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
 name = "iroh"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -1743,7 +1743,7 @@ dependencies = [
  "data-encoding",
  "flume",
  "futures",
- "iroh 0.13.0",
+ "iroh 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "iroh-io 0.3.0",
  "libc",
  "multibase",

--- a/README.python.md
+++ b/README.python.md
@@ -12,8 +12,8 @@ We currently ship binary wheels on pypi for:
 - amd64 win
 - x86_64 manylinux2014
 - aarch64 manylinux2014
-- arm64 maxosx
-- x86_64 maxosx
+- arm64 macosx
+- x86_64 macosx
 
 If you need another platform you will have to build from source using the repository at https://github.com/n0-computer/iroh-ffi/
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -45,3 +45,36 @@ let package = Package(
 ```
 
 6. Commit the result & push
+
+## Python
+
+The first time:
+
+1) Create an account on [pypi](https://pypi.org/) & [testpipy](https://test.pypi.org/project/iroh/)
+2) Get invited to the `iroh` project
+3) Install `twine`
+4) Upgrade `pkginfo` to at least `1.10`. For more information check out [this issue on twine](https://github.com/pypa/twine/issues/1070)
+5) Create an API token on pipy and test pipy
+6) Put those tokens into ~/.pypirc:
+```
+# ~/.pypirc
+[pypi]
+username = __token__
+password = pypi-TOKEN
+
+[testpypi]
+username = __token__
+password = pypi-TOKEN
+```
+
+To release iroh python:
+
+1) Download the artifacts from the [wheels ci workflow](https://github.com/n0-computer/iroh-ffi/actions/workflows/wheels.yml), picking the workflow that was run on the latest `main` branch
+2) Extract the artifacts
+3) Upload each to testpypi: `twine upload --repository testpypi iroh-$VERSION-*.whl`
+4) Dogfood by downloading the lastest iroh version from testpipy and using it. The simplest test may be to run the python code in the `iroh-ffi/python` directory.
+    - create & activate a new virtual env
+    - install iroh from testpypi `pip install -i https://test.pypi.org/simple/ iroh`
+    - run `python main.py`
+    - ensure it works (and remove the test env)
+5) Upload each to pypi: `twine upload iroh-$VERSION-*.whl`

--- a/python/main.py
+++ b/python/main.py
@@ -30,17 +30,17 @@ if __name__ == "__main__":
         print("Started Iroh node: {}".format(node.node_id()))
 
        # create doc
-        doc = node.doc_new();
+        doc = node.doc_create();
         print("Created doc: {}".format(doc.id()))
         
-        doc = node.doc_new();
+        doc = node.doc_create();
         print("Created doc: {}".format(doc.id()))
         
         # list docs
         docs = node.doc_list();
         print("List all {} docs:".format(len(docs)))
         for doc in docs:
-            print("\t{}".format(doc.to_string()))
+            print("\t{}".format(doc))
 
         exit()
 


### PR DESCRIPTION
Also fixes some typos and upgrades the `iroh-ffi/python/main.py` file to use the upgraded API

closes #72 