### PR TITLE
fix(ci): ensure mac uses correct image to build wheels

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -59,7 +59,7 @@ jobs:
             os: macOS-latest
             release-os: darwin
             release-arch: x86_64
-            runner: [macOS-latest]
+            runner: [macOS-13]
           - name: macOS-arm-latest
             python: 3.11
             os: macOS-latest


### PR DESCRIPTION
Github Actions bumped runner images to default `macOS-latest` to macOS 14 and running on arm based (m1) macs. This ensures the `x86_64` builds remain on `macOS-13`