### PR TITLE
GitHub Actions: build_and_test_python on Python 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,9 +84,9 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - uses: dtolnay/rust-toolchain@stable
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
-          python-version: 3.11
+          python-version: 3.12
     - name: Install Deps
       run: pip install virtualenv
     - name: Python tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
         source venv/bin/activate && \
         pip install setuptools pytest pytest-asyncio "maturin[patchelf]" uniffi-bindgen
         maturin develop && \
-        python -m pytest
+        python -m pytest -vvv
 
   build_and_test_kotlin:
     runs-on: ${{ matrix.runner }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
       run: |
         virtualenv venv && \
         source venv/bin/activate && \
-        pip install setuptools pytest pytest-asyncio maturin uniffi-bindgen
+        pip install setuptools pytest pytest-asyncio "maturin[patchelf]" uniffi-bindgen
         maturin develop && \
         python -m pytest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
       run: |
         virtualenv venv && \
         source venv/bin/activate && \
-        pip install pytest pytest-asyncio maturin uniffi-bindgen
+        pip install setuptools pytest pytest-asyncio maturin uniffi-bindgen
         maturin develop && \
         python -m pytest
 


### PR DESCRIPTION
https://github.com/actions/setup-python/releases

https://github.com/n0-computer/iroh-ffi/actions

The GitHub Actions run kicks out this warning...
> ⚠️ Warning: Failed to set rpath for /root/actions-runner/_work/iroh-ffi/iroh-ffi/target/debug/libiroh_ffi.so: Failed to execute 'patchelf', did you install it? Hint: Try `pip install maturin[patchelf]` (or just `pip install patchelf`)

Run `pytest` in _verbose_ mode to isolate which test is running in an infinite loop --> `python -m pytest -vvv`