### PR TITLE
GitHub Action to run doc-new for Python

### DIFF
--- a/.github/workflows/iroh_python_doc_new.yml
+++ b/.github/workflows/iroh_python_doc_new.yml
@@ -1,0 +1,37 @@
+name: iroh_python_doc_new
+on: [push, pull_request, workflow_dispatch]
+jobs:
+  iroh_python_doc_new:
+    strategy:
+      fail-fast: false
+      max-parallel: 4
+      matrix:  # GitHub Actions: macos-13 is Intel, macos-latest is ARM
+        os: [macos-13, macos-latest, ubuntu-latest]  # , windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      # - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+      # https://iroh.computer/docs/install
+      - run: curl -fsSL https://sh.iroh.computer/install.sh | sh
+      - run: pip install --upgrade pip
+      # https://iroh.computer/docs/sdks/python
+      - run: pip install iroh
+      # https://iroh.computer/docs/api/doc-new -- click 'python' at the right
+      - shell: python
+        run: |
+          # https://iroh.computer/docs/api/doc-new for Python
+          import iroh
+
+          IROH_DATA_DIR = "./iroh_data_dir"
+
+          # Fails: ValueError("This class has no default constructor")
+          node = iroh.IrohNode(IROH_DATA_DIR)
+          print("Started Iroh node: {}".format(node.node_id()))
+
+          author = node.author_create()
+          print("Created author: {}".format(author.to_string()))
+
+          doc = node.doc_create()
+          print("Created doc: {}".format(doc.id().to_string()))


### PR DESCRIPTION
https://iroh.computer/docs/api/doc-new for Python (click `python` at the right) **_fails_** with:
> ValueError("This class has no default constructor")

`node = iroh.IrohNode(IROH_DATA_DIR)`
```
Traceback (most recent call last):
  File "/Users/runner/work/_temp/d40f5f0c-d284-464d-bb30-bd5c820bd3f8.py", line 7, in <module>
    node = iroh.IrohNode(IROH_DATA_DIR)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/iroh/iroh_ffi.py",
   line 7493, in __init__
    raise ValueError("This class has no default constructor")
ValueError: This class has no default constructor
```