### PR TITLE
GitHub Actions: Run all other pytest before running flaky `python/gossip_test.py`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-
 jobs:
   build_and_test_rust:
     runs-on: ${{ matrix.runner }}
@@ -88,14 +87,13 @@ jobs:
       with:
           python-version: 3.12
     - name: Install Deps
-      run: pip install virtualenv
+      run: pip install setuptools pytest pytest-asyncio "maturin[patchelf]" uniffi-bindgen
     - name: Python tests
       run: |
-        virtualenv venv && \
-        source venv/bin/activate && \
-        pip install setuptools pytest pytest-asyncio "maturin[patchelf]" uniffi-bindgen
-        maturin develop && \
-        python -m pytest -vvv
+        maturin develop
+        # Test python/gossip_test.py often times out so run all other pytests first
+        pytest --ignore python/gossip_test.py
+        pytest -vvv python/gossip_test.py
 
   build_and_test_swift:
     name: Swift - Build and test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,10 +86,13 @@ jobs:
     - uses: actions/setup-python@v5
       with:
           python-version: 3.12
-    - name: Install Deps
-      run: pip install setuptools pytest pytest-asyncio "maturin[patchelf]" uniffi-bindgen
+    - name: Install virtualenv
+      run: pip install virtualenv
     - name: Python tests
       run: |
+        virtualenv venv
+        source venv/bin/activate
+        pip install setuptools pytest pytest-asyncio "maturin[patchelf]" uniffi-bindgen
         maturin develop
         # Test python/gossip_test.py often times out so run all other pytests first
         pytest --ignore python/gossip_test.py


### PR DESCRIPTION
Test `python/gossip_test.py` often times out waiting for a response so until it is fixed, let's run all other pytests first.
```
pytest --ignore python/gossip_test.py
pytest -vvv python/gossip_test.py
```
https://docs.pytest.org/en/stable/example/pythoncollection.html
```
============================= test session starts ==============================
platform linux -- Python 3.12.4, pytest-8.2.2, pluggy-1.5.0
rootdir: /root/actions-runner/_work/iroh-ffi/iroh-ffi
configfile: pyproject.toml
plugins: asyncio-0.23.7
asyncio: mode=Mode.STRICT
collected 14 items
python/author_test.py .                                                  [  7%]
python/blob_test.py .....                                                [ 42%]
python/doc_test.py .....                                                 [ 78%]
python/key_test.py .                                                     [ 85%]
python/lib_test.py .                                                     [ 92%]
python/node_test.py .                                                    [100%]
============================== 14 passed in 5.12s ==============================
```