### PR TITLE
refactor: align structure more closely with rust library

### DIFF
--- a/Iroh.xcframework/ios-arm64/Iroh.framework/Headers/iroh_ffiFFI.h
+++ b/Iroh.xcframework/ios-arm64/Iroh.framework/Headers/iroh_ffiFFI.h
@@ -445,6 +445,51 @@ int8_t uniffi_iroh_ffi_fn_method_authorid_equal(void*_Nonnull ptr, void*_Nonnull
 RustBuffer uniffi_iroh_ffi_fn_method_authorid_uniffi_trait_display(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_AUTHORS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_AUTHORS
+void*_Nonnull uniffi_iroh_ffi_fn_clone_authors(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_FREE_AUTHORS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_FREE_AUTHORS
+void uniffi_iroh_ffi_fn_free_authors(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_AUTHORS_CREATE
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_AUTHORS_CREATE
+uint64_t uniffi_iroh_ffi_fn_method_authors_create(void*_Nonnull ptr
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_AUTHORS_DEFAULT
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_AUTHORS_DEFAULT
+uint64_t uniffi_iroh_ffi_fn_method_authors_default(void*_Nonnull ptr
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_AUTHORS_DELETE
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_AUTHORS_DELETE
+uint64_t uniffi_iroh_ffi_fn_method_authors_delete(void*_Nonnull ptr, void*_Nonnull author
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_AUTHORS_EXPORT
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_AUTHORS_EXPORT
+uint64_t uniffi_iroh_ffi_fn_method_authors_export(void*_Nonnull ptr, void*_Nonnull author
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_AUTHORS_IMPORT
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_AUTHORS_IMPORT
+uint64_t uniffi_iroh_ffi_fn_method_authors_import(void*_Nonnull ptr, void*_Nonnull author
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_AUTHORS_IMPORT_AUTHOR
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_AUTHORS_IMPORT_AUTHOR
+uint64_t uniffi_iroh_ffi_fn_method_authors_import_author(void*_Nonnull ptr, void*_Nonnull author
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_AUTHORS_LIST
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_AUTHORS_LIST
+uint64_t uniffi_iroh_ffi_fn_method_authors_list(void*_Nonnull ptr
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_BLOBDOWNLOADOPTIONS
 #define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_BLOBDOWNLOADOPTIONS
 void*_Nonnull uniffi_iroh_ffi_fn_clone_blobdownloadoptions(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
@@ -498,6 +543,96 @@ void*_Nonnull uniffi_iroh_ffi_fn_method_blobticket_node_addr(void*_Nonnull ptr, 
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBTICKET_RECURSIVE
 #define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBTICKET_RECURSIVE
 int8_t uniffi_iroh_ffi_fn_method_blobticket_recursive(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_BLOBS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_BLOBS
+void*_Nonnull uniffi_iroh_ffi_fn_clone_blobs(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_FREE_BLOBS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_FREE_BLOBS
+void uniffi_iroh_ffi_fn_free_blobs(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_ADD_BYTES
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_ADD_BYTES
+uint64_t uniffi_iroh_ffi_fn_method_blobs_add_bytes(void*_Nonnull ptr, RustBuffer bytes
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_ADD_BYTES_NAMED
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_ADD_BYTES_NAMED
+uint64_t uniffi_iroh_ffi_fn_method_blobs_add_bytes_named(void*_Nonnull ptr, RustBuffer bytes, RustBuffer name
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_ADD_FROM_PATH
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_ADD_FROM_PATH
+uint64_t uniffi_iroh_ffi_fn_method_blobs_add_from_path(void*_Nonnull ptr, RustBuffer path, int8_t in_place, void*_Nonnull tag, void*_Nonnull wrap, void*_Nonnull cb
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_CREATE_COLLECTION
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_CREATE_COLLECTION
+uint64_t uniffi_iroh_ffi_fn_method_blobs_create_collection(void*_Nonnull ptr, void*_Nonnull collection, void*_Nonnull tag, RustBuffer tags_to_delete
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_DELETE_BLOB
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_DELETE_BLOB
+uint64_t uniffi_iroh_ffi_fn_method_blobs_delete_blob(void*_Nonnull ptr, void*_Nonnull hash
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_DOWNLOAD
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_DOWNLOAD
+uint64_t uniffi_iroh_ffi_fn_method_blobs_download(void*_Nonnull ptr, void*_Nonnull hash, void*_Nonnull opts, void*_Nonnull cb
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_EXPORT
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_EXPORT
+uint64_t uniffi_iroh_ffi_fn_method_blobs_export(void*_Nonnull ptr, void*_Nonnull hash, RustBuffer destination, RustBuffer format, RustBuffer mode
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_GET_COLLECTION
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_GET_COLLECTION
+uint64_t uniffi_iroh_ffi_fn_method_blobs_get_collection(void*_Nonnull ptr, void*_Nonnull hash
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_LIST
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_LIST
+uint64_t uniffi_iroh_ffi_fn_method_blobs_list(void*_Nonnull ptr
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_LIST_COLLECTIONS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_LIST_COLLECTIONS
+uint64_t uniffi_iroh_ffi_fn_method_blobs_list_collections(void*_Nonnull ptr
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_LIST_INCOMPLETE
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_LIST_INCOMPLETE
+uint64_t uniffi_iroh_ffi_fn_method_blobs_list_incomplete(void*_Nonnull ptr
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_READ_AT_TO_BYTES
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_READ_AT_TO_BYTES
+uint64_t uniffi_iroh_ffi_fn_method_blobs_read_at_to_bytes(void*_Nonnull ptr, void*_Nonnull hash, uint64_t offset, RustBuffer len
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_READ_TO_BYTES
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_READ_TO_BYTES
+uint64_t uniffi_iroh_ffi_fn_method_blobs_read_to_bytes(void*_Nonnull ptr, void*_Nonnull hash
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_SHARE
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_SHARE
+uint64_t uniffi_iroh_ffi_fn_method_blobs_share(void*_Nonnull ptr, void*_Nonnull hash, RustBuffer blob_format, RustBuffer ticket_options
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_SIZE
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_SIZE
+uint64_t uniffi_iroh_ffi_fn_method_blobs_size(void*_Nonnull ptr, void*_Nonnull hash
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_WRITE_TO_PATH
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_WRITE_TO_PATH
+uint64_t uniffi_iroh_ffi_fn_method_blobs_write_to_path(void*_Nonnull ptr, void*_Nonnull hash, RustBuffer path
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_COLLECTION
@@ -621,9 +756,9 @@ void uniffi_iroh_ffi_fn_free_doc(void*_Nonnull ptr, RustCallStatus *_Nonnull out
 uint64_t uniffi_iroh_ffi_fn_method_doc_close_me(void*_Nonnull ptr
 );
 #endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_DOC_DEL
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_DOC_DEL
-uint64_t uniffi_iroh_ffi_fn_method_doc_del(void*_Nonnull ptr, void*_Nonnull author_id, RustBuffer prefix
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_DOC_DELETE_ENTRY
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_DOC_DELETE_ENTRY
+uint64_t uniffi_iroh_ffi_fn_method_doc_delete_entry(void*_Nonnull ptr, void*_Nonnull author_id, RustBuffer prefix
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_DOC_EXPORT_FILE
@@ -816,6 +951,46 @@ RustBuffer uniffi_iroh_ffi_fn_method_docimportprogress_as_progress(void*_Nonnull
 RustBuffer uniffi_iroh_ffi_fn_method_docimportprogress_type(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_DOCS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_DOCS
+void*_Nonnull uniffi_iroh_ffi_fn_clone_docs(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_FREE_DOCS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_FREE_DOCS
+void uniffi_iroh_ffi_fn_free_docs(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_DOCS_CREATE
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_DOCS_CREATE
+uint64_t uniffi_iroh_ffi_fn_method_docs_create(void*_Nonnull ptr
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_DOCS_DROP_DOC
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_DOCS_DROP_DOC
+uint64_t uniffi_iroh_ffi_fn_method_docs_drop_doc(void*_Nonnull ptr, RustBuffer doc_id
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_DOCS_JOIN
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_DOCS_JOIN
+uint64_t uniffi_iroh_ffi_fn_method_docs_join(void*_Nonnull ptr, RustBuffer ticket
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_DOCS_JOIN_AND_SUBSCRIBE
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_DOCS_JOIN_AND_SUBSCRIBE
+uint64_t uniffi_iroh_ffi_fn_method_docs_join_and_subscribe(void*_Nonnull ptr, RustBuffer ticket, void*_Nonnull cb
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_DOCS_LIST
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_DOCS_LIST
+uint64_t uniffi_iroh_ffi_fn_method_docs_list(void*_Nonnull ptr
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_DOCS_OPEN
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_DOCS_OPEN
+uint64_t uniffi_iroh_ffi_fn_method_docs_open(void*_Nonnull ptr, RustBuffer id
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_DOWNLOADCALLBACK
 #define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_DOWNLOADCALLBACK
 void*_Nonnull uniffi_iroh_ffi_fn_clone_downloadcallback(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
@@ -988,6 +1163,21 @@ void*_Nonnull uniffi_iroh_ffi_fn_constructor_filterkind_prefix(RustBuffer prefix
 int8_t uniffi_iroh_ffi_fn_method_filterkind_matches(void*_Nonnull ptr, RustBuffer key, RustCallStatus *_Nonnull out_status
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_GOSSIP
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_GOSSIP
+void*_Nonnull uniffi_iroh_ffi_fn_clone_gossip(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_FREE_GOSSIP
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_FREE_GOSSIP
+void uniffi_iroh_ffi_fn_free_gossip(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_GOSSIP_SUBSCRIBE
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_GOSSIP_SUBSCRIBE
+uint64_t uniffi_iroh_ffi_fn_method_gossip_subscribe(void*_Nonnull ptr, RustBuffer topic, RustBuffer bootstrap, void*_Nonnull cb
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_GOSSIPMESSAGECALLBACK
 #define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_GOSSIPMESSAGECALLBACK
 void*_Nonnull uniffi_iroh_ffi_fn_clone_gossipmessagecallback(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
@@ -1053,6 +1243,67 @@ RustBuffer uniffi_iroh_ffi_fn_method_hash_to_hex(void*_Nonnull ptr, RustCallStat
 RustBuffer uniffi_iroh_ffi_fn_method_hash_uniffi_trait_display(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_IROH
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_IROH
+void*_Nonnull uniffi_iroh_ffi_fn_clone_iroh(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_FREE_IROH
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_FREE_IROH
+void uniffi_iroh_ffi_fn_free_iroh(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CONSTRUCTOR_IROH_MEMORY
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CONSTRUCTOR_IROH_MEMORY
+uint64_t uniffi_iroh_ffi_fn_constructor_iroh_memory(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CONSTRUCTOR_IROH_MEMORY_WITH_OPTIONS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CONSTRUCTOR_IROH_MEMORY_WITH_OPTIONS
+uint64_t uniffi_iroh_ffi_fn_constructor_iroh_memory_with_options(RustBuffer options
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CONSTRUCTOR_IROH_PERSISTENT
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CONSTRUCTOR_IROH_PERSISTENT
+uint64_t uniffi_iroh_ffi_fn_constructor_iroh_persistent(RustBuffer path
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CONSTRUCTOR_IROH_PERSISTENT_WITH_OPTIONS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CONSTRUCTOR_IROH_PERSISTENT_WITH_OPTIONS
+uint64_t uniffi_iroh_ffi_fn_constructor_iroh_persistent_with_options(RustBuffer path, RustBuffer options
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROH_AUTHORS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROH_AUTHORS
+void*_Nonnull uniffi_iroh_ffi_fn_method_iroh_authors(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROH_BLOBS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROH_BLOBS
+void*_Nonnull uniffi_iroh_ffi_fn_method_iroh_blobs(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROH_DOCS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROH_DOCS
+void*_Nonnull uniffi_iroh_ffi_fn_method_iroh_docs(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROH_GOSSIP
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROH_GOSSIP
+void*_Nonnull uniffi_iroh_ffi_fn_method_iroh_gossip(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROH_NODE
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROH_NODE
+void*_Nonnull uniffi_iroh_ffi_fn_method_iroh_node(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROH_TAGS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROH_TAGS
+void*_Nonnull uniffi_iroh_ffi_fn_method_iroh_tags(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_IROHERROR
 #define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_IROHERROR
 void*_Nonnull uniffi_iroh_ffi_fn_clone_iroherror(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
@@ -1071,242 +1322,6 @@ RustBuffer uniffi_iroh_ffi_fn_method_iroherror_message(void*_Nonnull ptr, RustCa
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHERROR_UNIFFI_TRAIT_DEBUG
 #define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHERROR_UNIFFI_TRAIT_DEBUG
 RustBuffer uniffi_iroh_ffi_fn_method_iroherror_uniffi_trait_debug(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_IROHNODE
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_IROHNODE
-void*_Nonnull uniffi_iroh_ffi_fn_clone_irohnode(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_FREE_IROHNODE
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_FREE_IROHNODE
-void uniffi_iroh_ffi_fn_free_irohnode(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CONSTRUCTOR_IROHNODE_MEMORY
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CONSTRUCTOR_IROHNODE_MEMORY
-uint64_t uniffi_iroh_ffi_fn_constructor_irohnode_memory(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CONSTRUCTOR_IROHNODE_MEMORY_WITH_OPTIONS
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CONSTRUCTOR_IROHNODE_MEMORY_WITH_OPTIONS
-uint64_t uniffi_iroh_ffi_fn_constructor_irohnode_memory_with_options(RustBuffer options
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CONSTRUCTOR_IROHNODE_PERSISTENT
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CONSTRUCTOR_IROHNODE_PERSISTENT
-uint64_t uniffi_iroh_ffi_fn_constructor_irohnode_persistent(RustBuffer path
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CONSTRUCTOR_IROHNODE_PERSISTENT_WITH_OPTIONS
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CONSTRUCTOR_IROHNODE_PERSISTENT_WITH_OPTIONS
-uint64_t uniffi_iroh_ffi_fn_constructor_irohnode_persistent_with_options(RustBuffer path, RustBuffer options
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_ADD_NODE_ADDR
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_ADD_NODE_ADDR
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_add_node_addr(void*_Nonnull ptr, void*_Nonnull addr
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_AUTHOR_CREATE
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_AUTHOR_CREATE
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_author_create(void*_Nonnull ptr
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_AUTHOR_DEFAULT
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_AUTHOR_DEFAULT
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_author_default(void*_Nonnull ptr
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_AUTHOR_DELETE
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_AUTHOR_DELETE
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_author_delete(void*_Nonnull ptr, void*_Nonnull author
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_AUTHOR_EXPORT
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_AUTHOR_EXPORT
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_author_export(void*_Nonnull ptr, void*_Nonnull author
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_AUTHOR_IMPORT
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_AUTHOR_IMPORT
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_author_import(void*_Nonnull ptr, void*_Nonnull author
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_AUTHOR_LIST
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_AUTHOR_LIST
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_author_list(void*_Nonnull ptr
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_ADD_BYTES
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_ADD_BYTES
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_blobs_add_bytes(void*_Nonnull ptr, RustBuffer bytes
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_ADD_BYTES_NAMED
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_ADD_BYTES_NAMED
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_blobs_add_bytes_named(void*_Nonnull ptr, RustBuffer bytes, RustBuffer name
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_ADD_FROM_PATH
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_ADD_FROM_PATH
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_blobs_add_from_path(void*_Nonnull ptr, RustBuffer path, int8_t in_place, void*_Nonnull tag, void*_Nonnull wrap, void*_Nonnull cb
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_CREATE_COLLECTION
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_CREATE_COLLECTION
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_blobs_create_collection(void*_Nonnull ptr, void*_Nonnull collection, void*_Nonnull tag, RustBuffer tags_to_delete
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_DELETE_BLOB
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_DELETE_BLOB
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_blobs_delete_blob(void*_Nonnull ptr, void*_Nonnull hash
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_DOWNLOAD
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_DOWNLOAD
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_blobs_download(void*_Nonnull ptr, void*_Nonnull hash, void*_Nonnull opts, void*_Nonnull cb
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_EXPORT
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_EXPORT
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_blobs_export(void*_Nonnull ptr, void*_Nonnull hash, RustBuffer destination, RustBuffer format, RustBuffer mode
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_GET_COLLECTION
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_GET_COLLECTION
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_blobs_get_collection(void*_Nonnull ptr, void*_Nonnull hash
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_LIST
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_LIST
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_blobs_list(void*_Nonnull ptr
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_LIST_COLLECTIONS
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_LIST_COLLECTIONS
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_blobs_list_collections(void*_Nonnull ptr
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_LIST_INCOMPLETE
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_LIST_INCOMPLETE
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_blobs_list_incomplete(void*_Nonnull ptr
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_READ_AT_TO_BYTES
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_READ_AT_TO_BYTES
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_blobs_read_at_to_bytes(void*_Nonnull ptr, void*_Nonnull hash, uint64_t offset, RustBuffer len
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_READ_TO_BYTES
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_READ_TO_BYTES
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_blobs_read_to_bytes(void*_Nonnull ptr, void*_Nonnull hash
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_SHARE
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_SHARE
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_blobs_share(void*_Nonnull ptr, void*_Nonnull hash, RustBuffer blob_format, RustBuffer ticket_options
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_SIZE
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_SIZE
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_blobs_size(void*_Nonnull ptr, void*_Nonnull hash
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_WRITE_TO_PATH
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_WRITE_TO_PATH
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_blobs_write_to_path(void*_Nonnull ptr, void*_Nonnull hash, RustBuffer path
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_CONNECTION_INFO
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_CONNECTION_INFO
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_connection_info(void*_Nonnull ptr, void*_Nonnull node_id
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_CONNECTIONS
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_CONNECTIONS
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_connections(void*_Nonnull ptr
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_DOC_CREATE
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_DOC_CREATE
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_doc_create(void*_Nonnull ptr
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_DOC_DROP
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_DOC_DROP
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_doc_drop(void*_Nonnull ptr, RustBuffer doc_id
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_DOC_JOIN
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_DOC_JOIN
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_doc_join(void*_Nonnull ptr, RustBuffer ticket
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_DOC_JOIN_AND_SUBSCRIBE
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_DOC_JOIN_AND_SUBSCRIBE
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_doc_join_and_subscribe(void*_Nonnull ptr, RustBuffer ticket, void*_Nonnull cb
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_DOC_LIST
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_DOC_LIST
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_doc_list(void*_Nonnull ptr
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_DOC_OPEN
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_DOC_OPEN
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_doc_open(void*_Nonnull ptr, RustBuffer id
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_GOSSIP_SUBSCRIBE
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_GOSSIP_SUBSCRIBE
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_gossip_subscribe(void*_Nonnull ptr, RustBuffer topic, RustBuffer bootstrap, void*_Nonnull cb
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_HOME_RELAY
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_HOME_RELAY
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_home_relay(void*_Nonnull ptr
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_MY_RPC_ADDR
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_MY_RPC_ADDR
-RustBuffer uniffi_iroh_ffi_fn_method_irohnode_my_rpc_addr(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_NODE_ADDR
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_NODE_ADDR
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_node_addr(void*_Nonnull ptr
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_NODE_ID
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_NODE_ID
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_node_id(void*_Nonnull ptr
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_SHUTDOWN
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_SHUTDOWN
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_shutdown(void*_Nonnull ptr, int8_t force
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_STATS
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_STATS
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_stats(void*_Nonnull ptr
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_STATUS
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_STATUS
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_status(void*_Nonnull ptr
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_TAGS_DELETE
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_TAGS_DELETE
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_tags_delete(void*_Nonnull ptr, RustBuffer name
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_TAGS_LIST
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_TAGS_LIST
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_tags_list(void*_Nonnull ptr
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_LIVEEVENT
@@ -1387,6 +1402,66 @@ RustBuffer uniffi_iroh_ffi_fn_method_message_as_received(void*_Nonnull ptr, Rust
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_MESSAGE_TYPE
 #define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_MESSAGE_TYPE
 RustBuffer uniffi_iroh_ffi_fn_method_message_type(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_NODE
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_NODE
+void*_Nonnull uniffi_iroh_ffi_fn_clone_node(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_FREE_NODE
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_FREE_NODE
+void uniffi_iroh_ffi_fn_free_node(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_NODE_ADD_NODE_ADDR
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_NODE_ADD_NODE_ADDR
+uint64_t uniffi_iroh_ffi_fn_method_node_add_node_addr(void*_Nonnull ptr, void*_Nonnull addr
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_NODE_CONNECTION_INFO
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_NODE_CONNECTION_INFO
+uint64_t uniffi_iroh_ffi_fn_method_node_connection_info(void*_Nonnull ptr, void*_Nonnull node_id
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_NODE_CONNECTIONS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_NODE_CONNECTIONS
+uint64_t uniffi_iroh_ffi_fn_method_node_connections(void*_Nonnull ptr
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_NODE_HOME_RELAY
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_NODE_HOME_RELAY
+uint64_t uniffi_iroh_ffi_fn_method_node_home_relay(void*_Nonnull ptr
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_NODE_MY_RPC_ADDR
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_NODE_MY_RPC_ADDR
+RustBuffer uniffi_iroh_ffi_fn_method_node_my_rpc_addr(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_NODE_NODE_ADDR
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_NODE_NODE_ADDR
+uint64_t uniffi_iroh_ffi_fn_method_node_node_addr(void*_Nonnull ptr
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_NODE_NODE_ID
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_NODE_NODE_ID
+uint64_t uniffi_iroh_ffi_fn_method_node_node_id(void*_Nonnull ptr
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_NODE_SHUTDOWN
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_NODE_SHUTDOWN
+uint64_t uniffi_iroh_ffi_fn_method_node_shutdown(void*_Nonnull ptr, int8_t force
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_NODE_STATS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_NODE_STATS
+uint64_t uniffi_iroh_ffi_fn_method_node_stats(void*_Nonnull ptr
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_NODE_STATUS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_NODE_STATUS
+uint64_t uniffi_iroh_ffi_fn_method_node_status(void*_Nonnull ptr
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_NODEADDR
@@ -1633,6 +1708,26 @@ void uniffi_iroh_ffi_fn_init_callback_vtable_subscribecallback(UniffiVTableCallb
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_SUBSCRIBECALLBACK_EVENT
 #define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_SUBSCRIBECALLBACK_EVENT
 uint64_t uniffi_iroh_ffi_fn_method_subscribecallback_event(void*_Nonnull ptr, void*_Nonnull event
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_TAGS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_TAGS
+void*_Nonnull uniffi_iroh_ffi_fn_clone_tags(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_FREE_TAGS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_FREE_TAGS
+void uniffi_iroh_ffi_fn_free_tags(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_TAGS_DELETE
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_TAGS_DELETE
+uint64_t uniffi_iroh_ffi_fn_method_tags_delete(void*_Nonnull ptr, RustBuffer name
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_TAGS_LIST
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_TAGS_LIST
+uint64_t uniffi_iroh_ffi_fn_method_tags_list(void*_Nonnull ptr
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_WRAPOPTION
@@ -2035,6 +2130,48 @@ uint16_t uniffi_iroh_ffi_checksum_method_authorid_equal(void
     
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_AUTHORS_CREATE
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_AUTHORS_CREATE
+uint16_t uniffi_iroh_ffi_checksum_method_authors_create(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_AUTHORS_DEFAULT
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_AUTHORS_DEFAULT
+uint16_t uniffi_iroh_ffi_checksum_method_authors_default(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_AUTHORS_DELETE
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_AUTHORS_DELETE
+uint16_t uniffi_iroh_ffi_checksum_method_authors_delete(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_AUTHORS_EXPORT
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_AUTHORS_EXPORT
+uint16_t uniffi_iroh_ffi_checksum_method_authors_export(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_AUTHORS_IMPORT
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_AUTHORS_IMPORT
+uint16_t uniffi_iroh_ffi_checksum_method_authors_import(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_AUTHORS_IMPORT_AUTHOR
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_AUTHORS_IMPORT_AUTHOR
+uint16_t uniffi_iroh_ffi_checksum_method_authors_import_author(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_AUTHORS_LIST
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_AUTHORS_LIST
+uint16_t uniffi_iroh_ffi_checksum_method_authors_list(void
+    
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBTICKET_AS_DOWNLOAD_OPTIONS
 #define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBTICKET_AS_DOWNLOAD_OPTIONS
 uint16_t uniffi_iroh_ffi_checksum_method_blobticket_as_download_options(void
@@ -2062,6 +2199,102 @@ uint16_t uniffi_iroh_ffi_checksum_method_blobticket_node_addr(void
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBTICKET_RECURSIVE
 #define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBTICKET_RECURSIVE
 uint16_t uniffi_iroh_ffi_checksum_method_blobticket_recursive(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_ADD_BYTES
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_ADD_BYTES
+uint16_t uniffi_iroh_ffi_checksum_method_blobs_add_bytes(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_ADD_BYTES_NAMED
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_ADD_BYTES_NAMED
+uint16_t uniffi_iroh_ffi_checksum_method_blobs_add_bytes_named(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_ADD_FROM_PATH
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_ADD_FROM_PATH
+uint16_t uniffi_iroh_ffi_checksum_method_blobs_add_from_path(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_CREATE_COLLECTION
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_CREATE_COLLECTION
+uint16_t uniffi_iroh_ffi_checksum_method_blobs_create_collection(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_DELETE_BLOB
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_DELETE_BLOB
+uint16_t uniffi_iroh_ffi_checksum_method_blobs_delete_blob(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_DOWNLOAD
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_DOWNLOAD
+uint16_t uniffi_iroh_ffi_checksum_method_blobs_download(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_EXPORT
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_EXPORT
+uint16_t uniffi_iroh_ffi_checksum_method_blobs_export(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_GET_COLLECTION
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_GET_COLLECTION
+uint16_t uniffi_iroh_ffi_checksum_method_blobs_get_collection(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_LIST
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_LIST
+uint16_t uniffi_iroh_ffi_checksum_method_blobs_list(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_LIST_COLLECTIONS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_LIST_COLLECTIONS
+uint16_t uniffi_iroh_ffi_checksum_method_blobs_list_collections(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_LIST_INCOMPLETE
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_LIST_INCOMPLETE
+uint16_t uniffi_iroh_ffi_checksum_method_blobs_list_incomplete(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_READ_AT_TO_BYTES
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_READ_AT_TO_BYTES
+uint16_t uniffi_iroh_ffi_checksum_method_blobs_read_at_to_bytes(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_READ_TO_BYTES
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_READ_TO_BYTES
+uint16_t uniffi_iroh_ffi_checksum_method_blobs_read_to_bytes(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_SHARE
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_SHARE
+uint16_t uniffi_iroh_ffi_checksum_method_blobs_share(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_SIZE
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_SIZE
+uint16_t uniffi_iroh_ffi_checksum_method_blobs_size(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_WRITE_TO_PATH
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_WRITE_TO_PATH
+uint16_t uniffi_iroh_ffi_checksum_method_blobs_write_to_path(void
     
 );
 #endif
@@ -2155,9 +2388,9 @@ uint16_t uniffi_iroh_ffi_checksum_method_doc_close_me(void
     
 );
 #endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_DOC_DEL
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_DOC_DEL
-uint16_t uniffi_iroh_ffi_checksum_method_doc_del(void
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_DOC_DELETE_ENTRY
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_DOC_DELETE_ENTRY
+uint16_t uniffi_iroh_ffi_checksum_method_doc_delete_entry(void
     
 );
 #endif
@@ -2329,6 +2562,42 @@ uint16_t uniffi_iroh_ffi_checksum_method_docimportprogress_type(void
     
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_DOCS_CREATE
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_DOCS_CREATE
+uint16_t uniffi_iroh_ffi_checksum_method_docs_create(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_DOCS_DROP_DOC
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_DOCS_DROP_DOC
+uint16_t uniffi_iroh_ffi_checksum_method_docs_drop_doc(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_DOCS_JOIN
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_DOCS_JOIN
+uint16_t uniffi_iroh_ffi_checksum_method_docs_join(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_DOCS_JOIN_AND_SUBSCRIBE
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_DOCS_JOIN_AND_SUBSCRIBE
+uint16_t uniffi_iroh_ffi_checksum_method_docs_join_and_subscribe(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_DOCS_LIST
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_DOCS_LIST
+uint16_t uniffi_iroh_ffi_checksum_method_docs_list(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_DOCS_OPEN
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_DOCS_OPEN
+uint16_t uniffi_iroh_ffi_checksum_method_docs_open(void
+    
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_DOWNLOADCALLBACK_PROGRESS
 #define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_DOWNLOADCALLBACK_PROGRESS
 uint16_t uniffi_iroh_ffi_checksum_method_downloadcallback_progress(void
@@ -2431,6 +2700,12 @@ uint16_t uniffi_iroh_ffi_checksum_method_filterkind_matches(void
     
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_GOSSIP_SUBSCRIBE
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_GOSSIP_SUBSCRIBE
+uint16_t uniffi_iroh_ffi_checksum_method_gossip_subscribe(void
+    
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_GOSSIPMESSAGECALLBACK_ON_MESSAGE
 #define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_GOSSIPMESSAGECALLBACK_ON_MESSAGE
 uint16_t uniffi_iroh_ffi_checksum_method_gossipmessagecallback_on_message(void
@@ -2455,255 +2730,45 @@ uint16_t uniffi_iroh_ffi_checksum_method_hash_to_hex(void
     
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROH_AUTHORS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROH_AUTHORS
+uint16_t uniffi_iroh_ffi_checksum_method_iroh_authors(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROH_BLOBS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROH_BLOBS
+uint16_t uniffi_iroh_ffi_checksum_method_iroh_blobs(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROH_DOCS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROH_DOCS
+uint16_t uniffi_iroh_ffi_checksum_method_iroh_docs(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROH_GOSSIP
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROH_GOSSIP
+uint16_t uniffi_iroh_ffi_checksum_method_iroh_gossip(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROH_NODE
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROH_NODE
+uint16_t uniffi_iroh_ffi_checksum_method_iroh_node(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROH_TAGS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROH_TAGS
+uint16_t uniffi_iroh_ffi_checksum_method_iroh_tags(void
+    
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHERROR_MESSAGE
 #define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHERROR_MESSAGE
 uint16_t uniffi_iroh_ffi_checksum_method_iroherror_message(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_ADD_NODE_ADDR
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_ADD_NODE_ADDR
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_add_node_addr(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_AUTHOR_CREATE
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_AUTHOR_CREATE
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_author_create(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_AUTHOR_DEFAULT
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_AUTHOR_DEFAULT
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_author_default(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_AUTHOR_DELETE
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_AUTHOR_DELETE
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_author_delete(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_AUTHOR_EXPORT
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_AUTHOR_EXPORT
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_author_export(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_AUTHOR_IMPORT
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_AUTHOR_IMPORT
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_author_import(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_AUTHOR_LIST
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_AUTHOR_LIST
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_author_list(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_ADD_BYTES
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_ADD_BYTES
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_blobs_add_bytes(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_ADD_BYTES_NAMED
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_ADD_BYTES_NAMED
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_blobs_add_bytes_named(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_ADD_FROM_PATH
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_ADD_FROM_PATH
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_blobs_add_from_path(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_CREATE_COLLECTION
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_CREATE_COLLECTION
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_blobs_create_collection(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_DELETE_BLOB
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_DELETE_BLOB
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_blobs_delete_blob(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_DOWNLOAD
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_DOWNLOAD
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_blobs_download(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_EXPORT
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_EXPORT
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_blobs_export(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_GET_COLLECTION
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_GET_COLLECTION
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_blobs_get_collection(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_LIST
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_LIST
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_blobs_list(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_LIST_COLLECTIONS
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_LIST_COLLECTIONS
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_blobs_list_collections(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_LIST_INCOMPLETE
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_LIST_INCOMPLETE
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_blobs_list_incomplete(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_READ_AT_TO_BYTES
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_READ_AT_TO_BYTES
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_blobs_read_at_to_bytes(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_READ_TO_BYTES
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_READ_TO_BYTES
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_blobs_read_to_bytes(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_SHARE
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_SHARE
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_blobs_share(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_SIZE
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_SIZE
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_blobs_size(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_WRITE_TO_PATH
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_WRITE_TO_PATH
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_blobs_write_to_path(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_CONNECTION_INFO
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_CONNECTION_INFO
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_connection_info(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_CONNECTIONS
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_CONNECTIONS
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_connections(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_DOC_CREATE
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_DOC_CREATE
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_doc_create(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_DOC_DROP
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_DOC_DROP
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_doc_drop(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_DOC_JOIN
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_DOC_JOIN
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_doc_join(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_DOC_JOIN_AND_SUBSCRIBE
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_DOC_JOIN_AND_SUBSCRIBE
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_doc_join_and_subscribe(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_DOC_LIST
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_DOC_LIST
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_doc_list(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_DOC_OPEN
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_DOC_OPEN
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_doc_open(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_GOSSIP_SUBSCRIBE
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_GOSSIP_SUBSCRIBE
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_gossip_subscribe(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_HOME_RELAY
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_HOME_RELAY
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_home_relay(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_MY_RPC_ADDR
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_MY_RPC_ADDR
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_my_rpc_addr(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_NODE_ADDR
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_NODE_ADDR
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_node_addr(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_NODE_ID
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_NODE_ID
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_node_id(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_SHUTDOWN
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_SHUTDOWN
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_shutdown(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_STATS
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_STATS
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_stats(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_STATUS
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_STATUS
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_status(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_TAGS_DELETE
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_TAGS_DELETE
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_tags_delete(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_TAGS_LIST
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_TAGS_LIST
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_tags_list(void
     
 );
 #endif
@@ -2776,6 +2841,66 @@ uint16_t uniffi_iroh_ffi_checksum_method_message_as_received(void
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_MESSAGE_TYPE
 #define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_MESSAGE_TYPE
 uint16_t uniffi_iroh_ffi_checksum_method_message_type(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_NODE_ADD_NODE_ADDR
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_NODE_ADD_NODE_ADDR
+uint16_t uniffi_iroh_ffi_checksum_method_node_add_node_addr(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_NODE_CONNECTION_INFO
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_NODE_CONNECTION_INFO
+uint16_t uniffi_iroh_ffi_checksum_method_node_connection_info(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_NODE_CONNECTIONS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_NODE_CONNECTIONS
+uint16_t uniffi_iroh_ffi_checksum_method_node_connections(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_NODE_HOME_RELAY
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_NODE_HOME_RELAY
+uint16_t uniffi_iroh_ffi_checksum_method_node_home_relay(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_NODE_MY_RPC_ADDR
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_NODE_MY_RPC_ADDR
+uint16_t uniffi_iroh_ffi_checksum_method_node_my_rpc_addr(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_NODE_NODE_ADDR
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_NODE_NODE_ADDR
+uint16_t uniffi_iroh_ffi_checksum_method_node_node_addr(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_NODE_NODE_ID
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_NODE_NODE_ID
+uint16_t uniffi_iroh_ffi_checksum_method_node_node_id(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_NODE_SHUTDOWN
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_NODE_SHUTDOWN
+uint16_t uniffi_iroh_ffi_checksum_method_node_shutdown(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_NODE_STATS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_NODE_STATS
+uint16_t uniffi_iroh_ffi_checksum_method_node_stats(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_NODE_STATUS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_NODE_STATUS
+uint16_t uniffi_iroh_ffi_checksum_method_node_status(void
     
 );
 #endif
@@ -2881,6 +3006,18 @@ uint16_t uniffi_iroh_ffi_checksum_method_subscribecallback_event(void
     
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_TAGS_DELETE
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_TAGS_DELETE
+uint16_t uniffi_iroh_ffi_checksum_method_tags_delete(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_TAGS_LIST
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_TAGS_LIST
+uint16_t uniffi_iroh_ffi_checksum_method_tags_list(void
+    
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_CONSTRUCTOR_AUTHOR_FROM_STRING
 #define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_CONSTRUCTOR_AUTHOR_FROM_STRING
 uint16_t uniffi_iroh_ffi_checksum_constructor_author_from_string(void
@@ -2965,27 +3102,27 @@ uint16_t uniffi_iroh_ffi_checksum_constructor_hash_new(void
     
 );
 #endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_CONSTRUCTOR_IROHNODE_MEMORY
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_CONSTRUCTOR_IROHNODE_MEMORY
-uint16_t uniffi_iroh_ffi_checksum_constructor_irohnode_memory(void
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_CONSTRUCTOR_IROH_MEMORY
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_CONSTRUCTOR_IROH_MEMORY
+uint16_t uniffi_iroh_ffi_checksum_constructor_iroh_memory(void
     
 );
 #endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_CONSTRUCTOR_IROHNODE_MEMORY_WITH_OPTIONS
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_CONSTRUCTOR_IROHNODE_MEMORY_WITH_OPTIONS
-uint16_t uniffi_iroh_ffi_checksum_constructor_irohnode_memory_with_options(void
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_CONSTRUCTOR_IROH_MEMORY_WITH_OPTIONS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_CONSTRUCTOR_IROH_MEMORY_WITH_OPTIONS
+uint16_t uniffi_iroh_ffi_checksum_constructor_iroh_memory_with_options(void
     
 );
 #endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_CONSTRUCTOR_IROHNODE_PERSISTENT
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_CONSTRUCTOR_IROHNODE_PERSISTENT
-uint16_t uniffi_iroh_ffi_checksum_constructor_irohnode_persistent(void
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_CONSTRUCTOR_IROH_PERSISTENT
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_CONSTRUCTOR_IROH_PERSISTENT
+uint16_t uniffi_iroh_ffi_checksum_constructor_iroh_persistent(void
     
 );
 #endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_CONSTRUCTOR_IROHNODE_PERSISTENT_WITH_OPTIONS
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_CONSTRUCTOR_IROHNODE_PERSISTENT_WITH_OPTIONS
-uint16_t uniffi_iroh_ffi_checksum_constructor_irohnode_persistent_with_options(void
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_CONSTRUCTOR_IROH_PERSISTENT_WITH_OPTIONS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_CONSTRUCTOR_IROH_PERSISTENT_WITH_OPTIONS
+uint16_t uniffi_iroh_ffi_checksum_constructor_iroh_persistent_with_options(void
     
 );
 #endif

--- a/Iroh.xcframework/ios-arm64_x86_64-simulator/Iroh.framework/Headers/iroh_ffiFFI.h
+++ b/Iroh.xcframework/ios-arm64_x86_64-simulator/Iroh.framework/Headers/iroh_ffiFFI.h
@@ -445,6 +445,51 @@ int8_t uniffi_iroh_ffi_fn_method_authorid_equal(void*_Nonnull ptr, void*_Nonnull
 RustBuffer uniffi_iroh_ffi_fn_method_authorid_uniffi_trait_display(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_AUTHORS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_AUTHORS
+void*_Nonnull uniffi_iroh_ffi_fn_clone_authors(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_FREE_AUTHORS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_FREE_AUTHORS
+void uniffi_iroh_ffi_fn_free_authors(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_AUTHORS_CREATE
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_AUTHORS_CREATE
+uint64_t uniffi_iroh_ffi_fn_method_authors_create(void*_Nonnull ptr
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_AUTHORS_DEFAULT
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_AUTHORS_DEFAULT
+uint64_t uniffi_iroh_ffi_fn_method_authors_default(void*_Nonnull ptr
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_AUTHORS_DELETE
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_AUTHORS_DELETE
+uint64_t uniffi_iroh_ffi_fn_method_authors_delete(void*_Nonnull ptr, void*_Nonnull author
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_AUTHORS_EXPORT
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_AUTHORS_EXPORT
+uint64_t uniffi_iroh_ffi_fn_method_authors_export(void*_Nonnull ptr, void*_Nonnull author
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_AUTHORS_IMPORT
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_AUTHORS_IMPORT
+uint64_t uniffi_iroh_ffi_fn_method_authors_import(void*_Nonnull ptr, void*_Nonnull author
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_AUTHORS_IMPORT_AUTHOR
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_AUTHORS_IMPORT_AUTHOR
+uint64_t uniffi_iroh_ffi_fn_method_authors_import_author(void*_Nonnull ptr, void*_Nonnull author
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_AUTHORS_LIST
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_AUTHORS_LIST
+uint64_t uniffi_iroh_ffi_fn_method_authors_list(void*_Nonnull ptr
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_BLOBDOWNLOADOPTIONS
 #define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_BLOBDOWNLOADOPTIONS
 void*_Nonnull uniffi_iroh_ffi_fn_clone_blobdownloadoptions(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
@@ -498,6 +543,96 @@ void*_Nonnull uniffi_iroh_ffi_fn_method_blobticket_node_addr(void*_Nonnull ptr, 
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBTICKET_RECURSIVE
 #define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBTICKET_RECURSIVE
 int8_t uniffi_iroh_ffi_fn_method_blobticket_recursive(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_BLOBS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_BLOBS
+void*_Nonnull uniffi_iroh_ffi_fn_clone_blobs(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_FREE_BLOBS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_FREE_BLOBS
+void uniffi_iroh_ffi_fn_free_blobs(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_ADD_BYTES
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_ADD_BYTES
+uint64_t uniffi_iroh_ffi_fn_method_blobs_add_bytes(void*_Nonnull ptr, RustBuffer bytes
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_ADD_BYTES_NAMED
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_ADD_BYTES_NAMED
+uint64_t uniffi_iroh_ffi_fn_method_blobs_add_bytes_named(void*_Nonnull ptr, RustBuffer bytes, RustBuffer name
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_ADD_FROM_PATH
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_ADD_FROM_PATH
+uint64_t uniffi_iroh_ffi_fn_method_blobs_add_from_path(void*_Nonnull ptr, RustBuffer path, int8_t in_place, void*_Nonnull tag, void*_Nonnull wrap, void*_Nonnull cb
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_CREATE_COLLECTION
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_CREATE_COLLECTION
+uint64_t uniffi_iroh_ffi_fn_method_blobs_create_collection(void*_Nonnull ptr, void*_Nonnull collection, void*_Nonnull tag, RustBuffer tags_to_delete
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_DELETE_BLOB
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_DELETE_BLOB
+uint64_t uniffi_iroh_ffi_fn_method_blobs_delete_blob(void*_Nonnull ptr, void*_Nonnull hash
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_DOWNLOAD
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_DOWNLOAD
+uint64_t uniffi_iroh_ffi_fn_method_blobs_download(void*_Nonnull ptr, void*_Nonnull hash, void*_Nonnull opts, void*_Nonnull cb
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_EXPORT
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_EXPORT
+uint64_t uniffi_iroh_ffi_fn_method_blobs_export(void*_Nonnull ptr, void*_Nonnull hash, RustBuffer destination, RustBuffer format, RustBuffer mode
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_GET_COLLECTION
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_GET_COLLECTION
+uint64_t uniffi_iroh_ffi_fn_method_blobs_get_collection(void*_Nonnull ptr, void*_Nonnull hash
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_LIST
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_LIST
+uint64_t uniffi_iroh_ffi_fn_method_blobs_list(void*_Nonnull ptr
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_LIST_COLLECTIONS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_LIST_COLLECTIONS
+uint64_t uniffi_iroh_ffi_fn_method_blobs_list_collections(void*_Nonnull ptr
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_LIST_INCOMPLETE
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_LIST_INCOMPLETE
+uint64_t uniffi_iroh_ffi_fn_method_blobs_list_incomplete(void*_Nonnull ptr
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_READ_AT_TO_BYTES
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_READ_AT_TO_BYTES
+uint64_t uniffi_iroh_ffi_fn_method_blobs_read_at_to_bytes(void*_Nonnull ptr, void*_Nonnull hash, uint64_t offset, RustBuffer len
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_READ_TO_BYTES
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_READ_TO_BYTES
+uint64_t uniffi_iroh_ffi_fn_method_blobs_read_to_bytes(void*_Nonnull ptr, void*_Nonnull hash
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_SHARE
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_SHARE
+uint64_t uniffi_iroh_ffi_fn_method_blobs_share(void*_Nonnull ptr, void*_Nonnull hash, RustBuffer blob_format, RustBuffer ticket_options
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_SIZE
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_SIZE
+uint64_t uniffi_iroh_ffi_fn_method_blobs_size(void*_Nonnull ptr, void*_Nonnull hash
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_WRITE_TO_PATH
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_WRITE_TO_PATH
+uint64_t uniffi_iroh_ffi_fn_method_blobs_write_to_path(void*_Nonnull ptr, void*_Nonnull hash, RustBuffer path
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_COLLECTION
@@ -621,9 +756,9 @@ void uniffi_iroh_ffi_fn_free_doc(void*_Nonnull ptr, RustCallStatus *_Nonnull out
 uint64_t uniffi_iroh_ffi_fn_method_doc_close_me(void*_Nonnull ptr
 );
 #endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_DOC_DEL
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_DOC_DEL
-uint64_t uniffi_iroh_ffi_fn_method_doc_del(void*_Nonnull ptr, void*_Nonnull author_id, RustBuffer prefix
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_DOC_DELETE_ENTRY
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_DOC_DELETE_ENTRY
+uint64_t uniffi_iroh_ffi_fn_method_doc_delete_entry(void*_Nonnull ptr, void*_Nonnull author_id, RustBuffer prefix
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_DOC_EXPORT_FILE
@@ -816,6 +951,46 @@ RustBuffer uniffi_iroh_ffi_fn_method_docimportprogress_as_progress(void*_Nonnull
 RustBuffer uniffi_iroh_ffi_fn_method_docimportprogress_type(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_DOCS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_DOCS
+void*_Nonnull uniffi_iroh_ffi_fn_clone_docs(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_FREE_DOCS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_FREE_DOCS
+void uniffi_iroh_ffi_fn_free_docs(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_DOCS_CREATE
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_DOCS_CREATE
+uint64_t uniffi_iroh_ffi_fn_method_docs_create(void*_Nonnull ptr
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_DOCS_DROP_DOC
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_DOCS_DROP_DOC
+uint64_t uniffi_iroh_ffi_fn_method_docs_drop_doc(void*_Nonnull ptr, RustBuffer doc_id
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_DOCS_JOIN
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_DOCS_JOIN
+uint64_t uniffi_iroh_ffi_fn_method_docs_join(void*_Nonnull ptr, RustBuffer ticket
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_DOCS_JOIN_AND_SUBSCRIBE
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_DOCS_JOIN_AND_SUBSCRIBE
+uint64_t uniffi_iroh_ffi_fn_method_docs_join_and_subscribe(void*_Nonnull ptr, RustBuffer ticket, void*_Nonnull cb
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_DOCS_LIST
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_DOCS_LIST
+uint64_t uniffi_iroh_ffi_fn_method_docs_list(void*_Nonnull ptr
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_DOCS_OPEN
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_DOCS_OPEN
+uint64_t uniffi_iroh_ffi_fn_method_docs_open(void*_Nonnull ptr, RustBuffer id
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_DOWNLOADCALLBACK
 #define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_DOWNLOADCALLBACK
 void*_Nonnull uniffi_iroh_ffi_fn_clone_downloadcallback(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
@@ -988,6 +1163,21 @@ void*_Nonnull uniffi_iroh_ffi_fn_constructor_filterkind_prefix(RustBuffer prefix
 int8_t uniffi_iroh_ffi_fn_method_filterkind_matches(void*_Nonnull ptr, RustBuffer key, RustCallStatus *_Nonnull out_status
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_GOSSIP
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_GOSSIP
+void*_Nonnull uniffi_iroh_ffi_fn_clone_gossip(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_FREE_GOSSIP
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_FREE_GOSSIP
+void uniffi_iroh_ffi_fn_free_gossip(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_GOSSIP_SUBSCRIBE
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_GOSSIP_SUBSCRIBE
+uint64_t uniffi_iroh_ffi_fn_method_gossip_subscribe(void*_Nonnull ptr, RustBuffer topic, RustBuffer bootstrap, void*_Nonnull cb
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_GOSSIPMESSAGECALLBACK
 #define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_GOSSIPMESSAGECALLBACK
 void*_Nonnull uniffi_iroh_ffi_fn_clone_gossipmessagecallback(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
@@ -1053,6 +1243,67 @@ RustBuffer uniffi_iroh_ffi_fn_method_hash_to_hex(void*_Nonnull ptr, RustCallStat
 RustBuffer uniffi_iroh_ffi_fn_method_hash_uniffi_trait_display(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_IROH
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_IROH
+void*_Nonnull uniffi_iroh_ffi_fn_clone_iroh(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_FREE_IROH
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_FREE_IROH
+void uniffi_iroh_ffi_fn_free_iroh(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CONSTRUCTOR_IROH_MEMORY
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CONSTRUCTOR_IROH_MEMORY
+uint64_t uniffi_iroh_ffi_fn_constructor_iroh_memory(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CONSTRUCTOR_IROH_MEMORY_WITH_OPTIONS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CONSTRUCTOR_IROH_MEMORY_WITH_OPTIONS
+uint64_t uniffi_iroh_ffi_fn_constructor_iroh_memory_with_options(RustBuffer options
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CONSTRUCTOR_IROH_PERSISTENT
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CONSTRUCTOR_IROH_PERSISTENT
+uint64_t uniffi_iroh_ffi_fn_constructor_iroh_persistent(RustBuffer path
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CONSTRUCTOR_IROH_PERSISTENT_WITH_OPTIONS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CONSTRUCTOR_IROH_PERSISTENT_WITH_OPTIONS
+uint64_t uniffi_iroh_ffi_fn_constructor_iroh_persistent_with_options(RustBuffer path, RustBuffer options
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROH_AUTHORS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROH_AUTHORS
+void*_Nonnull uniffi_iroh_ffi_fn_method_iroh_authors(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROH_BLOBS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROH_BLOBS
+void*_Nonnull uniffi_iroh_ffi_fn_method_iroh_blobs(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROH_DOCS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROH_DOCS
+void*_Nonnull uniffi_iroh_ffi_fn_method_iroh_docs(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROH_GOSSIP
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROH_GOSSIP
+void*_Nonnull uniffi_iroh_ffi_fn_method_iroh_gossip(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROH_NODE
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROH_NODE
+void*_Nonnull uniffi_iroh_ffi_fn_method_iroh_node(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROH_TAGS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROH_TAGS
+void*_Nonnull uniffi_iroh_ffi_fn_method_iroh_tags(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_IROHERROR
 #define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_IROHERROR
 void*_Nonnull uniffi_iroh_ffi_fn_clone_iroherror(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
@@ -1071,242 +1322,6 @@ RustBuffer uniffi_iroh_ffi_fn_method_iroherror_message(void*_Nonnull ptr, RustCa
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHERROR_UNIFFI_TRAIT_DEBUG
 #define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHERROR_UNIFFI_TRAIT_DEBUG
 RustBuffer uniffi_iroh_ffi_fn_method_iroherror_uniffi_trait_debug(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_IROHNODE
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_IROHNODE
-void*_Nonnull uniffi_iroh_ffi_fn_clone_irohnode(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_FREE_IROHNODE
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_FREE_IROHNODE
-void uniffi_iroh_ffi_fn_free_irohnode(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CONSTRUCTOR_IROHNODE_MEMORY
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CONSTRUCTOR_IROHNODE_MEMORY
-uint64_t uniffi_iroh_ffi_fn_constructor_irohnode_memory(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CONSTRUCTOR_IROHNODE_MEMORY_WITH_OPTIONS
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CONSTRUCTOR_IROHNODE_MEMORY_WITH_OPTIONS
-uint64_t uniffi_iroh_ffi_fn_constructor_irohnode_memory_with_options(RustBuffer options
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CONSTRUCTOR_IROHNODE_PERSISTENT
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CONSTRUCTOR_IROHNODE_PERSISTENT
-uint64_t uniffi_iroh_ffi_fn_constructor_irohnode_persistent(RustBuffer path
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CONSTRUCTOR_IROHNODE_PERSISTENT_WITH_OPTIONS
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CONSTRUCTOR_IROHNODE_PERSISTENT_WITH_OPTIONS
-uint64_t uniffi_iroh_ffi_fn_constructor_irohnode_persistent_with_options(RustBuffer path, RustBuffer options
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_ADD_NODE_ADDR
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_ADD_NODE_ADDR
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_add_node_addr(void*_Nonnull ptr, void*_Nonnull addr
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_AUTHOR_CREATE
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_AUTHOR_CREATE
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_author_create(void*_Nonnull ptr
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_AUTHOR_DEFAULT
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_AUTHOR_DEFAULT
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_author_default(void*_Nonnull ptr
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_AUTHOR_DELETE
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_AUTHOR_DELETE
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_author_delete(void*_Nonnull ptr, void*_Nonnull author
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_AUTHOR_EXPORT
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_AUTHOR_EXPORT
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_author_export(void*_Nonnull ptr, void*_Nonnull author
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_AUTHOR_IMPORT
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_AUTHOR_IMPORT
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_author_import(void*_Nonnull ptr, void*_Nonnull author
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_AUTHOR_LIST
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_AUTHOR_LIST
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_author_list(void*_Nonnull ptr
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_ADD_BYTES
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_ADD_BYTES
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_blobs_add_bytes(void*_Nonnull ptr, RustBuffer bytes
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_ADD_BYTES_NAMED
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_ADD_BYTES_NAMED
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_blobs_add_bytes_named(void*_Nonnull ptr, RustBuffer bytes, RustBuffer name
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_ADD_FROM_PATH
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_ADD_FROM_PATH
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_blobs_add_from_path(void*_Nonnull ptr, RustBuffer path, int8_t in_place, void*_Nonnull tag, void*_Nonnull wrap, void*_Nonnull cb
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_CREATE_COLLECTION
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_CREATE_COLLECTION
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_blobs_create_collection(void*_Nonnull ptr, void*_Nonnull collection, void*_Nonnull tag, RustBuffer tags_to_delete
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_DELETE_BLOB
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_DELETE_BLOB
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_blobs_delete_blob(void*_Nonnull ptr, void*_Nonnull hash
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_DOWNLOAD
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_DOWNLOAD
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_blobs_download(void*_Nonnull ptr, void*_Nonnull hash, void*_Nonnull opts, void*_Nonnull cb
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_EXPORT
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_EXPORT
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_blobs_export(void*_Nonnull ptr, void*_Nonnull hash, RustBuffer destination, RustBuffer format, RustBuffer mode
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_GET_COLLECTION
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_GET_COLLECTION
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_blobs_get_collection(void*_Nonnull ptr, void*_Nonnull hash
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_LIST
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_LIST
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_blobs_list(void*_Nonnull ptr
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_LIST_COLLECTIONS
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_LIST_COLLECTIONS
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_blobs_list_collections(void*_Nonnull ptr
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_LIST_INCOMPLETE
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_LIST_INCOMPLETE
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_blobs_list_incomplete(void*_Nonnull ptr
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_READ_AT_TO_BYTES
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_READ_AT_TO_BYTES
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_blobs_read_at_to_bytes(void*_Nonnull ptr, void*_Nonnull hash, uint64_t offset, RustBuffer len
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_READ_TO_BYTES
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_READ_TO_BYTES
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_blobs_read_to_bytes(void*_Nonnull ptr, void*_Nonnull hash
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_SHARE
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_SHARE
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_blobs_share(void*_Nonnull ptr, void*_Nonnull hash, RustBuffer blob_format, RustBuffer ticket_options
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_SIZE
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_SIZE
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_blobs_size(void*_Nonnull ptr, void*_Nonnull hash
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_WRITE_TO_PATH
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_WRITE_TO_PATH
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_blobs_write_to_path(void*_Nonnull ptr, void*_Nonnull hash, RustBuffer path
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_CONNECTION_INFO
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_CONNECTION_INFO
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_connection_info(void*_Nonnull ptr, void*_Nonnull node_id
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_CONNECTIONS
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_CONNECTIONS
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_connections(void*_Nonnull ptr
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_DOC_CREATE
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_DOC_CREATE
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_doc_create(void*_Nonnull ptr
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_DOC_DROP
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_DOC_DROP
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_doc_drop(void*_Nonnull ptr, RustBuffer doc_id
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_DOC_JOIN
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_DOC_JOIN
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_doc_join(void*_Nonnull ptr, RustBuffer ticket
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_DOC_JOIN_AND_SUBSCRIBE
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_DOC_JOIN_AND_SUBSCRIBE
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_doc_join_and_subscribe(void*_Nonnull ptr, RustBuffer ticket, void*_Nonnull cb
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_DOC_LIST
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_DOC_LIST
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_doc_list(void*_Nonnull ptr
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_DOC_OPEN
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_DOC_OPEN
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_doc_open(void*_Nonnull ptr, RustBuffer id
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_GOSSIP_SUBSCRIBE
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_GOSSIP_SUBSCRIBE
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_gossip_subscribe(void*_Nonnull ptr, RustBuffer topic, RustBuffer bootstrap, void*_Nonnull cb
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_HOME_RELAY
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_HOME_RELAY
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_home_relay(void*_Nonnull ptr
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_MY_RPC_ADDR
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_MY_RPC_ADDR
-RustBuffer uniffi_iroh_ffi_fn_method_irohnode_my_rpc_addr(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_NODE_ADDR
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_NODE_ADDR
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_node_addr(void*_Nonnull ptr
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_NODE_ID
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_NODE_ID
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_node_id(void*_Nonnull ptr
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_SHUTDOWN
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_SHUTDOWN
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_shutdown(void*_Nonnull ptr, int8_t force
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_STATS
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_STATS
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_stats(void*_Nonnull ptr
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_STATUS
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_STATUS
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_status(void*_Nonnull ptr
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_TAGS_DELETE
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_TAGS_DELETE
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_tags_delete(void*_Nonnull ptr, RustBuffer name
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_TAGS_LIST
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_TAGS_LIST
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_tags_list(void*_Nonnull ptr
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_LIVEEVENT
@@ -1387,6 +1402,66 @@ RustBuffer uniffi_iroh_ffi_fn_method_message_as_received(void*_Nonnull ptr, Rust
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_MESSAGE_TYPE
 #define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_MESSAGE_TYPE
 RustBuffer uniffi_iroh_ffi_fn_method_message_type(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_NODE
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_NODE
+void*_Nonnull uniffi_iroh_ffi_fn_clone_node(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_FREE_NODE
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_FREE_NODE
+void uniffi_iroh_ffi_fn_free_node(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_NODE_ADD_NODE_ADDR
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_NODE_ADD_NODE_ADDR
+uint64_t uniffi_iroh_ffi_fn_method_node_add_node_addr(void*_Nonnull ptr, void*_Nonnull addr
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_NODE_CONNECTION_INFO
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_NODE_CONNECTION_INFO
+uint64_t uniffi_iroh_ffi_fn_method_node_connection_info(void*_Nonnull ptr, void*_Nonnull node_id
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_NODE_CONNECTIONS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_NODE_CONNECTIONS
+uint64_t uniffi_iroh_ffi_fn_method_node_connections(void*_Nonnull ptr
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_NODE_HOME_RELAY
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_NODE_HOME_RELAY
+uint64_t uniffi_iroh_ffi_fn_method_node_home_relay(void*_Nonnull ptr
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_NODE_MY_RPC_ADDR
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_NODE_MY_RPC_ADDR
+RustBuffer uniffi_iroh_ffi_fn_method_node_my_rpc_addr(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_NODE_NODE_ADDR
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_NODE_NODE_ADDR
+uint64_t uniffi_iroh_ffi_fn_method_node_node_addr(void*_Nonnull ptr
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_NODE_NODE_ID
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_NODE_NODE_ID
+uint64_t uniffi_iroh_ffi_fn_method_node_node_id(void*_Nonnull ptr
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_NODE_SHUTDOWN
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_NODE_SHUTDOWN
+uint64_t uniffi_iroh_ffi_fn_method_node_shutdown(void*_Nonnull ptr, int8_t force
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_NODE_STATS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_NODE_STATS
+uint64_t uniffi_iroh_ffi_fn_method_node_stats(void*_Nonnull ptr
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_NODE_STATUS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_NODE_STATUS
+uint64_t uniffi_iroh_ffi_fn_method_node_status(void*_Nonnull ptr
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_NODEADDR
@@ -1633,6 +1708,26 @@ void uniffi_iroh_ffi_fn_init_callback_vtable_subscribecallback(UniffiVTableCallb
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_SUBSCRIBECALLBACK_EVENT
 #define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_SUBSCRIBECALLBACK_EVENT
 uint64_t uniffi_iroh_ffi_fn_method_subscribecallback_event(void*_Nonnull ptr, void*_Nonnull event
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_TAGS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_TAGS
+void*_Nonnull uniffi_iroh_ffi_fn_clone_tags(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_FREE_TAGS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_FREE_TAGS
+void uniffi_iroh_ffi_fn_free_tags(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_TAGS_DELETE
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_TAGS_DELETE
+uint64_t uniffi_iroh_ffi_fn_method_tags_delete(void*_Nonnull ptr, RustBuffer name
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_TAGS_LIST
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_TAGS_LIST
+uint64_t uniffi_iroh_ffi_fn_method_tags_list(void*_Nonnull ptr
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_WRAPOPTION
@@ -2035,6 +2130,48 @@ uint16_t uniffi_iroh_ffi_checksum_method_authorid_equal(void
     
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_AUTHORS_CREATE
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_AUTHORS_CREATE
+uint16_t uniffi_iroh_ffi_checksum_method_authors_create(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_AUTHORS_DEFAULT
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_AUTHORS_DEFAULT
+uint16_t uniffi_iroh_ffi_checksum_method_authors_default(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_AUTHORS_DELETE
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_AUTHORS_DELETE
+uint16_t uniffi_iroh_ffi_checksum_method_authors_delete(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_AUTHORS_EXPORT
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_AUTHORS_EXPORT
+uint16_t uniffi_iroh_ffi_checksum_method_authors_export(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_AUTHORS_IMPORT
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_AUTHORS_IMPORT
+uint16_t uniffi_iroh_ffi_checksum_method_authors_import(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_AUTHORS_IMPORT_AUTHOR
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_AUTHORS_IMPORT_AUTHOR
+uint16_t uniffi_iroh_ffi_checksum_method_authors_import_author(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_AUTHORS_LIST
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_AUTHORS_LIST
+uint16_t uniffi_iroh_ffi_checksum_method_authors_list(void
+    
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBTICKET_AS_DOWNLOAD_OPTIONS
 #define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBTICKET_AS_DOWNLOAD_OPTIONS
 uint16_t uniffi_iroh_ffi_checksum_method_blobticket_as_download_options(void
@@ -2062,6 +2199,102 @@ uint16_t uniffi_iroh_ffi_checksum_method_blobticket_node_addr(void
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBTICKET_RECURSIVE
 #define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBTICKET_RECURSIVE
 uint16_t uniffi_iroh_ffi_checksum_method_blobticket_recursive(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_ADD_BYTES
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_ADD_BYTES
+uint16_t uniffi_iroh_ffi_checksum_method_blobs_add_bytes(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_ADD_BYTES_NAMED
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_ADD_BYTES_NAMED
+uint16_t uniffi_iroh_ffi_checksum_method_blobs_add_bytes_named(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_ADD_FROM_PATH
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_ADD_FROM_PATH
+uint16_t uniffi_iroh_ffi_checksum_method_blobs_add_from_path(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_CREATE_COLLECTION
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_CREATE_COLLECTION
+uint16_t uniffi_iroh_ffi_checksum_method_blobs_create_collection(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_DELETE_BLOB
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_DELETE_BLOB
+uint16_t uniffi_iroh_ffi_checksum_method_blobs_delete_blob(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_DOWNLOAD
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_DOWNLOAD
+uint16_t uniffi_iroh_ffi_checksum_method_blobs_download(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_EXPORT
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_EXPORT
+uint16_t uniffi_iroh_ffi_checksum_method_blobs_export(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_GET_COLLECTION
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_GET_COLLECTION
+uint16_t uniffi_iroh_ffi_checksum_method_blobs_get_collection(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_LIST
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_LIST
+uint16_t uniffi_iroh_ffi_checksum_method_blobs_list(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_LIST_COLLECTIONS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_LIST_COLLECTIONS
+uint16_t uniffi_iroh_ffi_checksum_method_blobs_list_collections(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_LIST_INCOMPLETE
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_LIST_INCOMPLETE
+uint16_t uniffi_iroh_ffi_checksum_method_blobs_list_incomplete(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_READ_AT_TO_BYTES
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_READ_AT_TO_BYTES
+uint16_t uniffi_iroh_ffi_checksum_method_blobs_read_at_to_bytes(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_READ_TO_BYTES
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_READ_TO_BYTES
+uint16_t uniffi_iroh_ffi_checksum_method_blobs_read_to_bytes(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_SHARE
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_SHARE
+uint16_t uniffi_iroh_ffi_checksum_method_blobs_share(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_SIZE
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_SIZE
+uint16_t uniffi_iroh_ffi_checksum_method_blobs_size(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_WRITE_TO_PATH
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_WRITE_TO_PATH
+uint16_t uniffi_iroh_ffi_checksum_method_blobs_write_to_path(void
     
 );
 #endif
@@ -2155,9 +2388,9 @@ uint16_t uniffi_iroh_ffi_checksum_method_doc_close_me(void
     
 );
 #endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_DOC_DEL
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_DOC_DEL
-uint16_t uniffi_iroh_ffi_checksum_method_doc_del(void
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_DOC_DELETE_ENTRY
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_DOC_DELETE_ENTRY
+uint16_t uniffi_iroh_ffi_checksum_method_doc_delete_entry(void
     
 );
 #endif
@@ -2329,6 +2562,42 @@ uint16_t uniffi_iroh_ffi_checksum_method_docimportprogress_type(void
     
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_DOCS_CREATE
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_DOCS_CREATE
+uint16_t uniffi_iroh_ffi_checksum_method_docs_create(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_DOCS_DROP_DOC
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_DOCS_DROP_DOC
+uint16_t uniffi_iroh_ffi_checksum_method_docs_drop_doc(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_DOCS_JOIN
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_DOCS_JOIN
+uint16_t uniffi_iroh_ffi_checksum_method_docs_join(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_DOCS_JOIN_AND_SUBSCRIBE
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_DOCS_JOIN_AND_SUBSCRIBE
+uint16_t uniffi_iroh_ffi_checksum_method_docs_join_and_subscribe(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_DOCS_LIST
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_DOCS_LIST
+uint16_t uniffi_iroh_ffi_checksum_method_docs_list(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_DOCS_OPEN
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_DOCS_OPEN
+uint16_t uniffi_iroh_ffi_checksum_method_docs_open(void
+    
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_DOWNLOADCALLBACK_PROGRESS
 #define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_DOWNLOADCALLBACK_PROGRESS
 uint16_t uniffi_iroh_ffi_checksum_method_downloadcallback_progress(void
@@ -2431,6 +2700,12 @@ uint16_t uniffi_iroh_ffi_checksum_method_filterkind_matches(void
     
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_GOSSIP_SUBSCRIBE
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_GOSSIP_SUBSCRIBE
+uint16_t uniffi_iroh_ffi_checksum_method_gossip_subscribe(void
+    
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_GOSSIPMESSAGECALLBACK_ON_MESSAGE
 #define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_GOSSIPMESSAGECALLBACK_ON_MESSAGE
 uint16_t uniffi_iroh_ffi_checksum_method_gossipmessagecallback_on_message(void
@@ -2455,255 +2730,45 @@ uint16_t uniffi_iroh_ffi_checksum_method_hash_to_hex(void
     
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROH_AUTHORS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROH_AUTHORS
+uint16_t uniffi_iroh_ffi_checksum_method_iroh_authors(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROH_BLOBS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROH_BLOBS
+uint16_t uniffi_iroh_ffi_checksum_method_iroh_blobs(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROH_DOCS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROH_DOCS
+uint16_t uniffi_iroh_ffi_checksum_method_iroh_docs(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROH_GOSSIP
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROH_GOSSIP
+uint16_t uniffi_iroh_ffi_checksum_method_iroh_gossip(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROH_NODE
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROH_NODE
+uint16_t uniffi_iroh_ffi_checksum_method_iroh_node(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROH_TAGS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROH_TAGS
+uint16_t uniffi_iroh_ffi_checksum_method_iroh_tags(void
+    
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHERROR_MESSAGE
 #define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHERROR_MESSAGE
 uint16_t uniffi_iroh_ffi_checksum_method_iroherror_message(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_ADD_NODE_ADDR
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_ADD_NODE_ADDR
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_add_node_addr(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_AUTHOR_CREATE
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_AUTHOR_CREATE
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_author_create(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_AUTHOR_DEFAULT
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_AUTHOR_DEFAULT
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_author_default(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_AUTHOR_DELETE
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_AUTHOR_DELETE
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_author_delete(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_AUTHOR_EXPORT
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_AUTHOR_EXPORT
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_author_export(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_AUTHOR_IMPORT
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_AUTHOR_IMPORT
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_author_import(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_AUTHOR_LIST
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_AUTHOR_LIST
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_author_list(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_ADD_BYTES
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_ADD_BYTES
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_blobs_add_bytes(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_ADD_BYTES_NAMED
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_ADD_BYTES_NAMED
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_blobs_add_bytes_named(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_ADD_FROM_PATH
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_ADD_FROM_PATH
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_blobs_add_from_path(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_CREATE_COLLECTION
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_CREATE_COLLECTION
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_blobs_create_collection(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_DELETE_BLOB
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_DELETE_BLOB
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_blobs_delete_blob(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_DOWNLOAD
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_DOWNLOAD
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_blobs_download(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_EXPORT
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_EXPORT
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_blobs_export(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_GET_COLLECTION
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_GET_COLLECTION
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_blobs_get_collection(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_LIST
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_LIST
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_blobs_list(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_LIST_COLLECTIONS
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_LIST_COLLECTIONS
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_blobs_list_collections(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_LIST_INCOMPLETE
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_LIST_INCOMPLETE
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_blobs_list_incomplete(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_READ_AT_TO_BYTES
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_READ_AT_TO_BYTES
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_blobs_read_at_to_bytes(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_READ_TO_BYTES
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_READ_TO_BYTES
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_blobs_read_to_bytes(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_SHARE
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_SHARE
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_blobs_share(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_SIZE
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_SIZE
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_blobs_size(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_WRITE_TO_PATH
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_WRITE_TO_PATH
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_blobs_write_to_path(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_CONNECTION_INFO
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_CONNECTION_INFO
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_connection_info(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_CONNECTIONS
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_CONNECTIONS
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_connections(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_DOC_CREATE
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_DOC_CREATE
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_doc_create(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_DOC_DROP
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_DOC_DROP
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_doc_drop(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_DOC_JOIN
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_DOC_JOIN
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_doc_join(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_DOC_JOIN_AND_SUBSCRIBE
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_DOC_JOIN_AND_SUBSCRIBE
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_doc_join_and_subscribe(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_DOC_LIST
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_DOC_LIST
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_doc_list(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_DOC_OPEN
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_DOC_OPEN
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_doc_open(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_GOSSIP_SUBSCRIBE
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_GOSSIP_SUBSCRIBE
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_gossip_subscribe(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_HOME_RELAY
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_HOME_RELAY
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_home_relay(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_MY_RPC_ADDR
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_MY_RPC_ADDR
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_my_rpc_addr(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_NODE_ADDR
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_NODE_ADDR
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_node_addr(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_NODE_ID
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_NODE_ID
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_node_id(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_SHUTDOWN
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_SHUTDOWN
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_shutdown(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_STATS
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_STATS
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_stats(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_STATUS
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_STATUS
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_status(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_TAGS_DELETE
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_TAGS_DELETE
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_tags_delete(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_TAGS_LIST
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_TAGS_LIST
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_tags_list(void
     
 );
 #endif
@@ -2776,6 +2841,66 @@ uint16_t uniffi_iroh_ffi_checksum_method_message_as_received(void
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_MESSAGE_TYPE
 #define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_MESSAGE_TYPE
 uint16_t uniffi_iroh_ffi_checksum_method_message_type(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_NODE_ADD_NODE_ADDR
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_NODE_ADD_NODE_ADDR
+uint16_t uniffi_iroh_ffi_checksum_method_node_add_node_addr(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_NODE_CONNECTION_INFO
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_NODE_CONNECTION_INFO
+uint16_t uniffi_iroh_ffi_checksum_method_node_connection_info(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_NODE_CONNECTIONS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_NODE_CONNECTIONS
+uint16_t uniffi_iroh_ffi_checksum_method_node_connections(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_NODE_HOME_RELAY
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_NODE_HOME_RELAY
+uint16_t uniffi_iroh_ffi_checksum_method_node_home_relay(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_NODE_MY_RPC_ADDR
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_NODE_MY_RPC_ADDR
+uint16_t uniffi_iroh_ffi_checksum_method_node_my_rpc_addr(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_NODE_NODE_ADDR
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_NODE_NODE_ADDR
+uint16_t uniffi_iroh_ffi_checksum_method_node_node_addr(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_NODE_NODE_ID
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_NODE_NODE_ID
+uint16_t uniffi_iroh_ffi_checksum_method_node_node_id(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_NODE_SHUTDOWN
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_NODE_SHUTDOWN
+uint16_t uniffi_iroh_ffi_checksum_method_node_shutdown(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_NODE_STATS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_NODE_STATS
+uint16_t uniffi_iroh_ffi_checksum_method_node_stats(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_NODE_STATUS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_NODE_STATUS
+uint16_t uniffi_iroh_ffi_checksum_method_node_status(void
     
 );
 #endif
@@ -2881,6 +3006,18 @@ uint16_t uniffi_iroh_ffi_checksum_method_subscribecallback_event(void
     
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_TAGS_DELETE
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_TAGS_DELETE
+uint16_t uniffi_iroh_ffi_checksum_method_tags_delete(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_TAGS_LIST
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_TAGS_LIST
+uint16_t uniffi_iroh_ffi_checksum_method_tags_list(void
+    
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_CONSTRUCTOR_AUTHOR_FROM_STRING
 #define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_CONSTRUCTOR_AUTHOR_FROM_STRING
 uint16_t uniffi_iroh_ffi_checksum_constructor_author_from_string(void
@@ -2965,27 +3102,27 @@ uint16_t uniffi_iroh_ffi_checksum_constructor_hash_new(void
     
 );
 #endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_CONSTRUCTOR_IROHNODE_MEMORY
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_CONSTRUCTOR_IROHNODE_MEMORY
-uint16_t uniffi_iroh_ffi_checksum_constructor_irohnode_memory(void
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_CONSTRUCTOR_IROH_MEMORY
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_CONSTRUCTOR_IROH_MEMORY
+uint16_t uniffi_iroh_ffi_checksum_constructor_iroh_memory(void
     
 );
 #endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_CONSTRUCTOR_IROHNODE_MEMORY_WITH_OPTIONS
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_CONSTRUCTOR_IROHNODE_MEMORY_WITH_OPTIONS
-uint16_t uniffi_iroh_ffi_checksum_constructor_irohnode_memory_with_options(void
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_CONSTRUCTOR_IROH_MEMORY_WITH_OPTIONS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_CONSTRUCTOR_IROH_MEMORY_WITH_OPTIONS
+uint16_t uniffi_iroh_ffi_checksum_constructor_iroh_memory_with_options(void
     
 );
 #endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_CONSTRUCTOR_IROHNODE_PERSISTENT
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_CONSTRUCTOR_IROHNODE_PERSISTENT
-uint16_t uniffi_iroh_ffi_checksum_constructor_irohnode_persistent(void
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_CONSTRUCTOR_IROH_PERSISTENT
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_CONSTRUCTOR_IROH_PERSISTENT
+uint16_t uniffi_iroh_ffi_checksum_constructor_iroh_persistent(void
     
 );
 #endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_CONSTRUCTOR_IROHNODE_PERSISTENT_WITH_OPTIONS
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_CONSTRUCTOR_IROHNODE_PERSISTENT_WITH_OPTIONS
-uint16_t uniffi_iroh_ffi_checksum_constructor_irohnode_persistent_with_options(void
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_CONSTRUCTOR_IROH_PERSISTENT_WITH_OPTIONS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_CONSTRUCTOR_IROH_PERSISTENT_WITH_OPTIONS
+uint16_t uniffi_iroh_ffi_checksum_constructor_iroh_persistent_with_options(void
     
 );
 #endif

--- a/Iroh.xcframework/macos-arm64/Iroh.framework/Headers/iroh_ffiFFI.h
+++ b/Iroh.xcframework/macos-arm64/Iroh.framework/Headers/iroh_ffiFFI.h
@@ -445,6 +445,51 @@ int8_t uniffi_iroh_ffi_fn_method_authorid_equal(void*_Nonnull ptr, void*_Nonnull
 RustBuffer uniffi_iroh_ffi_fn_method_authorid_uniffi_trait_display(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_AUTHORS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_AUTHORS
+void*_Nonnull uniffi_iroh_ffi_fn_clone_authors(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_FREE_AUTHORS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_FREE_AUTHORS
+void uniffi_iroh_ffi_fn_free_authors(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_AUTHORS_CREATE
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_AUTHORS_CREATE
+uint64_t uniffi_iroh_ffi_fn_method_authors_create(void*_Nonnull ptr
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_AUTHORS_DEFAULT
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_AUTHORS_DEFAULT
+uint64_t uniffi_iroh_ffi_fn_method_authors_default(void*_Nonnull ptr
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_AUTHORS_DELETE
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_AUTHORS_DELETE
+uint64_t uniffi_iroh_ffi_fn_method_authors_delete(void*_Nonnull ptr, void*_Nonnull author
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_AUTHORS_EXPORT
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_AUTHORS_EXPORT
+uint64_t uniffi_iroh_ffi_fn_method_authors_export(void*_Nonnull ptr, void*_Nonnull author
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_AUTHORS_IMPORT
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_AUTHORS_IMPORT
+uint64_t uniffi_iroh_ffi_fn_method_authors_import(void*_Nonnull ptr, void*_Nonnull author
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_AUTHORS_IMPORT_AUTHOR
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_AUTHORS_IMPORT_AUTHOR
+uint64_t uniffi_iroh_ffi_fn_method_authors_import_author(void*_Nonnull ptr, void*_Nonnull author
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_AUTHORS_LIST
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_AUTHORS_LIST
+uint64_t uniffi_iroh_ffi_fn_method_authors_list(void*_Nonnull ptr
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_BLOBDOWNLOADOPTIONS
 #define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_BLOBDOWNLOADOPTIONS
 void*_Nonnull uniffi_iroh_ffi_fn_clone_blobdownloadoptions(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
@@ -498,6 +543,96 @@ void*_Nonnull uniffi_iroh_ffi_fn_method_blobticket_node_addr(void*_Nonnull ptr, 
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBTICKET_RECURSIVE
 #define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBTICKET_RECURSIVE
 int8_t uniffi_iroh_ffi_fn_method_blobticket_recursive(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_BLOBS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_BLOBS
+void*_Nonnull uniffi_iroh_ffi_fn_clone_blobs(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_FREE_BLOBS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_FREE_BLOBS
+void uniffi_iroh_ffi_fn_free_blobs(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_ADD_BYTES
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_ADD_BYTES
+uint64_t uniffi_iroh_ffi_fn_method_blobs_add_bytes(void*_Nonnull ptr, RustBuffer bytes
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_ADD_BYTES_NAMED
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_ADD_BYTES_NAMED
+uint64_t uniffi_iroh_ffi_fn_method_blobs_add_bytes_named(void*_Nonnull ptr, RustBuffer bytes, RustBuffer name
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_ADD_FROM_PATH
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_ADD_FROM_PATH
+uint64_t uniffi_iroh_ffi_fn_method_blobs_add_from_path(void*_Nonnull ptr, RustBuffer path, int8_t in_place, void*_Nonnull tag, void*_Nonnull wrap, void*_Nonnull cb
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_CREATE_COLLECTION
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_CREATE_COLLECTION
+uint64_t uniffi_iroh_ffi_fn_method_blobs_create_collection(void*_Nonnull ptr, void*_Nonnull collection, void*_Nonnull tag, RustBuffer tags_to_delete
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_DELETE_BLOB
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_DELETE_BLOB
+uint64_t uniffi_iroh_ffi_fn_method_blobs_delete_blob(void*_Nonnull ptr, void*_Nonnull hash
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_DOWNLOAD
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_DOWNLOAD
+uint64_t uniffi_iroh_ffi_fn_method_blobs_download(void*_Nonnull ptr, void*_Nonnull hash, void*_Nonnull opts, void*_Nonnull cb
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_EXPORT
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_EXPORT
+uint64_t uniffi_iroh_ffi_fn_method_blobs_export(void*_Nonnull ptr, void*_Nonnull hash, RustBuffer destination, RustBuffer format, RustBuffer mode
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_GET_COLLECTION
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_GET_COLLECTION
+uint64_t uniffi_iroh_ffi_fn_method_blobs_get_collection(void*_Nonnull ptr, void*_Nonnull hash
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_LIST
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_LIST
+uint64_t uniffi_iroh_ffi_fn_method_blobs_list(void*_Nonnull ptr
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_LIST_COLLECTIONS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_LIST_COLLECTIONS
+uint64_t uniffi_iroh_ffi_fn_method_blobs_list_collections(void*_Nonnull ptr
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_LIST_INCOMPLETE
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_LIST_INCOMPLETE
+uint64_t uniffi_iroh_ffi_fn_method_blobs_list_incomplete(void*_Nonnull ptr
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_READ_AT_TO_BYTES
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_READ_AT_TO_BYTES
+uint64_t uniffi_iroh_ffi_fn_method_blobs_read_at_to_bytes(void*_Nonnull ptr, void*_Nonnull hash, uint64_t offset, RustBuffer len
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_READ_TO_BYTES
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_READ_TO_BYTES
+uint64_t uniffi_iroh_ffi_fn_method_blobs_read_to_bytes(void*_Nonnull ptr, void*_Nonnull hash
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_SHARE
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_SHARE
+uint64_t uniffi_iroh_ffi_fn_method_blobs_share(void*_Nonnull ptr, void*_Nonnull hash, RustBuffer blob_format, RustBuffer ticket_options
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_SIZE
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_SIZE
+uint64_t uniffi_iroh_ffi_fn_method_blobs_size(void*_Nonnull ptr, void*_Nonnull hash
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_WRITE_TO_PATH
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBS_WRITE_TO_PATH
+uint64_t uniffi_iroh_ffi_fn_method_blobs_write_to_path(void*_Nonnull ptr, void*_Nonnull hash, RustBuffer path
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_COLLECTION
@@ -621,9 +756,9 @@ void uniffi_iroh_ffi_fn_free_doc(void*_Nonnull ptr, RustCallStatus *_Nonnull out
 uint64_t uniffi_iroh_ffi_fn_method_doc_close_me(void*_Nonnull ptr
 );
 #endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_DOC_DEL
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_DOC_DEL
-uint64_t uniffi_iroh_ffi_fn_method_doc_del(void*_Nonnull ptr, void*_Nonnull author_id, RustBuffer prefix
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_DOC_DELETE_ENTRY
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_DOC_DELETE_ENTRY
+uint64_t uniffi_iroh_ffi_fn_method_doc_delete_entry(void*_Nonnull ptr, void*_Nonnull author_id, RustBuffer prefix
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_DOC_EXPORT_FILE
@@ -816,6 +951,46 @@ RustBuffer uniffi_iroh_ffi_fn_method_docimportprogress_as_progress(void*_Nonnull
 RustBuffer uniffi_iroh_ffi_fn_method_docimportprogress_type(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_DOCS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_DOCS
+void*_Nonnull uniffi_iroh_ffi_fn_clone_docs(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_FREE_DOCS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_FREE_DOCS
+void uniffi_iroh_ffi_fn_free_docs(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_DOCS_CREATE
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_DOCS_CREATE
+uint64_t uniffi_iroh_ffi_fn_method_docs_create(void*_Nonnull ptr
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_DOCS_DROP_DOC
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_DOCS_DROP_DOC
+uint64_t uniffi_iroh_ffi_fn_method_docs_drop_doc(void*_Nonnull ptr, RustBuffer doc_id
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_DOCS_JOIN
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_DOCS_JOIN
+uint64_t uniffi_iroh_ffi_fn_method_docs_join(void*_Nonnull ptr, RustBuffer ticket
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_DOCS_JOIN_AND_SUBSCRIBE
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_DOCS_JOIN_AND_SUBSCRIBE
+uint64_t uniffi_iroh_ffi_fn_method_docs_join_and_subscribe(void*_Nonnull ptr, RustBuffer ticket, void*_Nonnull cb
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_DOCS_LIST
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_DOCS_LIST
+uint64_t uniffi_iroh_ffi_fn_method_docs_list(void*_Nonnull ptr
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_DOCS_OPEN
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_DOCS_OPEN
+uint64_t uniffi_iroh_ffi_fn_method_docs_open(void*_Nonnull ptr, RustBuffer id
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_DOWNLOADCALLBACK
 #define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_DOWNLOADCALLBACK
 void*_Nonnull uniffi_iroh_ffi_fn_clone_downloadcallback(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
@@ -988,6 +1163,21 @@ void*_Nonnull uniffi_iroh_ffi_fn_constructor_filterkind_prefix(RustBuffer prefix
 int8_t uniffi_iroh_ffi_fn_method_filterkind_matches(void*_Nonnull ptr, RustBuffer key, RustCallStatus *_Nonnull out_status
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_GOSSIP
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_GOSSIP
+void*_Nonnull uniffi_iroh_ffi_fn_clone_gossip(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_FREE_GOSSIP
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_FREE_GOSSIP
+void uniffi_iroh_ffi_fn_free_gossip(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_GOSSIP_SUBSCRIBE
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_GOSSIP_SUBSCRIBE
+uint64_t uniffi_iroh_ffi_fn_method_gossip_subscribe(void*_Nonnull ptr, RustBuffer topic, RustBuffer bootstrap, void*_Nonnull cb
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_GOSSIPMESSAGECALLBACK
 #define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_GOSSIPMESSAGECALLBACK
 void*_Nonnull uniffi_iroh_ffi_fn_clone_gossipmessagecallback(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
@@ -1053,6 +1243,67 @@ RustBuffer uniffi_iroh_ffi_fn_method_hash_to_hex(void*_Nonnull ptr, RustCallStat
 RustBuffer uniffi_iroh_ffi_fn_method_hash_uniffi_trait_display(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_IROH
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_IROH
+void*_Nonnull uniffi_iroh_ffi_fn_clone_iroh(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_FREE_IROH
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_FREE_IROH
+void uniffi_iroh_ffi_fn_free_iroh(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CONSTRUCTOR_IROH_MEMORY
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CONSTRUCTOR_IROH_MEMORY
+uint64_t uniffi_iroh_ffi_fn_constructor_iroh_memory(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CONSTRUCTOR_IROH_MEMORY_WITH_OPTIONS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CONSTRUCTOR_IROH_MEMORY_WITH_OPTIONS
+uint64_t uniffi_iroh_ffi_fn_constructor_iroh_memory_with_options(RustBuffer options
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CONSTRUCTOR_IROH_PERSISTENT
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CONSTRUCTOR_IROH_PERSISTENT
+uint64_t uniffi_iroh_ffi_fn_constructor_iroh_persistent(RustBuffer path
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CONSTRUCTOR_IROH_PERSISTENT_WITH_OPTIONS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CONSTRUCTOR_IROH_PERSISTENT_WITH_OPTIONS
+uint64_t uniffi_iroh_ffi_fn_constructor_iroh_persistent_with_options(RustBuffer path, RustBuffer options
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROH_AUTHORS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROH_AUTHORS
+void*_Nonnull uniffi_iroh_ffi_fn_method_iroh_authors(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROH_BLOBS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROH_BLOBS
+void*_Nonnull uniffi_iroh_ffi_fn_method_iroh_blobs(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROH_DOCS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROH_DOCS
+void*_Nonnull uniffi_iroh_ffi_fn_method_iroh_docs(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROH_GOSSIP
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROH_GOSSIP
+void*_Nonnull uniffi_iroh_ffi_fn_method_iroh_gossip(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROH_NODE
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROH_NODE
+void*_Nonnull uniffi_iroh_ffi_fn_method_iroh_node(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROH_TAGS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROH_TAGS
+void*_Nonnull uniffi_iroh_ffi_fn_method_iroh_tags(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_IROHERROR
 #define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_IROHERROR
 void*_Nonnull uniffi_iroh_ffi_fn_clone_iroherror(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
@@ -1071,242 +1322,6 @@ RustBuffer uniffi_iroh_ffi_fn_method_iroherror_message(void*_Nonnull ptr, RustCa
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHERROR_UNIFFI_TRAIT_DEBUG
 #define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHERROR_UNIFFI_TRAIT_DEBUG
 RustBuffer uniffi_iroh_ffi_fn_method_iroherror_uniffi_trait_debug(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_IROHNODE
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_IROHNODE
-void*_Nonnull uniffi_iroh_ffi_fn_clone_irohnode(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_FREE_IROHNODE
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_FREE_IROHNODE
-void uniffi_iroh_ffi_fn_free_irohnode(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CONSTRUCTOR_IROHNODE_MEMORY
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CONSTRUCTOR_IROHNODE_MEMORY
-uint64_t uniffi_iroh_ffi_fn_constructor_irohnode_memory(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CONSTRUCTOR_IROHNODE_MEMORY_WITH_OPTIONS
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CONSTRUCTOR_IROHNODE_MEMORY_WITH_OPTIONS
-uint64_t uniffi_iroh_ffi_fn_constructor_irohnode_memory_with_options(RustBuffer options
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CONSTRUCTOR_IROHNODE_PERSISTENT
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CONSTRUCTOR_IROHNODE_PERSISTENT
-uint64_t uniffi_iroh_ffi_fn_constructor_irohnode_persistent(RustBuffer path
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CONSTRUCTOR_IROHNODE_PERSISTENT_WITH_OPTIONS
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CONSTRUCTOR_IROHNODE_PERSISTENT_WITH_OPTIONS
-uint64_t uniffi_iroh_ffi_fn_constructor_irohnode_persistent_with_options(RustBuffer path, RustBuffer options
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_ADD_NODE_ADDR
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_ADD_NODE_ADDR
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_add_node_addr(void*_Nonnull ptr, void*_Nonnull addr
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_AUTHOR_CREATE
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_AUTHOR_CREATE
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_author_create(void*_Nonnull ptr
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_AUTHOR_DEFAULT
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_AUTHOR_DEFAULT
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_author_default(void*_Nonnull ptr
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_AUTHOR_DELETE
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_AUTHOR_DELETE
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_author_delete(void*_Nonnull ptr, void*_Nonnull author
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_AUTHOR_EXPORT
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_AUTHOR_EXPORT
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_author_export(void*_Nonnull ptr, void*_Nonnull author
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_AUTHOR_IMPORT
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_AUTHOR_IMPORT
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_author_import(void*_Nonnull ptr, void*_Nonnull author
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_AUTHOR_LIST
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_AUTHOR_LIST
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_author_list(void*_Nonnull ptr
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_ADD_BYTES
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_ADD_BYTES
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_blobs_add_bytes(void*_Nonnull ptr, RustBuffer bytes
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_ADD_BYTES_NAMED
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_ADD_BYTES_NAMED
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_blobs_add_bytes_named(void*_Nonnull ptr, RustBuffer bytes, RustBuffer name
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_ADD_FROM_PATH
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_ADD_FROM_PATH
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_blobs_add_from_path(void*_Nonnull ptr, RustBuffer path, int8_t in_place, void*_Nonnull tag, void*_Nonnull wrap, void*_Nonnull cb
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_CREATE_COLLECTION
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_CREATE_COLLECTION
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_blobs_create_collection(void*_Nonnull ptr, void*_Nonnull collection, void*_Nonnull tag, RustBuffer tags_to_delete
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_DELETE_BLOB
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_DELETE_BLOB
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_blobs_delete_blob(void*_Nonnull ptr, void*_Nonnull hash
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_DOWNLOAD
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_DOWNLOAD
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_blobs_download(void*_Nonnull ptr, void*_Nonnull hash, void*_Nonnull opts, void*_Nonnull cb
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_EXPORT
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_EXPORT
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_blobs_export(void*_Nonnull ptr, void*_Nonnull hash, RustBuffer destination, RustBuffer format, RustBuffer mode
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_GET_COLLECTION
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_GET_COLLECTION
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_blobs_get_collection(void*_Nonnull ptr, void*_Nonnull hash
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_LIST
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_LIST
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_blobs_list(void*_Nonnull ptr
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_LIST_COLLECTIONS
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_LIST_COLLECTIONS
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_blobs_list_collections(void*_Nonnull ptr
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_LIST_INCOMPLETE
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_LIST_INCOMPLETE
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_blobs_list_incomplete(void*_Nonnull ptr
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_READ_AT_TO_BYTES
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_READ_AT_TO_BYTES
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_blobs_read_at_to_bytes(void*_Nonnull ptr, void*_Nonnull hash, uint64_t offset, RustBuffer len
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_READ_TO_BYTES
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_READ_TO_BYTES
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_blobs_read_to_bytes(void*_Nonnull ptr, void*_Nonnull hash
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_SHARE
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_SHARE
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_blobs_share(void*_Nonnull ptr, void*_Nonnull hash, RustBuffer blob_format, RustBuffer ticket_options
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_SIZE
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_SIZE
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_blobs_size(void*_Nonnull ptr, void*_Nonnull hash
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_WRITE_TO_PATH
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_BLOBS_WRITE_TO_PATH
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_blobs_write_to_path(void*_Nonnull ptr, void*_Nonnull hash, RustBuffer path
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_CONNECTION_INFO
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_CONNECTION_INFO
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_connection_info(void*_Nonnull ptr, void*_Nonnull node_id
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_CONNECTIONS
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_CONNECTIONS
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_connections(void*_Nonnull ptr
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_DOC_CREATE
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_DOC_CREATE
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_doc_create(void*_Nonnull ptr
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_DOC_DROP
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_DOC_DROP
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_doc_drop(void*_Nonnull ptr, RustBuffer doc_id
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_DOC_JOIN
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_DOC_JOIN
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_doc_join(void*_Nonnull ptr, RustBuffer ticket
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_DOC_JOIN_AND_SUBSCRIBE
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_DOC_JOIN_AND_SUBSCRIBE
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_doc_join_and_subscribe(void*_Nonnull ptr, RustBuffer ticket, void*_Nonnull cb
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_DOC_LIST
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_DOC_LIST
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_doc_list(void*_Nonnull ptr
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_DOC_OPEN
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_DOC_OPEN
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_doc_open(void*_Nonnull ptr, RustBuffer id
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_GOSSIP_SUBSCRIBE
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_GOSSIP_SUBSCRIBE
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_gossip_subscribe(void*_Nonnull ptr, RustBuffer topic, RustBuffer bootstrap, void*_Nonnull cb
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_HOME_RELAY
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_HOME_RELAY
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_home_relay(void*_Nonnull ptr
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_MY_RPC_ADDR
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_MY_RPC_ADDR
-RustBuffer uniffi_iroh_ffi_fn_method_irohnode_my_rpc_addr(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_NODE_ADDR
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_NODE_ADDR
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_node_addr(void*_Nonnull ptr
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_NODE_ID
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_NODE_ID
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_node_id(void*_Nonnull ptr
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_SHUTDOWN
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_SHUTDOWN
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_shutdown(void*_Nonnull ptr, int8_t force
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_STATS
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_STATS
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_stats(void*_Nonnull ptr
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_STATUS
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_STATUS
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_status(void*_Nonnull ptr
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_TAGS_DELETE
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_TAGS_DELETE
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_tags_delete(void*_Nonnull ptr, RustBuffer name
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_TAGS_LIST
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_IROHNODE_TAGS_LIST
-uint64_t uniffi_iroh_ffi_fn_method_irohnode_tags_list(void*_Nonnull ptr
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_LIVEEVENT
@@ -1387,6 +1402,66 @@ RustBuffer uniffi_iroh_ffi_fn_method_message_as_received(void*_Nonnull ptr, Rust
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_MESSAGE_TYPE
 #define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_MESSAGE_TYPE
 RustBuffer uniffi_iroh_ffi_fn_method_message_type(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_NODE
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_NODE
+void*_Nonnull uniffi_iroh_ffi_fn_clone_node(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_FREE_NODE
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_FREE_NODE
+void uniffi_iroh_ffi_fn_free_node(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_NODE_ADD_NODE_ADDR
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_NODE_ADD_NODE_ADDR
+uint64_t uniffi_iroh_ffi_fn_method_node_add_node_addr(void*_Nonnull ptr, void*_Nonnull addr
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_NODE_CONNECTION_INFO
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_NODE_CONNECTION_INFO
+uint64_t uniffi_iroh_ffi_fn_method_node_connection_info(void*_Nonnull ptr, void*_Nonnull node_id
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_NODE_CONNECTIONS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_NODE_CONNECTIONS
+uint64_t uniffi_iroh_ffi_fn_method_node_connections(void*_Nonnull ptr
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_NODE_HOME_RELAY
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_NODE_HOME_RELAY
+uint64_t uniffi_iroh_ffi_fn_method_node_home_relay(void*_Nonnull ptr
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_NODE_MY_RPC_ADDR
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_NODE_MY_RPC_ADDR
+RustBuffer uniffi_iroh_ffi_fn_method_node_my_rpc_addr(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_NODE_NODE_ADDR
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_NODE_NODE_ADDR
+uint64_t uniffi_iroh_ffi_fn_method_node_node_addr(void*_Nonnull ptr
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_NODE_NODE_ID
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_NODE_NODE_ID
+uint64_t uniffi_iroh_ffi_fn_method_node_node_id(void*_Nonnull ptr
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_NODE_SHUTDOWN
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_NODE_SHUTDOWN
+uint64_t uniffi_iroh_ffi_fn_method_node_shutdown(void*_Nonnull ptr, int8_t force
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_NODE_STATS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_NODE_STATS
+uint64_t uniffi_iroh_ffi_fn_method_node_stats(void*_Nonnull ptr
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_NODE_STATUS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_NODE_STATUS
+uint64_t uniffi_iroh_ffi_fn_method_node_status(void*_Nonnull ptr
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_NODEADDR
@@ -1633,6 +1708,26 @@ void uniffi_iroh_ffi_fn_init_callback_vtable_subscribecallback(UniffiVTableCallb
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_SUBSCRIBECALLBACK_EVENT
 #define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_SUBSCRIBECALLBACK_EVENT
 uint64_t uniffi_iroh_ffi_fn_method_subscribecallback_event(void*_Nonnull ptr, void*_Nonnull event
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_TAGS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_TAGS
+void*_Nonnull uniffi_iroh_ffi_fn_clone_tags(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_FREE_TAGS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_FREE_TAGS
+void uniffi_iroh_ffi_fn_free_tags(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_TAGS_DELETE
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_TAGS_DELETE
+uint64_t uniffi_iroh_ffi_fn_method_tags_delete(void*_Nonnull ptr, RustBuffer name
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_TAGS_LIST
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_TAGS_LIST
+uint64_t uniffi_iroh_ffi_fn_method_tags_list(void*_Nonnull ptr
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_WRAPOPTION
@@ -2035,6 +2130,48 @@ uint16_t uniffi_iroh_ffi_checksum_method_authorid_equal(void
     
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_AUTHORS_CREATE
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_AUTHORS_CREATE
+uint16_t uniffi_iroh_ffi_checksum_method_authors_create(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_AUTHORS_DEFAULT
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_AUTHORS_DEFAULT
+uint16_t uniffi_iroh_ffi_checksum_method_authors_default(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_AUTHORS_DELETE
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_AUTHORS_DELETE
+uint16_t uniffi_iroh_ffi_checksum_method_authors_delete(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_AUTHORS_EXPORT
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_AUTHORS_EXPORT
+uint16_t uniffi_iroh_ffi_checksum_method_authors_export(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_AUTHORS_IMPORT
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_AUTHORS_IMPORT
+uint16_t uniffi_iroh_ffi_checksum_method_authors_import(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_AUTHORS_IMPORT_AUTHOR
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_AUTHORS_IMPORT_AUTHOR
+uint16_t uniffi_iroh_ffi_checksum_method_authors_import_author(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_AUTHORS_LIST
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_AUTHORS_LIST
+uint16_t uniffi_iroh_ffi_checksum_method_authors_list(void
+    
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBTICKET_AS_DOWNLOAD_OPTIONS
 #define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBTICKET_AS_DOWNLOAD_OPTIONS
 uint16_t uniffi_iroh_ffi_checksum_method_blobticket_as_download_options(void
@@ -2062,6 +2199,102 @@ uint16_t uniffi_iroh_ffi_checksum_method_blobticket_node_addr(void
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBTICKET_RECURSIVE
 #define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBTICKET_RECURSIVE
 uint16_t uniffi_iroh_ffi_checksum_method_blobticket_recursive(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_ADD_BYTES
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_ADD_BYTES
+uint16_t uniffi_iroh_ffi_checksum_method_blobs_add_bytes(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_ADD_BYTES_NAMED
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_ADD_BYTES_NAMED
+uint16_t uniffi_iroh_ffi_checksum_method_blobs_add_bytes_named(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_ADD_FROM_PATH
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_ADD_FROM_PATH
+uint16_t uniffi_iroh_ffi_checksum_method_blobs_add_from_path(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_CREATE_COLLECTION
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_CREATE_COLLECTION
+uint16_t uniffi_iroh_ffi_checksum_method_blobs_create_collection(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_DELETE_BLOB
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_DELETE_BLOB
+uint16_t uniffi_iroh_ffi_checksum_method_blobs_delete_blob(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_DOWNLOAD
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_DOWNLOAD
+uint16_t uniffi_iroh_ffi_checksum_method_blobs_download(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_EXPORT
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_EXPORT
+uint16_t uniffi_iroh_ffi_checksum_method_blobs_export(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_GET_COLLECTION
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_GET_COLLECTION
+uint16_t uniffi_iroh_ffi_checksum_method_blobs_get_collection(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_LIST
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_LIST
+uint16_t uniffi_iroh_ffi_checksum_method_blobs_list(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_LIST_COLLECTIONS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_LIST_COLLECTIONS
+uint16_t uniffi_iroh_ffi_checksum_method_blobs_list_collections(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_LIST_INCOMPLETE
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_LIST_INCOMPLETE
+uint16_t uniffi_iroh_ffi_checksum_method_blobs_list_incomplete(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_READ_AT_TO_BYTES
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_READ_AT_TO_BYTES
+uint16_t uniffi_iroh_ffi_checksum_method_blobs_read_at_to_bytes(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_READ_TO_BYTES
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_READ_TO_BYTES
+uint16_t uniffi_iroh_ffi_checksum_method_blobs_read_to_bytes(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_SHARE
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_SHARE
+uint16_t uniffi_iroh_ffi_checksum_method_blobs_share(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_SIZE
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_SIZE
+uint16_t uniffi_iroh_ffi_checksum_method_blobs_size(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_WRITE_TO_PATH
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_BLOBS_WRITE_TO_PATH
+uint16_t uniffi_iroh_ffi_checksum_method_blobs_write_to_path(void
     
 );
 #endif
@@ -2155,9 +2388,9 @@ uint16_t uniffi_iroh_ffi_checksum_method_doc_close_me(void
     
 );
 #endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_DOC_DEL
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_DOC_DEL
-uint16_t uniffi_iroh_ffi_checksum_method_doc_del(void
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_DOC_DELETE_ENTRY
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_DOC_DELETE_ENTRY
+uint16_t uniffi_iroh_ffi_checksum_method_doc_delete_entry(void
     
 );
 #endif
@@ -2329,6 +2562,42 @@ uint16_t uniffi_iroh_ffi_checksum_method_docimportprogress_type(void
     
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_DOCS_CREATE
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_DOCS_CREATE
+uint16_t uniffi_iroh_ffi_checksum_method_docs_create(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_DOCS_DROP_DOC
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_DOCS_DROP_DOC
+uint16_t uniffi_iroh_ffi_checksum_method_docs_drop_doc(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_DOCS_JOIN
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_DOCS_JOIN
+uint16_t uniffi_iroh_ffi_checksum_method_docs_join(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_DOCS_JOIN_AND_SUBSCRIBE
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_DOCS_JOIN_AND_SUBSCRIBE
+uint16_t uniffi_iroh_ffi_checksum_method_docs_join_and_subscribe(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_DOCS_LIST
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_DOCS_LIST
+uint16_t uniffi_iroh_ffi_checksum_method_docs_list(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_DOCS_OPEN
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_DOCS_OPEN
+uint16_t uniffi_iroh_ffi_checksum_method_docs_open(void
+    
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_DOWNLOADCALLBACK_PROGRESS
 #define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_DOWNLOADCALLBACK_PROGRESS
 uint16_t uniffi_iroh_ffi_checksum_method_downloadcallback_progress(void
@@ -2431,6 +2700,12 @@ uint16_t uniffi_iroh_ffi_checksum_method_filterkind_matches(void
     
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_GOSSIP_SUBSCRIBE
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_GOSSIP_SUBSCRIBE
+uint16_t uniffi_iroh_ffi_checksum_method_gossip_subscribe(void
+    
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_GOSSIPMESSAGECALLBACK_ON_MESSAGE
 #define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_GOSSIPMESSAGECALLBACK_ON_MESSAGE
 uint16_t uniffi_iroh_ffi_checksum_method_gossipmessagecallback_on_message(void
@@ -2455,255 +2730,45 @@ uint16_t uniffi_iroh_ffi_checksum_method_hash_to_hex(void
     
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROH_AUTHORS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROH_AUTHORS
+uint16_t uniffi_iroh_ffi_checksum_method_iroh_authors(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROH_BLOBS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROH_BLOBS
+uint16_t uniffi_iroh_ffi_checksum_method_iroh_blobs(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROH_DOCS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROH_DOCS
+uint16_t uniffi_iroh_ffi_checksum_method_iroh_docs(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROH_GOSSIP
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROH_GOSSIP
+uint16_t uniffi_iroh_ffi_checksum_method_iroh_gossip(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROH_NODE
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROH_NODE
+uint16_t uniffi_iroh_ffi_checksum_method_iroh_node(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROH_TAGS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROH_TAGS
+uint16_t uniffi_iroh_ffi_checksum_method_iroh_tags(void
+    
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHERROR_MESSAGE
 #define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHERROR_MESSAGE
 uint16_t uniffi_iroh_ffi_checksum_method_iroherror_message(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_ADD_NODE_ADDR
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_ADD_NODE_ADDR
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_add_node_addr(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_AUTHOR_CREATE
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_AUTHOR_CREATE
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_author_create(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_AUTHOR_DEFAULT
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_AUTHOR_DEFAULT
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_author_default(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_AUTHOR_DELETE
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_AUTHOR_DELETE
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_author_delete(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_AUTHOR_EXPORT
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_AUTHOR_EXPORT
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_author_export(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_AUTHOR_IMPORT
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_AUTHOR_IMPORT
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_author_import(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_AUTHOR_LIST
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_AUTHOR_LIST
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_author_list(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_ADD_BYTES
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_ADD_BYTES
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_blobs_add_bytes(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_ADD_BYTES_NAMED
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_ADD_BYTES_NAMED
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_blobs_add_bytes_named(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_ADD_FROM_PATH
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_ADD_FROM_PATH
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_blobs_add_from_path(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_CREATE_COLLECTION
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_CREATE_COLLECTION
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_blobs_create_collection(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_DELETE_BLOB
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_DELETE_BLOB
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_blobs_delete_blob(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_DOWNLOAD
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_DOWNLOAD
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_blobs_download(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_EXPORT
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_EXPORT
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_blobs_export(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_GET_COLLECTION
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_GET_COLLECTION
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_blobs_get_collection(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_LIST
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_LIST
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_blobs_list(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_LIST_COLLECTIONS
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_LIST_COLLECTIONS
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_blobs_list_collections(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_LIST_INCOMPLETE
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_LIST_INCOMPLETE
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_blobs_list_incomplete(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_READ_AT_TO_BYTES
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_READ_AT_TO_BYTES
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_blobs_read_at_to_bytes(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_READ_TO_BYTES
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_READ_TO_BYTES
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_blobs_read_to_bytes(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_SHARE
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_SHARE
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_blobs_share(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_SIZE
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_SIZE
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_blobs_size(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_WRITE_TO_PATH
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_BLOBS_WRITE_TO_PATH
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_blobs_write_to_path(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_CONNECTION_INFO
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_CONNECTION_INFO
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_connection_info(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_CONNECTIONS
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_CONNECTIONS
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_connections(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_DOC_CREATE
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_DOC_CREATE
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_doc_create(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_DOC_DROP
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_DOC_DROP
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_doc_drop(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_DOC_JOIN
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_DOC_JOIN
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_doc_join(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_DOC_JOIN_AND_SUBSCRIBE
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_DOC_JOIN_AND_SUBSCRIBE
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_doc_join_and_subscribe(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_DOC_LIST
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_DOC_LIST
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_doc_list(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_DOC_OPEN
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_DOC_OPEN
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_doc_open(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_GOSSIP_SUBSCRIBE
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_GOSSIP_SUBSCRIBE
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_gossip_subscribe(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_HOME_RELAY
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_HOME_RELAY
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_home_relay(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_MY_RPC_ADDR
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_MY_RPC_ADDR
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_my_rpc_addr(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_NODE_ADDR
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_NODE_ADDR
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_node_addr(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_NODE_ID
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_NODE_ID
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_node_id(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_SHUTDOWN
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_SHUTDOWN
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_shutdown(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_STATS
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_STATS
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_stats(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_STATUS
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_STATUS
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_status(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_TAGS_DELETE
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_TAGS_DELETE
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_tags_delete(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_TAGS_LIST
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_IROHNODE_TAGS_LIST
-uint16_t uniffi_iroh_ffi_checksum_method_irohnode_tags_list(void
     
 );
 #endif
@@ -2776,6 +2841,66 @@ uint16_t uniffi_iroh_ffi_checksum_method_message_as_received(void
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_MESSAGE_TYPE
 #define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_MESSAGE_TYPE
 uint16_t uniffi_iroh_ffi_checksum_method_message_type(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_NODE_ADD_NODE_ADDR
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_NODE_ADD_NODE_ADDR
+uint16_t uniffi_iroh_ffi_checksum_method_node_add_node_addr(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_NODE_CONNECTION_INFO
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_NODE_CONNECTION_INFO
+uint16_t uniffi_iroh_ffi_checksum_method_node_connection_info(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_NODE_CONNECTIONS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_NODE_CONNECTIONS
+uint16_t uniffi_iroh_ffi_checksum_method_node_connections(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_NODE_HOME_RELAY
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_NODE_HOME_RELAY
+uint16_t uniffi_iroh_ffi_checksum_method_node_home_relay(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_NODE_MY_RPC_ADDR
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_NODE_MY_RPC_ADDR
+uint16_t uniffi_iroh_ffi_checksum_method_node_my_rpc_addr(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_NODE_NODE_ADDR
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_NODE_NODE_ADDR
+uint16_t uniffi_iroh_ffi_checksum_method_node_node_addr(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_NODE_NODE_ID
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_NODE_NODE_ID
+uint16_t uniffi_iroh_ffi_checksum_method_node_node_id(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_NODE_SHUTDOWN
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_NODE_SHUTDOWN
+uint16_t uniffi_iroh_ffi_checksum_method_node_shutdown(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_NODE_STATS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_NODE_STATS
+uint16_t uniffi_iroh_ffi_checksum_method_node_stats(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_NODE_STATUS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_NODE_STATUS
+uint16_t uniffi_iroh_ffi_checksum_method_node_status(void
     
 );
 #endif
@@ -2881,6 +3006,18 @@ uint16_t uniffi_iroh_ffi_checksum_method_subscribecallback_event(void
     
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_TAGS_DELETE
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_TAGS_DELETE
+uint16_t uniffi_iroh_ffi_checksum_method_tags_delete(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_TAGS_LIST
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_TAGS_LIST
+uint16_t uniffi_iroh_ffi_checksum_method_tags_list(void
+    
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_CONSTRUCTOR_AUTHOR_FROM_STRING
 #define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_CONSTRUCTOR_AUTHOR_FROM_STRING
 uint16_t uniffi_iroh_ffi_checksum_constructor_author_from_string(void
@@ -2965,27 +3102,27 @@ uint16_t uniffi_iroh_ffi_checksum_constructor_hash_new(void
     
 );
 #endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_CONSTRUCTOR_IROHNODE_MEMORY
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_CONSTRUCTOR_IROHNODE_MEMORY
-uint16_t uniffi_iroh_ffi_checksum_constructor_irohnode_memory(void
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_CONSTRUCTOR_IROH_MEMORY
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_CONSTRUCTOR_IROH_MEMORY
+uint16_t uniffi_iroh_ffi_checksum_constructor_iroh_memory(void
     
 );
 #endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_CONSTRUCTOR_IROHNODE_MEMORY_WITH_OPTIONS
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_CONSTRUCTOR_IROHNODE_MEMORY_WITH_OPTIONS
-uint16_t uniffi_iroh_ffi_checksum_constructor_irohnode_memory_with_options(void
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_CONSTRUCTOR_IROH_MEMORY_WITH_OPTIONS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_CONSTRUCTOR_IROH_MEMORY_WITH_OPTIONS
+uint16_t uniffi_iroh_ffi_checksum_constructor_iroh_memory_with_options(void
     
 );
 #endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_CONSTRUCTOR_IROHNODE_PERSISTENT
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_CONSTRUCTOR_IROHNODE_PERSISTENT
-uint16_t uniffi_iroh_ffi_checksum_constructor_irohnode_persistent(void
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_CONSTRUCTOR_IROH_PERSISTENT
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_CONSTRUCTOR_IROH_PERSISTENT
+uint16_t uniffi_iroh_ffi_checksum_constructor_iroh_persistent(void
     
 );
 #endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_CONSTRUCTOR_IROHNODE_PERSISTENT_WITH_OPTIONS
-#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_CONSTRUCTOR_IROHNODE_PERSISTENT_WITH_OPTIONS
-uint16_t uniffi_iroh_ffi_checksum_constructor_irohnode_persistent_with_options(void
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_CONSTRUCTOR_IROH_PERSISTENT_WITH_OPTIONS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_CONSTRUCTOR_IROH_PERSISTENT_WITH_OPTIONS
+uint16_t uniffi_iroh_ffi_checksum_constructor_iroh_persistent_with_options(void
     
 );
 #endif

--- a/IrohLib/Sources/IrohLib/IrohLib.swift
+++ b/IrohLib/Sources/IrohLib/IrohLib.swift
@@ -1142,6 +1142,303 @@ public func FfiConverterTypeAuthorId_lower(_ value: AuthorId) -> UnsafeMutableRa
 }
 
 /**
+ * Iroh authors client.
+ */
+public protocol AuthorsProtocol: AnyObject {
+    /**
+     * Create a new document author.
+     *
+     * You likely want to save the returned [`AuthorId`] somewhere so that you can use this author
+     * again.
+     *
+     * If you need only a single author, use [`Self::default`].
+     */
+    func create() async throws -> AuthorId
+
+    /**
+     * Returns the default document author of this node.
+     *
+     * On persistent nodes, the author is created on first start and its public key is saved
+     * in the data directory.
+     *
+     * The default author can be set with [`Self::set_default`].
+     */
+    func `default`() async throws -> AuthorId
+
+    /**
+     * Deletes the given author by id.
+     *
+     * Warning: This permanently removes this author.
+     */
+    func delete(author: AuthorId) async throws
+
+    /**
+     * Export the given author.
+     *
+     * Warning: This contains sensitive data.
+     */
+    func export(author: AuthorId) async throws -> Author
+
+    /**
+     * Import the given author.
+     *
+     * Warning: This contains sensitive data.
+     */
+    func `import`(author: Author) async throws -> AuthorId
+
+    /**
+     * Import the given author.
+     *
+     * Warning: This contains sensitive data.
+     * `import` is reserved in python.
+     */
+    func importAuthor(author: Author) async throws -> AuthorId
+
+    /**
+     * List all the AuthorIds that exist on this node.
+     */
+    func list() async throws -> [AuthorId]
+}
+
+/**
+ * Iroh authors client.
+ */
+open class Authors:
+    AuthorsProtocol
+{
+    fileprivate let pointer: UnsafeMutableRawPointer!
+
+    /// Used to instantiate a [FFIObject] without an actual pointer, for fakes in tests, mostly.
+    public struct NoPointer {
+        public init() {}
+    }
+
+    // TODO: We'd like this to be `private` but for Swifty reasons,
+    // we can't implement `FfiConverter` without making this `required` and we can't
+    // make it `required` without making it `public`.
+    public required init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
+        self.pointer = pointer
+    }
+
+    /// This constructor can be used to instantiate a fake object.
+    /// - Parameter noPointer: Placeholder value so we can have a constructor separate from the default empty one that may be implemented for classes extending [FFIObject].
+    ///
+    /// - Warning:
+    ///     Any object instantiated with this constructor cannot be passed to an actual Rust-backed object. Since there isn't a backing [Pointer] the FFI lower functions will crash.
+    public init(noPointer _: NoPointer) {
+        pointer = nil
+    }
+
+    public func uniffiClonePointer() -> UnsafeMutableRawPointer {
+        return try! rustCall { uniffi_iroh_ffi_fn_clone_authors(self.pointer, $0) }
+    }
+
+    // No primary constructor declared for this class.
+
+    deinit {
+        guard let pointer = pointer else {
+            return
+        }
+
+        try! rustCall { uniffi_iroh_ffi_fn_free_authors(pointer, $0) }
+    }
+
+    /**
+     * Create a new document author.
+     *
+     * You likely want to save the returned [`AuthorId`] somewhere so that you can use this author
+     * again.
+     *
+     * If you need only a single author, use [`Self::default`].
+     */
+    open func create() async throws -> AuthorId {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_authors_create(
+                        self.uniffiClonePointer()
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_pointer,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_pointer,
+                freeFunc: ffi_iroh_ffi_rust_future_free_pointer,
+                liftFunc: FfiConverterTypeAuthorId.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
+    /**
+     * Returns the default document author of this node.
+     *
+     * On persistent nodes, the author is created on first start and its public key is saved
+     * in the data directory.
+     *
+     * The default author can be set with [`Self::set_default`].
+     */
+    open func `default`() async throws -> AuthorId {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_authors_default(
+                        self.uniffiClonePointer()
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_pointer,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_pointer,
+                freeFunc: ffi_iroh_ffi_rust_future_free_pointer,
+                liftFunc: FfiConverterTypeAuthorId.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
+    /**
+     * Deletes the given author by id.
+     *
+     * Warning: This permanently removes this author.
+     */
+    open func delete(author: AuthorId) async throws {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_authors_delete(
+                        self.uniffiClonePointer(),
+                        FfiConverterTypeAuthorId.lower(author)
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_void,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_void,
+                freeFunc: ffi_iroh_ffi_rust_future_free_void,
+                liftFunc: { $0 },
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
+    /**
+     * Export the given author.
+     *
+     * Warning: This contains sensitive data.
+     */
+    open func export(author: AuthorId) async throws -> Author {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_authors_export(
+                        self.uniffiClonePointer(),
+                        FfiConverterTypeAuthorId.lower(author)
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_pointer,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_pointer,
+                freeFunc: ffi_iroh_ffi_rust_future_free_pointer,
+                liftFunc: FfiConverterTypeAuthor.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
+    /**
+     * Import the given author.
+     *
+     * Warning: This contains sensitive data.
+     */
+    open func `import`(author: Author) async throws -> AuthorId {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_authors_import(
+                        self.uniffiClonePointer(),
+                        FfiConverterTypeAuthor.lower(author)
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_pointer,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_pointer,
+                freeFunc: ffi_iroh_ffi_rust_future_free_pointer,
+                liftFunc: FfiConverterTypeAuthorId.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
+    /**
+     * Import the given author.
+     *
+     * Warning: This contains sensitive data.
+     * `import` is reserved in python.
+     */
+    open func importAuthor(author: Author) async throws -> AuthorId {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_authors_import_author(
+                        self.uniffiClonePointer(),
+                        FfiConverterTypeAuthor.lower(author)
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_pointer,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_pointer,
+                freeFunc: ffi_iroh_ffi_rust_future_free_pointer,
+                liftFunc: FfiConverterTypeAuthorId.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
+    /**
+     * List all the AuthorIds that exist on this node.
+     */
+    open func list() async throws -> [AuthorId] {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_authors_list(
+                        self.uniffiClonePointer()
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
+                freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
+                liftFunc: FfiConverterSequenceTypeAuthorId.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+}
+
+public struct FfiConverterTypeAuthors: FfiConverter {
+    typealias FfiType = UnsafeMutableRawPointer
+    typealias SwiftType = Authors
+
+    public static func lift(_ pointer: UnsafeMutableRawPointer) throws -> Authors {
+        return Authors(unsafeFromRawPointer: pointer)
+    }
+
+    public static func lower(_ value: Authors) -> UnsafeMutableRawPointer {
+        return value.uniffiClonePointer()
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> Authors {
+        let v: UInt64 = try readInt(&buf)
+        // The Rust code won't compile if a pointer won't fit in a UInt64.
+        // We have to go via `UInt` because that's the thing that's the size of a pointer.
+        let ptr = UnsafeMutableRawPointer(bitPattern: UInt(truncatingIfNeeded: v))
+        if ptr == nil {
+            throw UniffiInternalError.unexpectedNullPointer
+        }
+        return try lift(ptr!)
+    }
+
+    public static func write(_ value: Authors, into buf: inout [UInt8]) {
+        // This fiddling is because `Int` is the thing that's the same size as a pointer.
+        // The Rust code won't compile if a pointer won't fit in a `UInt64`.
+        writeInt(&buf, UInt64(bitPattern: Int64(Int(bitPattern: lower(value)))))
+    }
+}
+
+public func FfiConverterTypeAuthors_lift(_ pointer: UnsafeMutableRawPointer) throws -> Authors {
+    return try FfiConverterTypeAuthors.lift(pointer)
+}
+
+public func FfiConverterTypeAuthors_lower(_ value: Authors) -> UnsafeMutableRawPointer {
+    return FfiConverterTypeAuthors.lower(value)
+}
+
+/**
  * Options to download  data specified by the hash.
  */
 public protocol BlobDownloadOptionsProtocol: AnyObject {}
@@ -1408,6 +1705,562 @@ public func FfiConverterTypeBlobTicket_lift(_ pointer: UnsafeMutableRawPointer) 
 
 public func FfiConverterTypeBlobTicket_lower(_ value: BlobTicket) -> UnsafeMutableRawPointer {
     return FfiConverterTypeBlobTicket.lower(value)
+}
+
+/**
+ * Iroh blobs client.
+ */
+public protocol BlobsProtocol: AnyObject {
+    /**
+     * Write a blob by passing bytes.
+     */
+    func addBytes(bytes: Data) async throws -> BlobAddOutcome
+
+    /**
+     * Write a blob by passing bytes, setting an explicit tag name.
+     */
+    func addBytesNamed(bytes: Data, name: String) async throws -> BlobAddOutcome
+
+    /**
+     * Import a blob from a filesystem path.
+     *
+     * `path` should be an absolute path valid for the file system on which
+     * the node runs.
+     * If `in_place` is true, Iroh will assume that the data will not change and will share it in
+     * place without copying to the Iroh data directory.
+     */
+    func addFromPath(path: String, inPlace: Bool, tag: SetTagOption, wrap: WrapOption, cb: AddCallback) async throws
+
+    /**
+     * Create a collection from already existing blobs.
+     *
+     * To automatically clear the tags for the passed in blobs you can set
+     * `tags_to_delete` on those tags, and they will be deleted once the collection is created.
+     */
+    func createCollection(collection: Collection, tag: SetTagOption, tagsToDelete: [String]) async throws -> HashAndTag
+
+    /**
+     * Delete a blob.
+     */
+    func deleteBlob(hash: Hash) async throws
+
+    /**
+     * Download a blob from another node and add it to the local database.
+     */
+    func download(hash: Hash, opts: BlobDownloadOptions, cb: DownloadCallback) async throws
+
+    /**
+     * Export a blob from the internal blob store to a path on the node's filesystem.
+     *
+     * `destination` should be a writeable, absolute path on the local node's filesystem.
+     *
+     * If `format` is set to [`ExportFormat::Collection`], and the `hash` refers to a collection,
+     * all children of the collection will be exported. See [`ExportFormat`] for details.
+     *
+     * The `mode` argument defines if the blob should be copied to the target location or moved out of
+     * the internal store into the target location. See [`ExportMode`] for details.
+     */
+    func export(hash: Hash, destination: String, format: BlobExportFormat, mode: BlobExportMode) async throws
+
+    /**
+     * Read the content of a collection
+     */
+    func getCollection(hash: Hash) async throws -> Collection
+
+    /**
+     * List all complete blobs.
+     *
+     * Note: this allocates for each `BlobListResponse`, if you have many `BlobListReponse`s this may be a prohibitively large list.
+     * Please file an [issue](https://github.com/n0-computer/iroh-ffi/issues/new) if you run into this issue
+     */
+    func list() async throws -> [Hash]
+
+    /**
+     * List all collections.
+     *
+     * Note: this allocates for each `BlobListCollectionsResponse`, if you have many `BlobListCollectionsResponse`s this may be a prohibitively large list.
+     * Please file an [issue](https://github.com/n0-computer/iroh-ffi/issues/new) if you run into this issue
+     */
+    func listCollections() async throws -> [CollectionInfo]
+
+    /**
+     * List all incomplete (partial) blobs.
+     *
+     * Note: this allocates for each `BlobListIncompleteResponse`, if you have many `BlobListIncompleteResponse`s this may be a prohibitively large list.
+     * Please file an [issue](https://github.com/n0-computer/iroh-ffi/issues/new) if you run into this issue
+     */
+    func listIncomplete() async throws -> [IncompleteBlobInfo]
+
+    /**
+     * Read all bytes of single blob at `offset` for length `len`.
+     *
+     * This allocates a buffer for the full length `len`. Use only if you know that the blob you're
+     * reading is small. If not sure, use [`Self::blobs_size`] and check the size with
+     * before calling [`Self::blobs_read_at_to_bytes`].
+     */
+    func readAtToBytes(hash: Hash, offset: UInt64, len: UInt64?) async throws -> Data
+
+    /**
+     * Read all bytes of single blob.
+     *
+     * This allocates a buffer for the full blob. Use only if you know that the blob you're
+     * reading is small. If not sure, use [`Self::blobs_size`] and check the size with
+     * before calling [`Self::blobs_read_to_bytes`].
+     */
+    func readToBytes(hash: Hash) async throws -> Data
+
+    /**
+     * Create a ticket for sharing a blob from this node.
+     */
+    func share(hash: Hash, blobFormat: BlobFormat, ticketOptions: AddrInfoOptions) async throws -> String
+
+    /**
+     * Get the size information on a single blob.
+     *
+     * Method only exists in FFI
+     */
+    func size(hash: Hash) async throws -> UInt64
+
+    /**
+     * Export the blob contents to a file path
+     * The `path` field is expected to be the absolute path.
+     */
+    func writeToPath(hash: Hash, path: String) async throws
+}
+
+/**
+ * Iroh blobs client.
+ */
+open class Blobs:
+    BlobsProtocol
+{
+    fileprivate let pointer: UnsafeMutableRawPointer!
+
+    /// Used to instantiate a [FFIObject] without an actual pointer, for fakes in tests, mostly.
+    public struct NoPointer {
+        public init() {}
+    }
+
+    // TODO: We'd like this to be `private` but for Swifty reasons,
+    // we can't implement `FfiConverter` without making this `required` and we can't
+    // make it `required` without making it `public`.
+    public required init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
+        self.pointer = pointer
+    }
+
+    /// This constructor can be used to instantiate a fake object.
+    /// - Parameter noPointer: Placeholder value so we can have a constructor separate from the default empty one that may be implemented for classes extending [FFIObject].
+    ///
+    /// - Warning:
+    ///     Any object instantiated with this constructor cannot be passed to an actual Rust-backed object. Since there isn't a backing [Pointer] the FFI lower functions will crash.
+    public init(noPointer _: NoPointer) {
+        pointer = nil
+    }
+
+    public func uniffiClonePointer() -> UnsafeMutableRawPointer {
+        return try! rustCall { uniffi_iroh_ffi_fn_clone_blobs(self.pointer, $0) }
+    }
+
+    // No primary constructor declared for this class.
+
+    deinit {
+        guard let pointer = pointer else {
+            return
+        }
+
+        try! rustCall { uniffi_iroh_ffi_fn_free_blobs(pointer, $0) }
+    }
+
+    /**
+     * Write a blob by passing bytes.
+     */
+    open func addBytes(bytes: Data) async throws -> BlobAddOutcome {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_blobs_add_bytes(
+                        self.uniffiClonePointer(),
+                        FfiConverterData.lower(bytes)
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
+                freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
+                liftFunc: FfiConverterTypeBlobAddOutcome.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
+    /**
+     * Write a blob by passing bytes, setting an explicit tag name.
+     */
+    open func addBytesNamed(bytes: Data, name: String) async throws -> BlobAddOutcome {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_blobs_add_bytes_named(
+                        self.uniffiClonePointer(),
+                        FfiConverterData.lower(bytes), FfiConverterString.lower(name)
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
+                freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
+                liftFunc: FfiConverterTypeBlobAddOutcome.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
+    /**
+     * Import a blob from a filesystem path.
+     *
+     * `path` should be an absolute path valid for the file system on which
+     * the node runs.
+     * If `in_place` is true, Iroh will assume that the data will not change and will share it in
+     * place without copying to the Iroh data directory.
+     */
+    open func addFromPath(path: String, inPlace: Bool, tag: SetTagOption, wrap: WrapOption, cb: AddCallback) async throws {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_blobs_add_from_path(
+                        self.uniffiClonePointer(),
+                        FfiConverterString.lower(path), FfiConverterBool.lower(inPlace), FfiConverterTypeSetTagOption.lower(tag), FfiConverterTypeWrapOption.lower(wrap), FfiConverterTypeAddCallback.lower(cb)
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_void,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_void,
+                freeFunc: ffi_iroh_ffi_rust_future_free_void,
+                liftFunc: { $0 },
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
+    /**
+     * Create a collection from already existing blobs.
+     *
+     * To automatically clear the tags for the passed in blobs you can set
+     * `tags_to_delete` on those tags, and they will be deleted once the collection is created.
+     */
+    open func createCollection(collection: Collection, tag: SetTagOption, tagsToDelete: [String]) async throws -> HashAndTag {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_blobs_create_collection(
+                        self.uniffiClonePointer(),
+                        FfiConverterTypeCollection.lower(collection), FfiConverterTypeSetTagOption.lower(tag), FfiConverterSequenceString.lower(tagsToDelete)
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
+                freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
+                liftFunc: FfiConverterTypeHashAndTag.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
+    /**
+     * Delete a blob.
+     */
+    open func deleteBlob(hash: Hash) async throws {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_blobs_delete_blob(
+                        self.uniffiClonePointer(),
+                        FfiConverterTypeHash.lower(hash)
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_void,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_void,
+                freeFunc: ffi_iroh_ffi_rust_future_free_void,
+                liftFunc: { $0 },
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
+    /**
+     * Download a blob from another node and add it to the local database.
+     */
+    open func download(hash: Hash, opts: BlobDownloadOptions, cb: DownloadCallback) async throws {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_blobs_download(
+                        self.uniffiClonePointer(),
+                        FfiConverterTypeHash.lower(hash), FfiConverterTypeBlobDownloadOptions.lower(opts), FfiConverterTypeDownloadCallback.lower(cb)
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_void,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_void,
+                freeFunc: ffi_iroh_ffi_rust_future_free_void,
+                liftFunc: { $0 },
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
+    /**
+     * Export a blob from the internal blob store to a path on the node's filesystem.
+     *
+     * `destination` should be a writeable, absolute path on the local node's filesystem.
+     *
+     * If `format` is set to [`ExportFormat::Collection`], and the `hash` refers to a collection,
+     * all children of the collection will be exported. See [`ExportFormat`] for details.
+     *
+     * The `mode` argument defines if the blob should be copied to the target location or moved out of
+     * the internal store into the target location. See [`ExportMode`] for details.
+     */
+    open func export(hash: Hash, destination: String, format: BlobExportFormat, mode: BlobExportMode) async throws {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_blobs_export(
+                        self.uniffiClonePointer(),
+                        FfiConverterTypeHash.lower(hash), FfiConverterString.lower(destination), FfiConverterTypeBlobExportFormat.lower(format), FfiConverterTypeBlobExportMode.lower(mode)
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_void,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_void,
+                freeFunc: ffi_iroh_ffi_rust_future_free_void,
+                liftFunc: { $0 },
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
+    /**
+     * Read the content of a collection
+     */
+    open func getCollection(hash: Hash) async throws -> Collection {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_blobs_get_collection(
+                        self.uniffiClonePointer(),
+                        FfiConverterTypeHash.lower(hash)
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_pointer,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_pointer,
+                freeFunc: ffi_iroh_ffi_rust_future_free_pointer,
+                liftFunc: FfiConverterTypeCollection.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
+    /**
+     * List all complete blobs.
+     *
+     * Note: this allocates for each `BlobListResponse`, if you have many `BlobListReponse`s this may be a prohibitively large list.
+     * Please file an [issue](https://github.com/n0-computer/iroh-ffi/issues/new) if you run into this issue
+     */
+    open func list() async throws -> [Hash] {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_blobs_list(
+                        self.uniffiClonePointer()
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
+                freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
+                liftFunc: FfiConverterSequenceTypeHash.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
+    /**
+     * List all collections.
+     *
+     * Note: this allocates for each `BlobListCollectionsResponse`, if you have many `BlobListCollectionsResponse`s this may be a prohibitively large list.
+     * Please file an [issue](https://github.com/n0-computer/iroh-ffi/issues/new) if you run into this issue
+     */
+    open func listCollections() async throws -> [CollectionInfo] {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_blobs_list_collections(
+                        self.uniffiClonePointer()
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
+                freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
+                liftFunc: FfiConverterSequenceTypeCollectionInfo.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
+    /**
+     * List all incomplete (partial) blobs.
+     *
+     * Note: this allocates for each `BlobListIncompleteResponse`, if you have many `BlobListIncompleteResponse`s this may be a prohibitively large list.
+     * Please file an [issue](https://github.com/n0-computer/iroh-ffi/issues/new) if you run into this issue
+     */
+    open func listIncomplete() async throws -> [IncompleteBlobInfo] {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_blobs_list_incomplete(
+                        self.uniffiClonePointer()
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
+                freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
+                liftFunc: FfiConverterSequenceTypeIncompleteBlobInfo.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
+    /**
+     * Read all bytes of single blob at `offset` for length `len`.
+     *
+     * This allocates a buffer for the full length `len`. Use only if you know that the blob you're
+     * reading is small. If not sure, use [`Self::blobs_size`] and check the size with
+     * before calling [`Self::blobs_read_at_to_bytes`].
+     */
+    open func readAtToBytes(hash: Hash, offset: UInt64, len: UInt64?) async throws -> Data {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_blobs_read_at_to_bytes(
+                        self.uniffiClonePointer(),
+                        FfiConverterTypeHash.lower(hash), FfiConverterUInt64.lower(offset), FfiConverterOptionUInt64.lower(len)
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
+                freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
+                liftFunc: FfiConverterData.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
+    /**
+     * Read all bytes of single blob.
+     *
+     * This allocates a buffer for the full blob. Use only if you know that the blob you're
+     * reading is small. If not sure, use [`Self::blobs_size`] and check the size with
+     * before calling [`Self::blobs_read_to_bytes`].
+     */
+    open func readToBytes(hash: Hash) async throws -> Data {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_blobs_read_to_bytes(
+                        self.uniffiClonePointer(),
+                        FfiConverterTypeHash.lower(hash)
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
+                freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
+                liftFunc: FfiConverterData.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
+    /**
+     * Create a ticket for sharing a blob from this node.
+     */
+    open func share(hash: Hash, blobFormat: BlobFormat, ticketOptions: AddrInfoOptions) async throws -> String {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_blobs_share(
+                        self.uniffiClonePointer(),
+                        FfiConverterTypeHash.lower(hash), FfiConverterTypeBlobFormat.lower(blobFormat), FfiConverterTypeAddrInfoOptions.lower(ticketOptions)
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
+                freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
+                liftFunc: FfiConverterString.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
+    /**
+     * Get the size information on a single blob.
+     *
+     * Method only exists in FFI
+     */
+    open func size(hash: Hash) async throws -> UInt64 {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_blobs_size(
+                        self.uniffiClonePointer(),
+                        FfiConverterTypeHash.lower(hash)
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_u64,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_u64,
+                freeFunc: ffi_iroh_ffi_rust_future_free_u64,
+                liftFunc: FfiConverterUInt64.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
+    /**
+     * Export the blob contents to a file path
+     * The `path` field is expected to be the absolute path.
+     */
+    open func writeToPath(hash: Hash, path: String) async throws {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_blobs_write_to_path(
+                        self.uniffiClonePointer(),
+                        FfiConverterTypeHash.lower(hash), FfiConverterString.lower(path)
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_void,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_void,
+                freeFunc: ffi_iroh_ffi_rust_future_free_void,
+                liftFunc: { $0 },
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+}
+
+public struct FfiConverterTypeBlobs: FfiConverter {
+    typealias FfiType = UnsafeMutableRawPointer
+    typealias SwiftType = Blobs
+
+    public static func lift(_ pointer: UnsafeMutableRawPointer) throws -> Blobs {
+        return Blobs(unsafeFromRawPointer: pointer)
+    }
+
+    public static func lower(_ value: Blobs) -> UnsafeMutableRawPointer {
+        return value.uniffiClonePointer()
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> Blobs {
+        let v: UInt64 = try readInt(&buf)
+        // The Rust code won't compile if a pointer won't fit in a UInt64.
+        // We have to go via `UInt` because that's the thing that's the size of a pointer.
+        let ptr = UnsafeMutableRawPointer(bitPattern: UInt(truncatingIfNeeded: v))
+        if ptr == nil {
+            throw UniffiInternalError.unexpectedNullPointer
+        }
+        return try lift(ptr!)
+    }
+
+    public static func write(_ value: Blobs, into buf: inout [UInt8]) {
+        // This fiddling is because `Int` is the thing that's the same size as a pointer.
+        // The Rust code won't compile if a pointer won't fit in a `UInt64`.
+        writeInt(&buf, UInt64(bitPattern: Int64(Int(bitPattern: lower(value)))))
+    }
+}
+
+public func FfiConverterTypeBlobs_lift(_ pointer: UnsafeMutableRawPointer) throws -> Blobs {
+    return try FfiConverterTypeBlobs.lift(pointer)
+}
+
+public func FfiConverterTypeBlobs_lower(_ value: Blobs) -> UnsafeMutableRawPointer {
+    return FfiConverterTypeBlobs.lower(value)
 }
 
 /**
@@ -1895,7 +2748,7 @@ public protocol DocProtocol: AnyObject {
      *
      * Returns the number of entries deleted.
      */
-    func del(authorId: AuthorId, prefix: Data) async throws -> UInt64
+    func deleteEntry(authorId: AuthorId, prefix: Data) async throws -> UInt64
 
     /**
      * Export an entry as a file to a given absolute path
@@ -2051,11 +2904,11 @@ open class Doc:
      *
      * Returns the number of entries deleted.
      */
-    open func del(authorId: AuthorId, prefix: Data) async throws -> UInt64 {
+    open func deleteEntry(authorId: AuthorId, prefix: Data) async throws -> UInt64 {
         return
             try await uniffiRustCallAsync(
                 rustFutureFunc: {
-                    uniffi_iroh_ffi_fn_method_doc_del(
+                    uniffi_iroh_ffi_fn_method_doc_delete_entry(
                         self.uniffiClonePointer(),
                         FfiConverterTypeAuthorId.lower(authorId), FfiConverterData.lower(prefix)
                     )
@@ -3078,6 +3931,253 @@ public func FfiConverterTypeDocImportProgress_lower(_ value: DocImportProgress) 
 }
 
 /**
+ * Iroh docs client.
+ */
+public protocol DocsProtocol: AnyObject {
+    /**
+     * Create a new doc.
+     */
+    func create() async throws -> Doc
+
+    /**
+     * Delete a document from the local node.
+     *
+     * This is a destructive operation. Both the document secret key and all entries in the
+     * document will be permanently deleted from the node's storage. Content blobs will be deleted
+     * through garbage collection unless they are referenced from another document or tag.
+     */
+    func dropDoc(docId: String) async throws
+
+    /**
+     * Join and sync with an already existing document.
+     */
+    func join(ticket: String) async throws -> Doc
+
+    /**
+     * Join and sync with an already existing document and subscribe to events on that document.
+     */
+    func joinAndSubscribe(ticket: String, cb: SubscribeCallback) async throws -> Doc
+
+    /**
+     * List all the docs we have access to on this node.
+     */
+    func list() async throws -> [NamespaceAndCapability]
+
+    /**
+     * Get a [`Doc`].
+     *
+     * Returns None if the document cannot be found.
+     */
+    func open(id: String) async throws -> Doc?
+}
+
+/**
+ * Iroh docs client.
+ */
+open class Docs:
+    DocsProtocol
+{
+    fileprivate let pointer: UnsafeMutableRawPointer!
+
+    /// Used to instantiate a [FFIObject] without an actual pointer, for fakes in tests, mostly.
+    public struct NoPointer {
+        public init() {}
+    }
+
+    // TODO: We'd like this to be `private` but for Swifty reasons,
+    // we can't implement `FfiConverter` without making this `required` and we can't
+    // make it `required` without making it `public`.
+    public required init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
+        self.pointer = pointer
+    }
+
+    /// This constructor can be used to instantiate a fake object.
+    /// - Parameter noPointer: Placeholder value so we can have a constructor separate from the default empty one that may be implemented for classes extending [FFIObject].
+    ///
+    /// - Warning:
+    ///     Any object instantiated with this constructor cannot be passed to an actual Rust-backed object. Since there isn't a backing [Pointer] the FFI lower functions will crash.
+    public init(noPointer _: NoPointer) {
+        pointer = nil
+    }
+
+    public func uniffiClonePointer() -> UnsafeMutableRawPointer {
+        return try! rustCall { uniffi_iroh_ffi_fn_clone_docs(self.pointer, $0) }
+    }
+
+    // No primary constructor declared for this class.
+
+    deinit {
+        guard let pointer = pointer else {
+            return
+        }
+
+        try! rustCall { uniffi_iroh_ffi_fn_free_docs(pointer, $0) }
+    }
+
+    /**
+     * Create a new doc.
+     */
+    open func create() async throws -> Doc {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_docs_create(
+                        self.uniffiClonePointer()
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_pointer,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_pointer,
+                freeFunc: ffi_iroh_ffi_rust_future_free_pointer,
+                liftFunc: FfiConverterTypeDoc.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
+    /**
+     * Delete a document from the local node.
+     *
+     * This is a destructive operation. Both the document secret key and all entries in the
+     * document will be permanently deleted from the node's storage. Content blobs will be deleted
+     * through garbage collection unless they are referenced from another document or tag.
+     */
+    open func dropDoc(docId: String) async throws {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_docs_drop_doc(
+                        self.uniffiClonePointer(),
+                        FfiConverterString.lower(docId)
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_void,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_void,
+                freeFunc: ffi_iroh_ffi_rust_future_free_void,
+                liftFunc: { $0 },
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
+    /**
+     * Join and sync with an already existing document.
+     */
+    open func join(ticket: String) async throws -> Doc {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_docs_join(
+                        self.uniffiClonePointer(),
+                        FfiConverterString.lower(ticket)
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_pointer,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_pointer,
+                freeFunc: ffi_iroh_ffi_rust_future_free_pointer,
+                liftFunc: FfiConverterTypeDoc.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
+    /**
+     * Join and sync with an already existing document and subscribe to events on that document.
+     */
+    open func joinAndSubscribe(ticket: String, cb: SubscribeCallback) async throws -> Doc {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_docs_join_and_subscribe(
+                        self.uniffiClonePointer(),
+                        FfiConverterString.lower(ticket), FfiConverterTypeSubscribeCallback.lower(cb)
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_pointer,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_pointer,
+                freeFunc: ffi_iroh_ffi_rust_future_free_pointer,
+                liftFunc: FfiConverterTypeDoc.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
+    /**
+     * List all the docs we have access to on this node.
+     */
+    open func list() async throws -> [NamespaceAndCapability] {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_docs_list(
+                        self.uniffiClonePointer()
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
+                freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
+                liftFunc: FfiConverterSequenceTypeNamespaceAndCapability.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
+    /**
+     * Get a [`Doc`].
+     *
+     * Returns None if the document cannot be found.
+     */
+    open func open(id: String) async throws -> Doc? {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_docs_open(
+                        self.uniffiClonePointer(),
+                        FfiConverterString.lower(id)
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
+                freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
+                liftFunc: FfiConverterOptionTypeDoc.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+}
+
+public struct FfiConverterTypeDocs: FfiConverter {
+    typealias FfiType = UnsafeMutableRawPointer
+    typealias SwiftType = Docs
+
+    public static func lift(_ pointer: UnsafeMutableRawPointer) throws -> Docs {
+        return Docs(unsafeFromRawPointer: pointer)
+    }
+
+    public static func lower(_ value: Docs) -> UnsafeMutableRawPointer {
+        return value.uniffiClonePointer()
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> Docs {
+        let v: UInt64 = try readInt(&buf)
+        // The Rust code won't compile if a pointer won't fit in a UInt64.
+        // We have to go via `UInt` because that's the thing that's the size of a pointer.
+        let ptr = UnsafeMutableRawPointer(bitPattern: UInt(truncatingIfNeeded: v))
+        if ptr == nil {
+            throw UniffiInternalError.unexpectedNullPointer
+        }
+        return try lift(ptr!)
+    }
+
+    public static func write(_ value: Docs, into buf: inout [UInt8]) {
+        // This fiddling is because `Int` is the thing that's the same size as a pointer.
+        // The Rust code won't compile if a pointer won't fit in a `UInt64`.
+        writeInt(&buf, UInt64(bitPattern: Int64(Int(bitPattern: lower(value)))))
+    }
+}
+
+public func FfiConverterTypeDocs_lift(_ pointer: UnsafeMutableRawPointer) throws -> Docs {
+    return try FfiConverterTypeDocs.lift(pointer)
+}
+
+public func FfiConverterTypeDocs_lower(_ value: Docs) -> UnsafeMutableRawPointer {
+    return FfiConverterTypeDocs.lower(value)
+}
+
+/**
  * The `progress` method will be called for each `DownloadProgress` event that is emitted during
  * a `node.blobs_download`. Use the `DownloadProgress.type()` method to check the
  * `DownloadProgressType` of the event.
@@ -3915,6 +5015,112 @@ public func FfiConverterTypeFilterKind_lower(_ value: FilterKind) -> UnsafeMutab
     return FfiConverterTypeFilterKind.lower(value)
 }
 
+/**
+ * Iroh gossip client.
+ */
+public protocol GossipProtocol: AnyObject {
+    func subscribe(topic: Data, bootstrap: [String], cb: GossipMessageCallback) async throws -> Sender
+}
+
+/**
+ * Iroh gossip client.
+ */
+open class Gossip:
+    GossipProtocol
+{
+    fileprivate let pointer: UnsafeMutableRawPointer!
+
+    /// Used to instantiate a [FFIObject] without an actual pointer, for fakes in tests, mostly.
+    public struct NoPointer {
+        public init() {}
+    }
+
+    // TODO: We'd like this to be `private` but for Swifty reasons,
+    // we can't implement `FfiConverter` without making this `required` and we can't
+    // make it `required` without making it `public`.
+    public required init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
+        self.pointer = pointer
+    }
+
+    /// This constructor can be used to instantiate a fake object.
+    /// - Parameter noPointer: Placeholder value so we can have a constructor separate from the default empty one that may be implemented for classes extending [FFIObject].
+    ///
+    /// - Warning:
+    ///     Any object instantiated with this constructor cannot be passed to an actual Rust-backed object. Since there isn't a backing [Pointer] the FFI lower functions will crash.
+    public init(noPointer _: NoPointer) {
+        pointer = nil
+    }
+
+    public func uniffiClonePointer() -> UnsafeMutableRawPointer {
+        return try! rustCall { uniffi_iroh_ffi_fn_clone_gossip(self.pointer, $0) }
+    }
+
+    // No primary constructor declared for this class.
+
+    deinit {
+        guard let pointer = pointer else {
+            return
+        }
+
+        try! rustCall { uniffi_iroh_ffi_fn_free_gossip(pointer, $0) }
+    }
+
+    open func subscribe(topic: Data, bootstrap: [String], cb: GossipMessageCallback) async throws -> Sender {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_gossip_subscribe(
+                        self.uniffiClonePointer(),
+                        FfiConverterData.lower(topic), FfiConverterSequenceString.lower(bootstrap), FfiConverterTypeGossipMessageCallback.lower(cb)
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_pointer,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_pointer,
+                freeFunc: ffi_iroh_ffi_rust_future_free_pointer,
+                liftFunc: FfiConverterTypeSender.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+}
+
+public struct FfiConverterTypeGossip: FfiConverter {
+    typealias FfiType = UnsafeMutableRawPointer
+    typealias SwiftType = Gossip
+
+    public static func lift(_ pointer: UnsafeMutableRawPointer) throws -> Gossip {
+        return Gossip(unsafeFromRawPointer: pointer)
+    }
+
+    public static func lower(_ value: Gossip) -> UnsafeMutableRawPointer {
+        return value.uniffiClonePointer()
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> Gossip {
+        let v: UInt64 = try readInt(&buf)
+        // The Rust code won't compile if a pointer won't fit in a UInt64.
+        // We have to go via `UInt` because that's the thing that's the size of a pointer.
+        let ptr = UnsafeMutableRawPointer(bitPattern: UInt(truncatingIfNeeded: v))
+        if ptr == nil {
+            throw UniffiInternalError.unexpectedNullPointer
+        }
+        return try lift(ptr!)
+    }
+
+    public static func write(_ value: Gossip, into buf: inout [UInt8]) {
+        // This fiddling is because `Int` is the thing that's the same size as a pointer.
+        // The Rust code won't compile if a pointer won't fit in a `UInt64`.
+        writeInt(&buf, UInt64(bitPattern: Int64(Int(bitPattern: lower(value)))))
+    }
+}
+
+public func FfiConverterTypeGossip_lift(_ pointer: UnsafeMutableRawPointer) throws -> Gossip {
+    return try FfiConverterTypeGossip.lift(pointer)
+}
+
+public func FfiConverterTypeGossip_lower(_ value: Gossip) -> UnsafeMutableRawPointer {
+    return FfiConverterTypeGossip.lower(value)
+}
+
 public protocol GossipMessageCallback: AnyObject {
     func onMessage(msg: Message) async throws
 }
@@ -4252,6 +5458,253 @@ public func FfiConverterTypeHash_lower(_ value: Hash) -> UnsafeMutableRawPointer
 }
 
 /**
+ * An Iroh node. Allows you to sync, store, and transfer data.
+ */
+public protocol IrohProtocol: AnyObject {
+    /**
+     * Access to authors specific funtionaliy.
+     */
+    func authors() -> Authors
+
+    /**
+     * Access to blob specific funtionaliy.
+     */
+    func blobs() -> Blobs
+
+    /**
+     * Access to docs specific funtionaliy.
+     */
+    func docs() -> Docs
+
+    /**
+     * Access to gossip specific funtionaliy.
+     */
+    func gossip() -> Gossip
+
+    /**
+     * Access to node specific funtionaliy.
+     */
+    func node() -> Node
+
+    /**
+     * Access to tags specific funtionaliy.
+     */
+    func tags() -> Tags
+}
+
+/**
+ * An Iroh node. Allows you to sync, store, and transfer data.
+ */
+open class Iroh:
+    IrohProtocol
+{
+    fileprivate let pointer: UnsafeMutableRawPointer!
+
+    /// Used to instantiate a [FFIObject] without an actual pointer, for fakes in tests, mostly.
+    public struct NoPointer {
+        public init() {}
+    }
+
+    // TODO: We'd like this to be `private` but for Swifty reasons,
+    // we can't implement `FfiConverter` without making this `required` and we can't
+    // make it `required` without making it `public`.
+    public required init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
+        self.pointer = pointer
+    }
+
+    /// This constructor can be used to instantiate a fake object.
+    /// - Parameter noPointer: Placeholder value so we can have a constructor separate from the default empty one that may be implemented for classes extending [FFIObject].
+    ///
+    /// - Warning:
+    ///     Any object instantiated with this constructor cannot be passed to an actual Rust-backed object. Since there isn't a backing [Pointer] the FFI lower functions will crash.
+    public init(noPointer _: NoPointer) {
+        pointer = nil
+    }
+
+    public func uniffiClonePointer() -> UnsafeMutableRawPointer {
+        return try! rustCall { uniffi_iroh_ffi_fn_clone_iroh(self.pointer, $0) }
+    }
+
+    // No primary constructor declared for this class.
+
+    deinit {
+        guard let pointer = pointer else {
+            return
+        }
+
+        try! rustCall { uniffi_iroh_ffi_fn_free_iroh(pointer, $0) }
+    }
+
+    /**
+     * Create a new iroh node.
+     *
+     * All data will be only persistet in memory.
+     */
+    public static func memory() async throws -> Iroh {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_constructor_iroh_memory(
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_pointer,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_pointer,
+                freeFunc: ffi_iroh_ffi_rust_future_free_pointer,
+                liftFunc: FfiConverterTypeIroh.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
+    /**
+     * Create a new in memory iroh node with options.
+     */
+    public static func memoryWithOptions(options: NodeOptions) async throws -> Iroh {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_constructor_iroh_memory_with_options(FfiConverterTypeNodeOptions.lower(options)
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_pointer,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_pointer,
+                freeFunc: ffi_iroh_ffi_rust_future_free_pointer,
+                liftFunc: FfiConverterTypeIroh.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
+    /**
+     * Create a new iroh node.
+     *
+     * The `path` param should be a directory where we can store or load
+     * iroh data from a previous session.
+     */
+    public static func persistent(path: String) async throws -> Iroh {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_constructor_iroh_persistent(FfiConverterString.lower(path)
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_pointer,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_pointer,
+                freeFunc: ffi_iroh_ffi_rust_future_free_pointer,
+                liftFunc: FfiConverterTypeIroh.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
+    /**
+     * Create a new iroh node with options.
+     */
+    public static func persistentWithOptions(path: String, options: NodeOptions) async throws -> Iroh {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_constructor_iroh_persistent_with_options(FfiConverterString.lower(path), FfiConverterTypeNodeOptions.lower(options))
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_pointer,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_pointer,
+                freeFunc: ffi_iroh_ffi_rust_future_free_pointer,
+                liftFunc: FfiConverterTypeIroh.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
+    /**
+     * Access to authors specific funtionaliy.
+     */
+    open func authors() -> Authors {
+        return try! FfiConverterTypeAuthors.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_iroh_authors(self.uniffiClonePointer(), $0)
+        })
+    }
+
+    /**
+     * Access to blob specific funtionaliy.
+     */
+    open func blobs() -> Blobs {
+        return try! FfiConverterTypeBlobs.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_iroh_blobs(self.uniffiClonePointer(), $0)
+        })
+    }
+
+    /**
+     * Access to docs specific funtionaliy.
+     */
+    open func docs() -> Docs {
+        return try! FfiConverterTypeDocs.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_iroh_docs(self.uniffiClonePointer(), $0)
+        })
+    }
+
+    /**
+     * Access to gossip specific funtionaliy.
+     */
+    open func gossip() -> Gossip {
+        return try! FfiConverterTypeGossip.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_iroh_gossip(self.uniffiClonePointer(), $0)
+        })
+    }
+
+    /**
+     * Access to node specific funtionaliy.
+     */
+    open func node() -> Node {
+        return try! FfiConverterTypeNode.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_iroh_node(self.uniffiClonePointer(), $0)
+        })
+    }
+
+    /**
+     * Access to tags specific funtionaliy.
+     */
+    open func tags() -> Tags {
+        return try! FfiConverterTypeTags.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_iroh_tags(self.uniffiClonePointer(), $0)
+        })
+    }
+}
+
+public struct FfiConverterTypeIroh: FfiConverter {
+    typealias FfiType = UnsafeMutableRawPointer
+    typealias SwiftType = Iroh
+
+    public static func lift(_ pointer: UnsafeMutableRawPointer) throws -> Iroh {
+        return Iroh(unsafeFromRawPointer: pointer)
+    }
+
+    public static func lower(_ value: Iroh) -> UnsafeMutableRawPointer {
+        return value.uniffiClonePointer()
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> Iroh {
+        let v: UInt64 = try readInt(&buf)
+        // The Rust code won't compile if a pointer won't fit in a UInt64.
+        // We have to go via `UInt` because that's the thing that's the size of a pointer.
+        let ptr = UnsafeMutableRawPointer(bitPattern: UInt(truncatingIfNeeded: v))
+        if ptr == nil {
+            throw UniffiInternalError.unexpectedNullPointer
+        }
+        return try lift(ptr!)
+    }
+
+    public static func write(_ value: Iroh, into buf: inout [UInt8]) {
+        // This fiddling is because `Int` is the thing that's the same size as a pointer.
+        // The Rust code won't compile if a pointer won't fit in a `UInt64`.
+        writeInt(&buf, UInt64(bitPattern: Int64(Int(bitPattern: lower(value)))))
+    }
+}
+
+public func FfiConverterTypeIroh_lift(_ pointer: UnsafeMutableRawPointer) throws -> Iroh {
+    return try FfiConverterTypeIroh.lift(pointer)
+}
+
+public func FfiConverterTypeIroh_lower(_ value: Iroh) -> UnsafeMutableRawPointer {
+    return FfiConverterTypeIroh.lower(value)
+}
+
+/**
  * An Error.
  */
 public protocol IrohErrorProtocol: AnyObject {
@@ -4380,1284 +5833,6 @@ public func FfiConverterTypeIrohError_lift(_ pointer: UnsafeMutableRawPointer) t
 
 public func FfiConverterTypeIrohError_lower(_ value: IrohError) -> UnsafeMutableRawPointer {
     return FfiConverterTypeIrohError.lower(value)
-}
-
-/**
- * An Iroh node. Allows you to sync, store, and transfer data.
- */
-public protocol IrohNodeProtocol: AnyObject {
-    /**
-     * Add a known node address to the node.
-     */
-    func addNodeAddr(addr: NodeAddr) async throws
-
-    /**
-     * Create a new document author.
-     *
-     * You likely want to save the returned [`AuthorId`] somewhere so that you can use this author
-     * again.
-     *
-     * If you need only a single author, use [`Self::default`].
-     */
-    func authorCreate() async throws -> AuthorId
-
-    /**
-     * Returns the default document author of this node.
-     *
-     * On persistent nodes, the author is created on first start and its public key is saved
-     * in the data directory.
-     *
-     * The default author can be set with [`Self::set_default`].
-     */
-    func authorDefault() async throws -> AuthorId
-
-    /**
-     * Deletes the given author by id.
-     *
-     * Warning: This permanently removes this author.
-     */
-    func authorDelete(author: AuthorId) async throws
-
-    /**
-     * Export the given author.
-     *
-     * Warning: This contains sensitive data.
-     */
-    func authorExport(author: AuthorId) async throws -> Author
-
-    /**
-     * Import the given author.
-     *
-     * Warning: This contains sensitive data.
-     */
-    func authorImport(author: Author) async throws -> AuthorId
-
-    /**
-     * List all the AuthorIds that exist on this node.
-     */
-    func authorList() async throws -> [AuthorId]
-
-    /**
-     * Write a blob by passing bytes.
-     */
-    func blobsAddBytes(bytes: Data) async throws -> BlobAddOutcome
-
-    /**
-     * Write a blob by passing bytes, setting an explicit tag name.
-     */
-    func blobsAddBytesNamed(bytes: Data, name: String) async throws -> BlobAddOutcome
-
-    /**
-     * Import a blob from a filesystem path.
-     *
-     * `path` should be an absolute path valid for the file system on which
-     * the node runs.
-     * If `in_place` is true, Iroh will assume that the data will not change and will share it in
-     * place without copying to the Iroh data directory.
-     */
-    func blobsAddFromPath(path: String, inPlace: Bool, tag: SetTagOption, wrap: WrapOption, cb: AddCallback) async throws
-
-    /**
-     * Create a collection from already existing blobs.
-     *
-     * To automatically clear the tags for the passed in blobs you can set
-     * `tags_to_delete` on those tags, and they will be deleted once the collection is created.
-     */
-    func blobsCreateCollection(collection: Collection, tag: SetTagOption, tagsToDelete: [String]) async throws -> HashAndTag
-
-    /**
-     * Delete a blob.
-     */
-    func blobsDeleteBlob(hash: Hash) async throws
-
-    /**
-     * Download a blob from another node and add it to the local database.
-     */
-    func blobsDownload(hash: Hash, opts: BlobDownloadOptions, cb: DownloadCallback) async throws
-
-    /**
-     * Export a blob from the internal blob store to a path on the node's filesystem.
-     *
-     * `destination` should be a writeable, absolute path on the local node's filesystem.
-     *
-     * If `format` is set to [`ExportFormat::Collection`], and the `hash` refers to a collection,
-     * all children of the collection will be exported. See [`ExportFormat`] for details.
-     *
-     * The `mode` argument defines if the blob should be copied to the target location or moved out of
-     * the internal store into the target location. See [`ExportMode`] for details.
-     */
-    func blobsExport(hash: Hash, destination: String, format: BlobExportFormat, mode: BlobExportMode) async throws
-
-    /**
-     * Read the content of a collection
-     */
-    func blobsGetCollection(hash: Hash) async throws -> Collection
-
-    /**
-     * List all complete blobs.
-     *
-     * Note: this allocates for each `BlobListResponse`, if you have many `BlobListReponse`s this may be a prohibitively large list.
-     * Please file an [issue](https://github.com/n0-computer/iroh-ffi/issues/new) if you run into this issue
-     */
-    func blobsList() async throws -> [Hash]
-
-    /**
-     * List all collections.
-     *
-     * Note: this allocates for each `BlobListCollectionsResponse`, if you have many `BlobListCollectionsResponse`s this may be a prohibitively large list.
-     * Please file an [issue](https://github.com/n0-computer/iroh-ffi/issues/new) if you run into this issue
-     */
-    func blobsListCollections() async throws -> [CollectionInfo]
-
-    /**
-     * List all incomplete (partial) blobs.
-     *
-     * Note: this allocates for each `BlobListIncompleteResponse`, if you have many `BlobListIncompleteResponse`s this may be a prohibitively large list.
-     * Please file an [issue](https://github.com/n0-computer/iroh-ffi/issues/new) if you run into this issue
-     */
-    func blobsListIncomplete() async throws -> [IncompleteBlobInfo]
-
-    /**
-     * Read all bytes of single blob at `offset` for length `len`.
-     *
-     * This allocates a buffer for the full length `len`. Use only if you know that the blob you're
-     * reading is small. If not sure, use [`Self::blobs_size`] and check the size with
-     * before calling [`Self::blobs_read_at_to_bytes`].
-     */
-    func blobsReadAtToBytes(hash: Hash, offset: UInt64, len: UInt64?) async throws -> Data
-
-    /**
-     * Read all bytes of single blob.
-     *
-     * This allocates a buffer for the full blob. Use only if you know that the blob you're
-     * reading is small. If not sure, use [`Self::blobs_size`] and check the size with
-     * before calling [`Self::blobs_read_to_bytes`].
-     */
-    func blobsReadToBytes(hash: Hash) async throws -> Data
-
-    /**
-     * Create a ticket for sharing a blob from this node.
-     */
-    func blobsShare(hash: Hash, blobFormat: BlobFormat, ticketOptions: AddrInfoOptions) async throws -> String
-
-    /**
-     * Get the size information on a single blob.
-     *
-     * Method only exists in FFI
-     */
-    func blobsSize(hash: Hash) async throws -> UInt64
-
-    /**
-     * Export the blob contents to a file path
-     * The `path` field is expected to be the absolute path.
-     */
-    func blobsWriteToPath(hash: Hash, path: String) async throws
-
-    /**
-     * Return connection information on the currently running node.
-     */
-    func connectionInfo(nodeId: PublicKey) async throws -> ConnectionInfo?
-
-    /**
-     * Return `ConnectionInfo`s for each connection we have to another iroh node.
-     */
-    func connections() async throws -> [ConnectionInfo]
-
-    /**
-     * Create a new doc.
-     */
-    func docCreate() async throws -> Doc
-
-    /**
-     * Delete a document from the local node.
-     *
-     * This is a destructive operation. Both the document secret key and all entries in the
-     * document will be permanently deleted from the node's storage. Content blobs will be deleted
-     * through garbage collection unless they are referenced from another document or tag.
-     */
-    func docDrop(docId: String) async throws
-
-    /**
-     * Join and sync with an already existing document.
-     */
-    func docJoin(ticket: String) async throws -> Doc
-
-    /**
-     * Join and sync with an already existing document and subscribe to events on that document.
-     */
-    func docJoinAndSubscribe(ticket: String, cb: SubscribeCallback) async throws -> Doc
-
-    /**
-     * List all the docs we have access to on this node.
-     */
-    func docList() async throws -> [NamespaceAndCapability]
-
-    /**
-     * Get a [`Doc`].
-     *
-     * Returns None if the document cannot be found.
-     */
-    func docOpen(id: String) async throws -> Doc?
-
-    func gossipSubscribe(topic: Data, bootstrap: [String], cb: GossipMessageCallback) async throws -> Sender
-
-    /**
-     * Get the relay server we are connected to.
-     */
-    func homeRelay() async throws -> String?
-
-    /**
-     * Returns `Some(addr)` if an RPC endpoint is running, `None` otherwise.
-     */
-    func myRpcAddr() -> String?
-
-    /**
-     * Return the [`NodeAddr`] for this node.
-     */
-    func nodeAddr() async throws -> NodeAddr
-
-    /**
-     * The string representation of the PublicKey of this node.
-     */
-    func nodeId() async throws -> String
-
-    /**
-     * Shutdown this iroh node.
-     */
-    func shutdown(force: Bool) async throws
-
-    /**
-     * Get statistics of the running node.
-     */
-    func stats() async throws -> [String: CounterStats]
-
-    /**
-     * Get status information about a node
-     */
-    func status() async throws -> NodeStatus
-
-    /**
-     * Delete a tag
-     */
-    func tagsDelete(name: Data) async throws
-
-    /**
-     * List all tags
-     *
-     * Note: this allocates for each `ListTagsResponse`, if you have many `Tags`s this may be a prohibitively large list.
-     * Please file an [issue](https://github.com/n0-computer/iroh-ffi/issues/new) if you run into this issue
-     */
-    func tagsList() async throws -> [TagInfo]
-}
-
-/**
- * An Iroh node. Allows you to sync, store, and transfer data.
- */
-open class IrohNode:
-    IrohNodeProtocol
-{
-    fileprivate let pointer: UnsafeMutableRawPointer!
-
-    /// Used to instantiate a [FFIObject] without an actual pointer, for fakes in tests, mostly.
-    public struct NoPointer {
-        public init() {}
-    }
-
-    // TODO: We'd like this to be `private` but for Swifty reasons,
-    // we can't implement `FfiConverter` without making this `required` and we can't
-    // make it `required` without making it `public`.
-    public required init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
-        self.pointer = pointer
-    }
-
-    /// This constructor can be used to instantiate a fake object.
-    /// - Parameter noPointer: Placeholder value so we can have a constructor separate from the default empty one that may be implemented for classes extending [FFIObject].
-    ///
-    /// - Warning:
-    ///     Any object instantiated with this constructor cannot be passed to an actual Rust-backed object. Since there isn't a backing [Pointer] the FFI lower functions will crash.
-    public init(noPointer _: NoPointer) {
-        pointer = nil
-    }
-
-    public func uniffiClonePointer() -> UnsafeMutableRawPointer {
-        return try! rustCall { uniffi_iroh_ffi_fn_clone_irohnode(self.pointer, $0) }
-    }
-
-    // No primary constructor declared for this class.
-
-    deinit {
-        guard let pointer = pointer else {
-            return
-        }
-
-        try! rustCall { uniffi_iroh_ffi_fn_free_irohnode(pointer, $0) }
-    }
-
-    /**
-     * Create a new iroh node.
-     *
-     * All data will be only persistet in memory.
-     */
-    public static func memory() async throws -> IrohNode {
-        return
-            try await uniffiRustCallAsync(
-                rustFutureFunc: {
-                    uniffi_iroh_ffi_fn_constructor_irohnode_memory(
-                    )
-                },
-                pollFunc: ffi_iroh_ffi_rust_future_poll_pointer,
-                completeFunc: ffi_iroh_ffi_rust_future_complete_pointer,
-                freeFunc: ffi_iroh_ffi_rust_future_free_pointer,
-                liftFunc: FfiConverterTypeIrohNode.lift,
-                errorHandler: FfiConverterTypeIrohError__as_error.lift
-            )
-    }
-
-    /**
-     * Create a new in memory iroh node with options.
-     */
-    public static func memoryWithOptions(options: NodeOptions) async throws -> IrohNode {
-        return
-            try await uniffiRustCallAsync(
-                rustFutureFunc: {
-                    uniffi_iroh_ffi_fn_constructor_irohnode_memory_with_options(FfiConverterTypeNodeOptions.lower(options)
-                    )
-                },
-                pollFunc: ffi_iroh_ffi_rust_future_poll_pointer,
-                completeFunc: ffi_iroh_ffi_rust_future_complete_pointer,
-                freeFunc: ffi_iroh_ffi_rust_future_free_pointer,
-                liftFunc: FfiConverterTypeIrohNode.lift,
-                errorHandler: FfiConverterTypeIrohError__as_error.lift
-            )
-    }
-
-    /**
-     * Create a new iroh node.
-     *
-     * The `path` param should be a directory where we can store or load
-     * iroh data from a previous session.
-     */
-    public static func persistent(path: String) async throws -> IrohNode {
-        return
-            try await uniffiRustCallAsync(
-                rustFutureFunc: {
-                    uniffi_iroh_ffi_fn_constructor_irohnode_persistent(FfiConverterString.lower(path)
-                    )
-                },
-                pollFunc: ffi_iroh_ffi_rust_future_poll_pointer,
-                completeFunc: ffi_iroh_ffi_rust_future_complete_pointer,
-                freeFunc: ffi_iroh_ffi_rust_future_free_pointer,
-                liftFunc: FfiConverterTypeIrohNode.lift,
-                errorHandler: FfiConverterTypeIrohError__as_error.lift
-            )
-    }
-
-    /**
-     * Create a new iroh node with options.
-     */
-    public static func persistentWithOptions(path: String, options: NodeOptions) async throws -> IrohNode {
-        return
-            try await uniffiRustCallAsync(
-                rustFutureFunc: {
-                    uniffi_iroh_ffi_fn_constructor_irohnode_persistent_with_options(FfiConverterString.lower(path), FfiConverterTypeNodeOptions.lower(options))
-                },
-                pollFunc: ffi_iroh_ffi_rust_future_poll_pointer,
-                completeFunc: ffi_iroh_ffi_rust_future_complete_pointer,
-                freeFunc: ffi_iroh_ffi_rust_future_free_pointer,
-                liftFunc: FfiConverterTypeIrohNode.lift,
-                errorHandler: FfiConverterTypeIrohError__as_error.lift
-            )
-    }
-
-    /**
-     * Add a known node address to the node.
-     */
-    open func addNodeAddr(addr: NodeAddr) async throws {
-        return
-            try await uniffiRustCallAsync(
-                rustFutureFunc: {
-                    uniffi_iroh_ffi_fn_method_irohnode_add_node_addr(
-                        self.uniffiClonePointer(),
-                        FfiConverterTypeNodeAddr.lower(addr)
-                    )
-                },
-                pollFunc: ffi_iroh_ffi_rust_future_poll_void,
-                completeFunc: ffi_iroh_ffi_rust_future_complete_void,
-                freeFunc: ffi_iroh_ffi_rust_future_free_void,
-                liftFunc: { $0 },
-                errorHandler: FfiConverterTypeIrohError__as_error.lift
-            )
-    }
-
-    /**
-     * Create a new document author.
-     *
-     * You likely want to save the returned [`AuthorId`] somewhere so that you can use this author
-     * again.
-     *
-     * If you need only a single author, use [`Self::default`].
-     */
-    open func authorCreate() async throws -> AuthorId {
-        return
-            try await uniffiRustCallAsync(
-                rustFutureFunc: {
-                    uniffi_iroh_ffi_fn_method_irohnode_author_create(
-                        self.uniffiClonePointer()
-                    )
-                },
-                pollFunc: ffi_iroh_ffi_rust_future_poll_pointer,
-                completeFunc: ffi_iroh_ffi_rust_future_complete_pointer,
-                freeFunc: ffi_iroh_ffi_rust_future_free_pointer,
-                liftFunc: FfiConverterTypeAuthorId.lift,
-                errorHandler: FfiConverterTypeIrohError__as_error.lift
-            )
-    }
-
-    /**
-     * Returns the default document author of this node.
-     *
-     * On persistent nodes, the author is created on first start and its public key is saved
-     * in the data directory.
-     *
-     * The default author can be set with [`Self::set_default`].
-     */
-    open func authorDefault() async throws -> AuthorId {
-        return
-            try await uniffiRustCallAsync(
-                rustFutureFunc: {
-                    uniffi_iroh_ffi_fn_method_irohnode_author_default(
-                        self.uniffiClonePointer()
-                    )
-                },
-                pollFunc: ffi_iroh_ffi_rust_future_poll_pointer,
-                completeFunc: ffi_iroh_ffi_rust_future_complete_pointer,
-                freeFunc: ffi_iroh_ffi_rust_future_free_pointer,
-                liftFunc: FfiConverterTypeAuthorId.lift,
-                errorHandler: FfiConverterTypeIrohError__as_error.lift
-            )
-    }
-
-    /**
-     * Deletes the given author by id.
-     *
-     * Warning: This permanently removes this author.
-     */
-    open func authorDelete(author: AuthorId) async throws {
-        return
-            try await uniffiRustCallAsync(
-                rustFutureFunc: {
-                    uniffi_iroh_ffi_fn_method_irohnode_author_delete(
-                        self.uniffiClonePointer(),
-                        FfiConverterTypeAuthorId.lower(author)
-                    )
-                },
-                pollFunc: ffi_iroh_ffi_rust_future_poll_void,
-                completeFunc: ffi_iroh_ffi_rust_future_complete_void,
-                freeFunc: ffi_iroh_ffi_rust_future_free_void,
-                liftFunc: { $0 },
-                errorHandler: FfiConverterTypeIrohError__as_error.lift
-            )
-    }
-
-    /**
-     * Export the given author.
-     *
-     * Warning: This contains sensitive data.
-     */
-    open func authorExport(author: AuthorId) async throws -> Author {
-        return
-            try await uniffiRustCallAsync(
-                rustFutureFunc: {
-                    uniffi_iroh_ffi_fn_method_irohnode_author_export(
-                        self.uniffiClonePointer(),
-                        FfiConverterTypeAuthorId.lower(author)
-                    )
-                },
-                pollFunc: ffi_iroh_ffi_rust_future_poll_pointer,
-                completeFunc: ffi_iroh_ffi_rust_future_complete_pointer,
-                freeFunc: ffi_iroh_ffi_rust_future_free_pointer,
-                liftFunc: FfiConverterTypeAuthor.lift,
-                errorHandler: FfiConverterTypeIrohError__as_error.lift
-            )
-    }
-
-    /**
-     * Import the given author.
-     *
-     * Warning: This contains sensitive data.
-     */
-    open func authorImport(author: Author) async throws -> AuthorId {
-        return
-            try await uniffiRustCallAsync(
-                rustFutureFunc: {
-                    uniffi_iroh_ffi_fn_method_irohnode_author_import(
-                        self.uniffiClonePointer(),
-                        FfiConverterTypeAuthor.lower(author)
-                    )
-                },
-                pollFunc: ffi_iroh_ffi_rust_future_poll_pointer,
-                completeFunc: ffi_iroh_ffi_rust_future_complete_pointer,
-                freeFunc: ffi_iroh_ffi_rust_future_free_pointer,
-                liftFunc: FfiConverterTypeAuthorId.lift,
-                errorHandler: FfiConverterTypeIrohError__as_error.lift
-            )
-    }
-
-    /**
-     * List all the AuthorIds that exist on this node.
-     */
-    open func authorList() async throws -> [AuthorId] {
-        return
-            try await uniffiRustCallAsync(
-                rustFutureFunc: {
-                    uniffi_iroh_ffi_fn_method_irohnode_author_list(
-                        self.uniffiClonePointer()
-                    )
-                },
-                pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
-                completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
-                freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
-                liftFunc: FfiConverterSequenceTypeAuthorId.lift,
-                errorHandler: FfiConverterTypeIrohError__as_error.lift
-            )
-    }
-
-    /**
-     * Write a blob by passing bytes.
-     */
-    open func blobsAddBytes(bytes: Data) async throws -> BlobAddOutcome {
-        return
-            try await uniffiRustCallAsync(
-                rustFutureFunc: {
-                    uniffi_iroh_ffi_fn_method_irohnode_blobs_add_bytes(
-                        self.uniffiClonePointer(),
-                        FfiConverterData.lower(bytes)
-                    )
-                },
-                pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
-                completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
-                freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
-                liftFunc: FfiConverterTypeBlobAddOutcome.lift,
-                errorHandler: FfiConverterTypeIrohError__as_error.lift
-            )
-    }
-
-    /**
-     * Write a blob by passing bytes, setting an explicit tag name.
-     */
-    open func blobsAddBytesNamed(bytes: Data, name: String) async throws -> BlobAddOutcome {
-        return
-            try await uniffiRustCallAsync(
-                rustFutureFunc: {
-                    uniffi_iroh_ffi_fn_method_irohnode_blobs_add_bytes_named(
-                        self.uniffiClonePointer(),
-                        FfiConverterData.lower(bytes), FfiConverterString.lower(name)
-                    )
-                },
-                pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
-                completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
-                freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
-                liftFunc: FfiConverterTypeBlobAddOutcome.lift,
-                errorHandler: FfiConverterTypeIrohError__as_error.lift
-            )
-    }
-
-    /**
-     * Import a blob from a filesystem path.
-     *
-     * `path` should be an absolute path valid for the file system on which
-     * the node runs.
-     * If `in_place` is true, Iroh will assume that the data will not change and will share it in
-     * place without copying to the Iroh data directory.
-     */
-    open func blobsAddFromPath(path: String, inPlace: Bool, tag: SetTagOption, wrap: WrapOption, cb: AddCallback) async throws {
-        return
-            try await uniffiRustCallAsync(
-                rustFutureFunc: {
-                    uniffi_iroh_ffi_fn_method_irohnode_blobs_add_from_path(
-                        self.uniffiClonePointer(),
-                        FfiConverterString.lower(path), FfiConverterBool.lower(inPlace), FfiConverterTypeSetTagOption.lower(tag), FfiConverterTypeWrapOption.lower(wrap), FfiConverterTypeAddCallback.lower(cb)
-                    )
-                },
-                pollFunc: ffi_iroh_ffi_rust_future_poll_void,
-                completeFunc: ffi_iroh_ffi_rust_future_complete_void,
-                freeFunc: ffi_iroh_ffi_rust_future_free_void,
-                liftFunc: { $0 },
-                errorHandler: FfiConverterTypeIrohError__as_error.lift
-            )
-    }
-
-    /**
-     * Create a collection from already existing blobs.
-     *
-     * To automatically clear the tags for the passed in blobs you can set
-     * `tags_to_delete` on those tags, and they will be deleted once the collection is created.
-     */
-    open func blobsCreateCollection(collection: Collection, tag: SetTagOption, tagsToDelete: [String]) async throws -> HashAndTag {
-        return
-            try await uniffiRustCallAsync(
-                rustFutureFunc: {
-                    uniffi_iroh_ffi_fn_method_irohnode_blobs_create_collection(
-                        self.uniffiClonePointer(),
-                        FfiConverterTypeCollection.lower(collection), FfiConverterTypeSetTagOption.lower(tag), FfiConverterSequenceString.lower(tagsToDelete)
-                    )
-                },
-                pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
-                completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
-                freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
-                liftFunc: FfiConverterTypeHashAndTag.lift,
-                errorHandler: FfiConverterTypeIrohError__as_error.lift
-            )
-    }
-
-    /**
-     * Delete a blob.
-     */
-    open func blobsDeleteBlob(hash: Hash) async throws {
-        return
-            try await uniffiRustCallAsync(
-                rustFutureFunc: {
-                    uniffi_iroh_ffi_fn_method_irohnode_blobs_delete_blob(
-                        self.uniffiClonePointer(),
-                        FfiConverterTypeHash.lower(hash)
-                    )
-                },
-                pollFunc: ffi_iroh_ffi_rust_future_poll_void,
-                completeFunc: ffi_iroh_ffi_rust_future_complete_void,
-                freeFunc: ffi_iroh_ffi_rust_future_free_void,
-                liftFunc: { $0 },
-                errorHandler: FfiConverterTypeIrohError__as_error.lift
-            )
-    }
-
-    /**
-     * Download a blob from another node and add it to the local database.
-     */
-    open func blobsDownload(hash: Hash, opts: BlobDownloadOptions, cb: DownloadCallback) async throws {
-        return
-            try await uniffiRustCallAsync(
-                rustFutureFunc: {
-                    uniffi_iroh_ffi_fn_method_irohnode_blobs_download(
-                        self.uniffiClonePointer(),
-                        FfiConverterTypeHash.lower(hash), FfiConverterTypeBlobDownloadOptions.lower(opts), FfiConverterTypeDownloadCallback.lower(cb)
-                    )
-                },
-                pollFunc: ffi_iroh_ffi_rust_future_poll_void,
-                completeFunc: ffi_iroh_ffi_rust_future_complete_void,
-                freeFunc: ffi_iroh_ffi_rust_future_free_void,
-                liftFunc: { $0 },
-                errorHandler: FfiConverterTypeIrohError__as_error.lift
-            )
-    }
-
-    /**
-     * Export a blob from the internal blob store to a path on the node's filesystem.
-     *
-     * `destination` should be a writeable, absolute path on the local node's filesystem.
-     *
-     * If `format` is set to [`ExportFormat::Collection`], and the `hash` refers to a collection,
-     * all children of the collection will be exported. See [`ExportFormat`] for details.
-     *
-     * The `mode` argument defines if the blob should be copied to the target location or moved out of
-     * the internal store into the target location. See [`ExportMode`] for details.
-     */
-    open func blobsExport(hash: Hash, destination: String, format: BlobExportFormat, mode: BlobExportMode) async throws {
-        return
-            try await uniffiRustCallAsync(
-                rustFutureFunc: {
-                    uniffi_iroh_ffi_fn_method_irohnode_blobs_export(
-                        self.uniffiClonePointer(),
-                        FfiConverterTypeHash.lower(hash), FfiConverterString.lower(destination), FfiConverterTypeBlobExportFormat.lower(format), FfiConverterTypeBlobExportMode.lower(mode)
-                    )
-                },
-                pollFunc: ffi_iroh_ffi_rust_future_poll_void,
-                completeFunc: ffi_iroh_ffi_rust_future_complete_void,
-                freeFunc: ffi_iroh_ffi_rust_future_free_void,
-                liftFunc: { $0 },
-                errorHandler: FfiConverterTypeIrohError__as_error.lift
-            )
-    }
-
-    /**
-     * Read the content of a collection
-     */
-    open func blobsGetCollection(hash: Hash) async throws -> Collection {
-        return
-            try await uniffiRustCallAsync(
-                rustFutureFunc: {
-                    uniffi_iroh_ffi_fn_method_irohnode_blobs_get_collection(
-                        self.uniffiClonePointer(),
-                        FfiConverterTypeHash.lower(hash)
-                    )
-                },
-                pollFunc: ffi_iroh_ffi_rust_future_poll_pointer,
-                completeFunc: ffi_iroh_ffi_rust_future_complete_pointer,
-                freeFunc: ffi_iroh_ffi_rust_future_free_pointer,
-                liftFunc: FfiConverterTypeCollection.lift,
-                errorHandler: FfiConverterTypeIrohError__as_error.lift
-            )
-    }
-
-    /**
-     * List all complete blobs.
-     *
-     * Note: this allocates for each `BlobListResponse`, if you have many `BlobListReponse`s this may be a prohibitively large list.
-     * Please file an [issue](https://github.com/n0-computer/iroh-ffi/issues/new) if you run into this issue
-     */
-    open func blobsList() async throws -> [Hash] {
-        return
-            try await uniffiRustCallAsync(
-                rustFutureFunc: {
-                    uniffi_iroh_ffi_fn_method_irohnode_blobs_list(
-                        self.uniffiClonePointer()
-                    )
-                },
-                pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
-                completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
-                freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
-                liftFunc: FfiConverterSequenceTypeHash.lift,
-                errorHandler: FfiConverterTypeIrohError__as_error.lift
-            )
-    }
-
-    /**
-     * List all collections.
-     *
-     * Note: this allocates for each `BlobListCollectionsResponse`, if you have many `BlobListCollectionsResponse`s this may be a prohibitively large list.
-     * Please file an [issue](https://github.com/n0-computer/iroh-ffi/issues/new) if you run into this issue
-     */
-    open func blobsListCollections() async throws -> [CollectionInfo] {
-        return
-            try await uniffiRustCallAsync(
-                rustFutureFunc: {
-                    uniffi_iroh_ffi_fn_method_irohnode_blobs_list_collections(
-                        self.uniffiClonePointer()
-                    )
-                },
-                pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
-                completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
-                freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
-                liftFunc: FfiConverterSequenceTypeCollectionInfo.lift,
-                errorHandler: FfiConverterTypeIrohError__as_error.lift
-            )
-    }
-
-    /**
-     * List all incomplete (partial) blobs.
-     *
-     * Note: this allocates for each `BlobListIncompleteResponse`, if you have many `BlobListIncompleteResponse`s this may be a prohibitively large list.
-     * Please file an [issue](https://github.com/n0-computer/iroh-ffi/issues/new) if you run into this issue
-     */
-    open func blobsListIncomplete() async throws -> [IncompleteBlobInfo] {
-        return
-            try await uniffiRustCallAsync(
-                rustFutureFunc: {
-                    uniffi_iroh_ffi_fn_method_irohnode_blobs_list_incomplete(
-                        self.uniffiClonePointer()
-                    )
-                },
-                pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
-                completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
-                freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
-                liftFunc: FfiConverterSequenceTypeIncompleteBlobInfo.lift,
-                errorHandler: FfiConverterTypeIrohError__as_error.lift
-            )
-    }
-
-    /**
-     * Read all bytes of single blob at `offset` for length `len`.
-     *
-     * This allocates a buffer for the full length `len`. Use only if you know that the blob you're
-     * reading is small. If not sure, use [`Self::blobs_size`] and check the size with
-     * before calling [`Self::blobs_read_at_to_bytes`].
-     */
-    open func blobsReadAtToBytes(hash: Hash, offset: UInt64, len: UInt64?) async throws -> Data {
-        return
-            try await uniffiRustCallAsync(
-                rustFutureFunc: {
-                    uniffi_iroh_ffi_fn_method_irohnode_blobs_read_at_to_bytes(
-                        self.uniffiClonePointer(),
-                        FfiConverterTypeHash.lower(hash), FfiConverterUInt64.lower(offset), FfiConverterOptionUInt64.lower(len)
-                    )
-                },
-                pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
-                completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
-                freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
-                liftFunc: FfiConverterData.lift,
-                errorHandler: FfiConverterTypeIrohError__as_error.lift
-            )
-    }
-
-    /**
-     * Read all bytes of single blob.
-     *
-     * This allocates a buffer for the full blob. Use only if you know that the blob you're
-     * reading is small. If not sure, use [`Self::blobs_size`] and check the size with
-     * before calling [`Self::blobs_read_to_bytes`].
-     */
-    open func blobsReadToBytes(hash: Hash) async throws -> Data {
-        return
-            try await uniffiRustCallAsync(
-                rustFutureFunc: {
-                    uniffi_iroh_ffi_fn_method_irohnode_blobs_read_to_bytes(
-                        self.uniffiClonePointer(),
-                        FfiConverterTypeHash.lower(hash)
-                    )
-                },
-                pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
-                completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
-                freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
-                liftFunc: FfiConverterData.lift,
-                errorHandler: FfiConverterTypeIrohError__as_error.lift
-            )
-    }
-
-    /**
-     * Create a ticket for sharing a blob from this node.
-     */
-    open func blobsShare(hash: Hash, blobFormat: BlobFormat, ticketOptions: AddrInfoOptions) async throws -> String {
-        return
-            try await uniffiRustCallAsync(
-                rustFutureFunc: {
-                    uniffi_iroh_ffi_fn_method_irohnode_blobs_share(
-                        self.uniffiClonePointer(),
-                        FfiConverterTypeHash.lower(hash), FfiConverterTypeBlobFormat.lower(blobFormat), FfiConverterTypeAddrInfoOptions.lower(ticketOptions)
-                    )
-                },
-                pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
-                completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
-                freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
-                liftFunc: FfiConverterString.lift,
-                errorHandler: FfiConverterTypeIrohError__as_error.lift
-            )
-    }
-
-    /**
-     * Get the size information on a single blob.
-     *
-     * Method only exists in FFI
-     */
-    open func blobsSize(hash: Hash) async throws -> UInt64 {
-        return
-            try await uniffiRustCallAsync(
-                rustFutureFunc: {
-                    uniffi_iroh_ffi_fn_method_irohnode_blobs_size(
-                        self.uniffiClonePointer(),
-                        FfiConverterTypeHash.lower(hash)
-                    )
-                },
-                pollFunc: ffi_iroh_ffi_rust_future_poll_u64,
-                completeFunc: ffi_iroh_ffi_rust_future_complete_u64,
-                freeFunc: ffi_iroh_ffi_rust_future_free_u64,
-                liftFunc: FfiConverterUInt64.lift,
-                errorHandler: FfiConverterTypeIrohError__as_error.lift
-            )
-    }
-
-    /**
-     * Export the blob contents to a file path
-     * The `path` field is expected to be the absolute path.
-     */
-    open func blobsWriteToPath(hash: Hash, path: String) async throws {
-        return
-            try await uniffiRustCallAsync(
-                rustFutureFunc: {
-                    uniffi_iroh_ffi_fn_method_irohnode_blobs_write_to_path(
-                        self.uniffiClonePointer(),
-                        FfiConverterTypeHash.lower(hash), FfiConverterString.lower(path)
-                    )
-                },
-                pollFunc: ffi_iroh_ffi_rust_future_poll_void,
-                completeFunc: ffi_iroh_ffi_rust_future_complete_void,
-                freeFunc: ffi_iroh_ffi_rust_future_free_void,
-                liftFunc: { $0 },
-                errorHandler: FfiConverterTypeIrohError__as_error.lift
-            )
-    }
-
-    /**
-     * Return connection information on the currently running node.
-     */
-    open func connectionInfo(nodeId: PublicKey) async throws -> ConnectionInfo? {
-        return
-            try await uniffiRustCallAsync(
-                rustFutureFunc: {
-                    uniffi_iroh_ffi_fn_method_irohnode_connection_info(
-                        self.uniffiClonePointer(),
-                        FfiConverterTypePublicKey.lower(nodeId)
-                    )
-                },
-                pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
-                completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
-                freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
-                liftFunc: FfiConverterOptionTypeConnectionInfo.lift,
-                errorHandler: FfiConverterTypeIrohError__as_error.lift
-            )
-    }
-
-    /**
-     * Return `ConnectionInfo`s for each connection we have to another iroh node.
-     */
-    open func connections() async throws -> [ConnectionInfo] {
-        return
-            try await uniffiRustCallAsync(
-                rustFutureFunc: {
-                    uniffi_iroh_ffi_fn_method_irohnode_connections(
-                        self.uniffiClonePointer()
-                    )
-                },
-                pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
-                completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
-                freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
-                liftFunc: FfiConverterSequenceTypeConnectionInfo.lift,
-                errorHandler: FfiConverterTypeIrohError__as_error.lift
-            )
-    }
-
-    /**
-     * Create a new doc.
-     */
-    open func docCreate() async throws -> Doc {
-        return
-            try await uniffiRustCallAsync(
-                rustFutureFunc: {
-                    uniffi_iroh_ffi_fn_method_irohnode_doc_create(
-                        self.uniffiClonePointer()
-                    )
-                },
-                pollFunc: ffi_iroh_ffi_rust_future_poll_pointer,
-                completeFunc: ffi_iroh_ffi_rust_future_complete_pointer,
-                freeFunc: ffi_iroh_ffi_rust_future_free_pointer,
-                liftFunc: FfiConverterTypeDoc.lift,
-                errorHandler: FfiConverterTypeIrohError__as_error.lift
-            )
-    }
-
-    /**
-     * Delete a document from the local node.
-     *
-     * This is a destructive operation. Both the document secret key and all entries in the
-     * document will be permanently deleted from the node's storage. Content blobs will be deleted
-     * through garbage collection unless they are referenced from another document or tag.
-     */
-    open func docDrop(docId: String) async throws {
-        return
-            try await uniffiRustCallAsync(
-                rustFutureFunc: {
-                    uniffi_iroh_ffi_fn_method_irohnode_doc_drop(
-                        self.uniffiClonePointer(),
-                        FfiConverterString.lower(docId)
-                    )
-                },
-                pollFunc: ffi_iroh_ffi_rust_future_poll_void,
-                completeFunc: ffi_iroh_ffi_rust_future_complete_void,
-                freeFunc: ffi_iroh_ffi_rust_future_free_void,
-                liftFunc: { $0 },
-                errorHandler: FfiConverterTypeIrohError__as_error.lift
-            )
-    }
-
-    /**
-     * Join and sync with an already existing document.
-     */
-    open func docJoin(ticket: String) async throws -> Doc {
-        return
-            try await uniffiRustCallAsync(
-                rustFutureFunc: {
-                    uniffi_iroh_ffi_fn_method_irohnode_doc_join(
-                        self.uniffiClonePointer(),
-                        FfiConverterString.lower(ticket)
-                    )
-                },
-                pollFunc: ffi_iroh_ffi_rust_future_poll_pointer,
-                completeFunc: ffi_iroh_ffi_rust_future_complete_pointer,
-                freeFunc: ffi_iroh_ffi_rust_future_free_pointer,
-                liftFunc: FfiConverterTypeDoc.lift,
-                errorHandler: FfiConverterTypeIrohError__as_error.lift
-            )
-    }
-
-    /**
-     * Join and sync with an already existing document and subscribe to events on that document.
-     */
-    open func docJoinAndSubscribe(ticket: String, cb: SubscribeCallback) async throws -> Doc {
-        return
-            try await uniffiRustCallAsync(
-                rustFutureFunc: {
-                    uniffi_iroh_ffi_fn_method_irohnode_doc_join_and_subscribe(
-                        self.uniffiClonePointer(),
-                        FfiConverterString.lower(ticket), FfiConverterTypeSubscribeCallback.lower(cb)
-                    )
-                },
-                pollFunc: ffi_iroh_ffi_rust_future_poll_pointer,
-                completeFunc: ffi_iroh_ffi_rust_future_complete_pointer,
-                freeFunc: ffi_iroh_ffi_rust_future_free_pointer,
-                liftFunc: FfiConverterTypeDoc.lift,
-                errorHandler: FfiConverterTypeIrohError__as_error.lift
-            )
-    }
-
-    /**
-     * List all the docs we have access to on this node.
-     */
-    open func docList() async throws -> [NamespaceAndCapability] {
-        return
-            try await uniffiRustCallAsync(
-                rustFutureFunc: {
-                    uniffi_iroh_ffi_fn_method_irohnode_doc_list(
-                        self.uniffiClonePointer()
-                    )
-                },
-                pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
-                completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
-                freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
-                liftFunc: FfiConverterSequenceTypeNamespaceAndCapability.lift,
-                errorHandler: FfiConverterTypeIrohError__as_error.lift
-            )
-    }
-
-    /**
-     * Get a [`Doc`].
-     *
-     * Returns None if the document cannot be found.
-     */
-    open func docOpen(id: String) async throws -> Doc? {
-        return
-            try await uniffiRustCallAsync(
-                rustFutureFunc: {
-                    uniffi_iroh_ffi_fn_method_irohnode_doc_open(
-                        self.uniffiClonePointer(),
-                        FfiConverterString.lower(id)
-                    )
-                },
-                pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
-                completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
-                freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
-                liftFunc: FfiConverterOptionTypeDoc.lift,
-                errorHandler: FfiConverterTypeIrohError__as_error.lift
-            )
-    }
-
-    open func gossipSubscribe(topic: Data, bootstrap: [String], cb: GossipMessageCallback) async throws -> Sender {
-        return
-            try await uniffiRustCallAsync(
-                rustFutureFunc: {
-                    uniffi_iroh_ffi_fn_method_irohnode_gossip_subscribe(
-                        self.uniffiClonePointer(),
-                        FfiConverterData.lower(topic), FfiConverterSequenceString.lower(bootstrap), FfiConverterTypeGossipMessageCallback.lower(cb)
-                    )
-                },
-                pollFunc: ffi_iroh_ffi_rust_future_poll_pointer,
-                completeFunc: ffi_iroh_ffi_rust_future_complete_pointer,
-                freeFunc: ffi_iroh_ffi_rust_future_free_pointer,
-                liftFunc: FfiConverterTypeSender.lift,
-                errorHandler: FfiConverterTypeIrohError__as_error.lift
-            )
-    }
-
-    /**
-     * Get the relay server we are connected to.
-     */
-    open func homeRelay() async throws -> String? {
-        return
-            try await uniffiRustCallAsync(
-                rustFutureFunc: {
-                    uniffi_iroh_ffi_fn_method_irohnode_home_relay(
-                        self.uniffiClonePointer()
-                    )
-                },
-                pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
-                completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
-                freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
-                liftFunc: FfiConverterOptionString.lift,
-                errorHandler: FfiConverterTypeIrohError__as_error.lift
-            )
-    }
-
-    /**
-     * Returns `Some(addr)` if an RPC endpoint is running, `None` otherwise.
-     */
-    open func myRpcAddr() -> String? {
-        return try! FfiConverterOptionString.lift(try! rustCall {
-            uniffi_iroh_ffi_fn_method_irohnode_my_rpc_addr(self.uniffiClonePointer(), $0)
-        })
-    }
-
-    /**
-     * Return the [`NodeAddr`] for this node.
-     */
-    open func nodeAddr() async throws -> NodeAddr {
-        return
-            try await uniffiRustCallAsync(
-                rustFutureFunc: {
-                    uniffi_iroh_ffi_fn_method_irohnode_node_addr(
-                        self.uniffiClonePointer()
-                    )
-                },
-                pollFunc: ffi_iroh_ffi_rust_future_poll_pointer,
-                completeFunc: ffi_iroh_ffi_rust_future_complete_pointer,
-                freeFunc: ffi_iroh_ffi_rust_future_free_pointer,
-                liftFunc: FfiConverterTypeNodeAddr.lift,
-                errorHandler: FfiConverterTypeIrohError__as_error.lift
-            )
-    }
-
-    /**
-     * The string representation of the PublicKey of this node.
-     */
-    open func nodeId() async throws -> String {
-        return
-            try await uniffiRustCallAsync(
-                rustFutureFunc: {
-                    uniffi_iroh_ffi_fn_method_irohnode_node_id(
-                        self.uniffiClonePointer()
-                    )
-                },
-                pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
-                completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
-                freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
-                liftFunc: FfiConverterString.lift,
-                errorHandler: FfiConverterTypeIrohError__as_error.lift
-            )
-    }
-
-    /**
-     * Shutdown this iroh node.
-     */
-    open func shutdown(force: Bool) async throws {
-        return
-            try await uniffiRustCallAsync(
-                rustFutureFunc: {
-                    uniffi_iroh_ffi_fn_method_irohnode_shutdown(
-                        self.uniffiClonePointer(),
-                        FfiConverterBool.lower(force)
-                    )
-                },
-                pollFunc: ffi_iroh_ffi_rust_future_poll_void,
-                completeFunc: ffi_iroh_ffi_rust_future_complete_void,
-                freeFunc: ffi_iroh_ffi_rust_future_free_void,
-                liftFunc: { $0 },
-                errorHandler: FfiConverterTypeIrohError__as_error.lift
-            )
-    }
-
-    /**
-     * Get statistics of the running node.
-     */
-    open func stats() async throws -> [String: CounterStats] {
-        return
-            try await uniffiRustCallAsync(
-                rustFutureFunc: {
-                    uniffi_iroh_ffi_fn_method_irohnode_stats(
-                        self.uniffiClonePointer()
-                    )
-                },
-                pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
-                completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
-                freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
-                liftFunc: FfiConverterDictionaryStringTypeCounterStats.lift,
-                errorHandler: FfiConverterTypeIrohError__as_error.lift
-            )
-    }
-
-    /**
-     * Get status information about a node
-     */
-    open func status() async throws -> NodeStatus {
-        return
-            try await uniffiRustCallAsync(
-                rustFutureFunc: {
-                    uniffi_iroh_ffi_fn_method_irohnode_status(
-                        self.uniffiClonePointer()
-                    )
-                },
-                pollFunc: ffi_iroh_ffi_rust_future_poll_pointer,
-                completeFunc: ffi_iroh_ffi_rust_future_complete_pointer,
-                freeFunc: ffi_iroh_ffi_rust_future_free_pointer,
-                liftFunc: FfiConverterTypeNodeStatus.lift,
-                errorHandler: FfiConverterTypeIrohError__as_error.lift
-            )
-    }
-
-    /**
-     * Delete a tag
-     */
-    open func tagsDelete(name: Data) async throws {
-        return
-            try await uniffiRustCallAsync(
-                rustFutureFunc: {
-                    uniffi_iroh_ffi_fn_method_irohnode_tags_delete(
-                        self.uniffiClonePointer(),
-                        FfiConverterData.lower(name)
-                    )
-                },
-                pollFunc: ffi_iroh_ffi_rust_future_poll_void,
-                completeFunc: ffi_iroh_ffi_rust_future_complete_void,
-                freeFunc: ffi_iroh_ffi_rust_future_free_void,
-                liftFunc: { $0 },
-                errorHandler: FfiConverterTypeIrohError__as_error.lift
-            )
-    }
-
-    /**
-     * List all tags
-     *
-     * Note: this allocates for each `ListTagsResponse`, if you have many `Tags`s this may be a prohibitively large list.
-     * Please file an [issue](https://github.com/n0-computer/iroh-ffi/issues/new) if you run into this issue
-     */
-    open func tagsList() async throws -> [TagInfo] {
-        return
-            try await uniffiRustCallAsync(
-                rustFutureFunc: {
-                    uniffi_iroh_ffi_fn_method_irohnode_tags_list(
-                        self.uniffiClonePointer()
-                    )
-                },
-                pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
-                completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
-                freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
-                liftFunc: FfiConverterSequenceTypeTagInfo.lift,
-                errorHandler: FfiConverterTypeIrohError__as_error.lift
-            )
-    }
-}
-
-public struct FfiConverterTypeIrohNode: FfiConverter {
-    typealias FfiType = UnsafeMutableRawPointer
-    typealias SwiftType = IrohNode
-
-    public static func lift(_ pointer: UnsafeMutableRawPointer) throws -> IrohNode {
-        return IrohNode(unsafeFromRawPointer: pointer)
-    }
-
-    public static func lower(_ value: IrohNode) -> UnsafeMutableRawPointer {
-        return value.uniffiClonePointer()
-    }
-
-    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> IrohNode {
-        let v: UInt64 = try readInt(&buf)
-        // The Rust code won't compile if a pointer won't fit in a UInt64.
-        // We have to go via `UInt` because that's the thing that's the size of a pointer.
-        let ptr = UnsafeMutableRawPointer(bitPattern: UInt(truncatingIfNeeded: v))
-        if ptr == nil {
-            throw UniffiInternalError.unexpectedNullPointer
-        }
-        return try lift(ptr!)
-    }
-
-    public static func write(_ value: IrohNode, into buf: inout [UInt8]) {
-        // This fiddling is because `Int` is the thing that's the same size as a pointer.
-        // The Rust code won't compile if a pointer won't fit in a `UInt64`.
-        writeInt(&buf, UInt64(bitPattern: Int64(Int(bitPattern: lower(value)))))
-    }
-}
-
-public func FfiConverterTypeIrohNode_lift(_ pointer: UnsafeMutableRawPointer) throws -> IrohNode {
-    return try FfiConverterTypeIrohNode.lift(pointer)
-}
-
-public func FfiConverterTypeIrohNode_lower(_ value: IrohNode) -> UnsafeMutableRawPointer {
-    return FfiConverterTypeIrohNode.lower(value)
 }
 
 /**
@@ -5970,6 +6145,326 @@ public func FfiConverterTypeMessage_lift(_ pointer: UnsafeMutableRawPointer) thr
 
 public func FfiConverterTypeMessage_lower(_ value: Message) -> UnsafeMutableRawPointer {
     return FfiConverterTypeMessage.lower(value)
+}
+
+/**
+ * Iroh node client.
+ */
+public protocol NodeProtocol: AnyObject {
+    /**
+     * Add a known node address to the node.
+     */
+    func addNodeAddr(addr: NodeAddr) async throws
+
+    /**
+     * Return connection information on the currently running node.
+     */
+    func connectionInfo(nodeId: PublicKey) async throws -> ConnectionInfo?
+
+    /**
+     * Return `ConnectionInfo`s for each connection we have to another iroh node.
+     */
+    func connections() async throws -> [ConnectionInfo]
+
+    /**
+     * Get the relay server we are connected to.
+     */
+    func homeRelay() async throws -> String?
+
+    /**
+     * Returns `Some(addr)` if an RPC endpoint is running, `None` otherwise.
+     */
+    func myRpcAddr() -> String?
+
+    /**
+     * Return the [`NodeAddr`] for this node.
+     */
+    func nodeAddr() async throws -> NodeAddr
+
+    /**
+     * The string representation of the PublicKey of this node.
+     */
+    func nodeId() async throws -> String
+
+    /**
+     * Shutdown this iroh node.
+     */
+    func shutdown(force: Bool) async throws
+
+    /**
+     * Get statistics of the running node.
+     */
+    func stats() async throws -> [String: CounterStats]
+
+    /**
+     * Get status information about a node
+     */
+    func status() async throws -> NodeStatus
+}
+
+/**
+ * Iroh node client.
+ */
+open class Node:
+    NodeProtocol
+{
+    fileprivate let pointer: UnsafeMutableRawPointer!
+
+    /// Used to instantiate a [FFIObject] without an actual pointer, for fakes in tests, mostly.
+    public struct NoPointer {
+        public init() {}
+    }
+
+    // TODO: We'd like this to be `private` but for Swifty reasons,
+    // we can't implement `FfiConverter` without making this `required` and we can't
+    // make it `required` without making it `public`.
+    public required init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
+        self.pointer = pointer
+    }
+
+    /// This constructor can be used to instantiate a fake object.
+    /// - Parameter noPointer: Placeholder value so we can have a constructor separate from the default empty one that may be implemented for classes extending [FFIObject].
+    ///
+    /// - Warning:
+    ///     Any object instantiated with this constructor cannot be passed to an actual Rust-backed object. Since there isn't a backing [Pointer] the FFI lower functions will crash.
+    public init(noPointer _: NoPointer) {
+        pointer = nil
+    }
+
+    public func uniffiClonePointer() -> UnsafeMutableRawPointer {
+        return try! rustCall { uniffi_iroh_ffi_fn_clone_node(self.pointer, $0) }
+    }
+
+    // No primary constructor declared for this class.
+
+    deinit {
+        guard let pointer = pointer else {
+            return
+        }
+
+        try! rustCall { uniffi_iroh_ffi_fn_free_node(pointer, $0) }
+    }
+
+    /**
+     * Add a known node address to the node.
+     */
+    open func addNodeAddr(addr: NodeAddr) async throws {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_node_add_node_addr(
+                        self.uniffiClonePointer(),
+                        FfiConverterTypeNodeAddr.lower(addr)
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_void,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_void,
+                freeFunc: ffi_iroh_ffi_rust_future_free_void,
+                liftFunc: { $0 },
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
+    /**
+     * Return connection information on the currently running node.
+     */
+    open func connectionInfo(nodeId: PublicKey) async throws -> ConnectionInfo? {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_node_connection_info(
+                        self.uniffiClonePointer(),
+                        FfiConverterTypePublicKey.lower(nodeId)
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
+                freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
+                liftFunc: FfiConverterOptionTypeConnectionInfo.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
+    /**
+     * Return `ConnectionInfo`s for each connection we have to another iroh node.
+     */
+    open func connections() async throws -> [ConnectionInfo] {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_node_connections(
+                        self.uniffiClonePointer()
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
+                freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
+                liftFunc: FfiConverterSequenceTypeConnectionInfo.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
+    /**
+     * Get the relay server we are connected to.
+     */
+    open func homeRelay() async throws -> String? {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_node_home_relay(
+                        self.uniffiClonePointer()
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
+                freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
+                liftFunc: FfiConverterOptionString.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
+    /**
+     * Returns `Some(addr)` if an RPC endpoint is running, `None` otherwise.
+     */
+    open func myRpcAddr() -> String? {
+        return try! FfiConverterOptionString.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_node_my_rpc_addr(self.uniffiClonePointer(), $0)
+        })
+    }
+
+    /**
+     * Return the [`NodeAddr`] for this node.
+     */
+    open func nodeAddr() async throws -> NodeAddr {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_node_node_addr(
+                        self.uniffiClonePointer()
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_pointer,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_pointer,
+                freeFunc: ffi_iroh_ffi_rust_future_free_pointer,
+                liftFunc: FfiConverterTypeNodeAddr.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
+    /**
+     * The string representation of the PublicKey of this node.
+     */
+    open func nodeId() async throws -> String {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_node_node_id(
+                        self.uniffiClonePointer()
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
+                freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
+                liftFunc: FfiConverterString.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
+    /**
+     * Shutdown this iroh node.
+     */
+    open func shutdown(force: Bool) async throws {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_node_shutdown(
+                        self.uniffiClonePointer(),
+                        FfiConverterBool.lower(force)
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_void,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_void,
+                freeFunc: ffi_iroh_ffi_rust_future_free_void,
+                liftFunc: { $0 },
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
+    /**
+     * Get statistics of the running node.
+     */
+    open func stats() async throws -> [String: CounterStats] {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_node_stats(
+                        self.uniffiClonePointer()
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
+                freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
+                liftFunc: FfiConverterDictionaryStringTypeCounterStats.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
+    /**
+     * Get status information about a node
+     */
+    open func status() async throws -> NodeStatus {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_node_status(
+                        self.uniffiClonePointer()
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_pointer,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_pointer,
+                freeFunc: ffi_iroh_ffi_rust_future_free_pointer,
+                liftFunc: FfiConverterTypeNodeStatus.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+}
+
+public struct FfiConverterTypeNode: FfiConverter {
+    typealias FfiType = UnsafeMutableRawPointer
+    typealias SwiftType = Node
+
+    public static func lift(_ pointer: UnsafeMutableRawPointer) throws -> Node {
+        return Node(unsafeFromRawPointer: pointer)
+    }
+
+    public static func lower(_ value: Node) -> UnsafeMutableRawPointer {
+        return value.uniffiClonePointer()
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> Node {
+        let v: UInt64 = try readInt(&buf)
+        // The Rust code won't compile if a pointer won't fit in a UInt64.
+        // We have to go via `UInt` because that's the thing that's the size of a pointer.
+        let ptr = UnsafeMutableRawPointer(bitPattern: UInt(truncatingIfNeeded: v))
+        if ptr == nil {
+            throw UniffiInternalError.unexpectedNullPointer
+        }
+        return try lift(ptr!)
+    }
+
+    public static func write(_ value: Node, into buf: inout [UInt8]) {
+        // This fiddling is because `Int` is the thing that's the same size as a pointer.
+        // The Rust code won't compile if a pointer won't fit in a `UInt64`.
+        writeInt(&buf, UInt64(bitPattern: Int64(Int(bitPattern: lower(value)))))
+    }
+}
+
+public func FfiConverterTypeNode_lift(_ pointer: UnsafeMutableRawPointer) throws -> Node {
+    return try FfiConverterTypeNode.lift(pointer)
+}
+
+public func FfiConverterTypeNode_lower(_ value: Node) -> UnsafeMutableRawPointer {
+    return FfiConverterTypeNode.lower(value)
 }
 
 /**
@@ -7226,6 +7721,148 @@ public func FfiConverterTypeSubscribeCallback_lift(_ pointer: UnsafeMutableRawPo
 
 public func FfiConverterTypeSubscribeCallback_lower(_ value: SubscribeCallback) -> UnsafeMutableRawPointer {
     return FfiConverterTypeSubscribeCallback.lower(value)
+}
+
+/**
+ * Iroh tags client.
+ */
+public protocol TagsProtocol: AnyObject {
+    /**
+     * Delete a tag
+     */
+    func delete(name: Data) async throws
+
+    /**
+     * List all tags
+     *
+     * Note: this allocates for each `ListTagsResponse`, if you have many `Tags`s this may be a prohibitively large list.
+     * Please file an [issue](https://github.com/n0-computer/iroh-ffi/issues/new) if you run into this issue
+     */
+    func list() async throws -> [TagInfo]
+}
+
+/**
+ * Iroh tags client.
+ */
+open class Tags:
+    TagsProtocol
+{
+    fileprivate let pointer: UnsafeMutableRawPointer!
+
+    /// Used to instantiate a [FFIObject] without an actual pointer, for fakes in tests, mostly.
+    public struct NoPointer {
+        public init() {}
+    }
+
+    // TODO: We'd like this to be `private` but for Swifty reasons,
+    // we can't implement `FfiConverter` without making this `required` and we can't
+    // make it `required` without making it `public`.
+    public required init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
+        self.pointer = pointer
+    }
+
+    /// This constructor can be used to instantiate a fake object.
+    /// - Parameter noPointer: Placeholder value so we can have a constructor separate from the default empty one that may be implemented for classes extending [FFIObject].
+    ///
+    /// - Warning:
+    ///     Any object instantiated with this constructor cannot be passed to an actual Rust-backed object. Since there isn't a backing [Pointer] the FFI lower functions will crash.
+    public init(noPointer _: NoPointer) {
+        pointer = nil
+    }
+
+    public func uniffiClonePointer() -> UnsafeMutableRawPointer {
+        return try! rustCall { uniffi_iroh_ffi_fn_clone_tags(self.pointer, $0) }
+    }
+
+    // No primary constructor declared for this class.
+
+    deinit {
+        guard let pointer = pointer else {
+            return
+        }
+
+        try! rustCall { uniffi_iroh_ffi_fn_free_tags(pointer, $0) }
+    }
+
+    /**
+     * Delete a tag
+     */
+    open func delete(name: Data) async throws {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_tags_delete(
+                        self.uniffiClonePointer(),
+                        FfiConverterData.lower(name)
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_void,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_void,
+                freeFunc: ffi_iroh_ffi_rust_future_free_void,
+                liftFunc: { $0 },
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
+    /**
+     * List all tags
+     *
+     * Note: this allocates for each `ListTagsResponse`, if you have many `Tags`s this may be a prohibitively large list.
+     * Please file an [issue](https://github.com/n0-computer/iroh-ffi/issues/new) if you run into this issue
+     */
+    open func list() async throws -> [TagInfo] {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_tags_list(
+                        self.uniffiClonePointer()
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
+                freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
+                liftFunc: FfiConverterSequenceTypeTagInfo.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+}
+
+public struct FfiConverterTypeTags: FfiConverter {
+    typealias FfiType = UnsafeMutableRawPointer
+    typealias SwiftType = Tags
+
+    public static func lift(_ pointer: UnsafeMutableRawPointer) throws -> Tags {
+        return Tags(unsafeFromRawPointer: pointer)
+    }
+
+    public static func lower(_ value: Tags) -> UnsafeMutableRawPointer {
+        return value.uniffiClonePointer()
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> Tags {
+        let v: UInt64 = try readInt(&buf)
+        // The Rust code won't compile if a pointer won't fit in a UInt64.
+        // We have to go via `UInt` because that's the thing that's the size of a pointer.
+        let ptr = UnsafeMutableRawPointer(bitPattern: UInt(truncatingIfNeeded: v))
+        if ptr == nil {
+            throw UniffiInternalError.unexpectedNullPointer
+        }
+        return try lift(ptr!)
+    }
+
+    public static func write(_ value: Tags, into buf: inout [UInt8]) {
+        // This fiddling is because `Int` is the thing that's the same size as a pointer.
+        // The Rust code won't compile if a pointer won't fit in a `UInt64`.
+        writeInt(&buf, UInt64(bitPattern: Int64(Int(bitPattern: lower(value)))))
+    }
+}
+
+public func FfiConverterTypeTags_lift(_ pointer: UnsafeMutableRawPointer) throws -> Tags {
+    return try FfiConverterTypeTags.lift(pointer)
+}
+
+public func FfiConverterTypeTags_lower(_ value: Tags) -> UnsafeMutableRawPointer {
+    return FfiConverterTypeTags.lower(value)
 }
 
 /**
@@ -12046,6 +12683,27 @@ private var initializationResult: InitializationResult = {
     if uniffi_iroh_ffi_checksum_method_authorid_equal() != 56356 {
         return InitializationResult.apiChecksumMismatch
     }
+    if uniffi_iroh_ffi_checksum_method_authors_create() != 47692 {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if uniffi_iroh_ffi_checksum_method_authors_default() != 6795 {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if uniffi_iroh_ffi_checksum_method_authors_delete() != 51040 {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if uniffi_iroh_ffi_checksum_method_authors_export() != 17391 {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if uniffi_iroh_ffi_checksum_method_authors_import() != 11067 {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if uniffi_iroh_ffi_checksum_method_authors_import_author() != 56460 {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if uniffi_iroh_ffi_checksum_method_authors_list() != 33930 {
+        return InitializationResult.apiChecksumMismatch
+    }
     if uniffi_iroh_ffi_checksum_method_blobticket_as_download_options() != 18713 {
         return InitializationResult.apiChecksumMismatch
     }
@@ -12059,6 +12717,54 @@ private var initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if uniffi_iroh_ffi_checksum_method_blobticket_recursive() != 53797 {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if uniffi_iroh_ffi_checksum_method_blobs_add_bytes() != 16525 {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if uniffi_iroh_ffi_checksum_method_blobs_add_bytes_named() != 4623 {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if uniffi_iroh_ffi_checksum_method_blobs_add_from_path() != 12412 {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if uniffi_iroh_ffi_checksum_method_blobs_create_collection() != 63440 {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if uniffi_iroh_ffi_checksum_method_blobs_delete_blob() != 24901 {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if uniffi_iroh_ffi_checksum_method_blobs_download() != 14779 {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if uniffi_iroh_ffi_checksum_method_blobs_export() != 23697 {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if uniffi_iroh_ffi_checksum_method_blobs_get_collection() != 57130 {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if uniffi_iroh_ffi_checksum_method_blobs_list() != 9714 {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if uniffi_iroh_ffi_checksum_method_blobs_list_collections() != 22274 {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if uniffi_iroh_ffi_checksum_method_blobs_list_incomplete() != 31740 {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if uniffi_iroh_ffi_checksum_method_blobs_read_at_to_bytes() != 29675 {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if uniffi_iroh_ffi_checksum_method_blobs_read_to_bytes() != 13624 {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if uniffi_iroh_ffi_checksum_method_blobs_share() != 55307 {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if uniffi_iroh_ffi_checksum_method_blobs_size() != 20254 {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if uniffi_iroh_ffi_checksum_method_blobs_write_to_path() != 47517 {
         return InitializationResult.apiChecksumMismatch
     }
     if uniffi_iroh_ffi_checksum_method_collection_blobs() != 52509 {
@@ -12106,7 +12812,7 @@ private var initializationResult: InitializationResult = {
     if uniffi_iroh_ffi_checksum_method_doc_close_me() != 13449 {
         return InitializationResult.apiChecksumMismatch
     }
-    if uniffi_iroh_ffi_checksum_method_doc_del() != 7367 {
+    if uniffi_iroh_ffi_checksum_method_doc_delete_entry() != 42178 {
         return InitializationResult.apiChecksumMismatch
     }
     if uniffi_iroh_ffi_checksum_method_doc_export_file() != 16067 {
@@ -12193,6 +12899,24 @@ private var initializationResult: InitializationResult = {
     if uniffi_iroh_ffi_checksum_method_docimportprogress_type() != 48401 {
         return InitializationResult.apiChecksumMismatch
     }
+    if uniffi_iroh_ffi_checksum_method_docs_create() != 54486 {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if uniffi_iroh_ffi_checksum_method_docs_drop_doc() != 5864 {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if uniffi_iroh_ffi_checksum_method_docs_join() != 29064 {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if uniffi_iroh_ffi_checksum_method_docs_join_and_subscribe() != 30619 {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if uniffi_iroh_ffi_checksum_method_docs_list() != 23866 {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if uniffi_iroh_ffi_checksum_method_docs_open() != 45928 {
+        return InitializationResult.apiChecksumMismatch
+    }
     if uniffi_iroh_ffi_checksum_method_downloadcallback_progress() != 21881 {
         return InitializationResult.apiChecksumMismatch
     }
@@ -12244,6 +12968,9 @@ private var initializationResult: InitializationResult = {
     if uniffi_iroh_ffi_checksum_method_filterkind_matches() != 24522 {
         return InitializationResult.apiChecksumMismatch
     }
+    if uniffi_iroh_ffi_checksum_method_gossip_subscribe() != 6414 {
+        return InitializationResult.apiChecksumMismatch
+    }
     if uniffi_iroh_ffi_checksum_method_gossipmessagecallback_on_message() != 49150 {
         return InitializationResult.apiChecksumMismatch
     }
@@ -12256,130 +12983,25 @@ private var initializationResult: InitializationResult = {
     if uniffi_iroh_ffi_checksum_method_hash_to_hex() != 52108 {
         return InitializationResult.apiChecksumMismatch
     }
+    if uniffi_iroh_ffi_checksum_method_iroh_authors() != 25106 {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if uniffi_iroh_ffi_checksum_method_iroh_blobs() != 50340 {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if uniffi_iroh_ffi_checksum_method_iroh_docs() != 17607 {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if uniffi_iroh_ffi_checksum_method_iroh_gossip() != 58884 {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if uniffi_iroh_ffi_checksum_method_iroh_node() != 12499 {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if uniffi_iroh_ffi_checksum_method_iroh_tags() != 59606 {
+        return InitializationResult.apiChecksumMismatch
+    }
     if uniffi_iroh_ffi_checksum_method_iroherror_message() != 31085 {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if uniffi_iroh_ffi_checksum_method_irohnode_add_node_addr() != 52679 {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if uniffi_iroh_ffi_checksum_method_irohnode_author_create() != 28895 {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if uniffi_iroh_ffi_checksum_method_irohnode_author_default() != 42499 {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if uniffi_iroh_ffi_checksum_method_irohnode_author_delete() != 4225 {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if uniffi_iroh_ffi_checksum_method_irohnode_author_export() != 37686 {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if uniffi_iroh_ffi_checksum_method_irohnode_author_import() != 5607 {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if uniffi_iroh_ffi_checksum_method_irohnode_author_list() != 62761 {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if uniffi_iroh_ffi_checksum_method_irohnode_blobs_add_bytes() != 17203 {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if uniffi_iroh_ffi_checksum_method_irohnode_blobs_add_bytes_named() != 63529 {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if uniffi_iroh_ffi_checksum_method_irohnode_blobs_add_from_path() != 37809 {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if uniffi_iroh_ffi_checksum_method_irohnode_blobs_create_collection() != 52712 {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if uniffi_iroh_ffi_checksum_method_irohnode_blobs_delete_blob() != 37832 {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if uniffi_iroh_ffi_checksum_method_irohnode_blobs_download() != 54471 {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if uniffi_iroh_ffi_checksum_method_irohnode_blobs_export() != 19194 {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if uniffi_iroh_ffi_checksum_method_irohnode_blobs_get_collection() != 22036 {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if uniffi_iroh_ffi_checksum_method_irohnode_blobs_list() != 31880 {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if uniffi_iroh_ffi_checksum_method_irohnode_blobs_list_collections() != 189 {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if uniffi_iroh_ffi_checksum_method_irohnode_blobs_list_incomplete() != 31752 {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if uniffi_iroh_ffi_checksum_method_irohnode_blobs_read_at_to_bytes() != 11107 {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if uniffi_iroh_ffi_checksum_method_irohnode_blobs_read_to_bytes() != 15494 {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if uniffi_iroh_ffi_checksum_method_irohnode_blobs_share() != 38899 {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if uniffi_iroh_ffi_checksum_method_irohnode_blobs_size() != 39132 {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if uniffi_iroh_ffi_checksum_method_irohnode_blobs_write_to_path() != 43769 {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if uniffi_iroh_ffi_checksum_method_irohnode_connection_info() != 64141 {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if uniffi_iroh_ffi_checksum_method_irohnode_connections() != 55452 {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if uniffi_iroh_ffi_checksum_method_irohnode_doc_create() != 25418 {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if uniffi_iroh_ffi_checksum_method_irohnode_doc_drop() != 41240 {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if uniffi_iroh_ffi_checksum_method_irohnode_doc_join() != 61748 {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if uniffi_iroh_ffi_checksum_method_irohnode_doc_join_and_subscribe() != 992 {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if uniffi_iroh_ffi_checksum_method_irohnode_doc_list() != 63026 {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if uniffi_iroh_ffi_checksum_method_irohnode_doc_open() != 16291 {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if uniffi_iroh_ffi_checksum_method_irohnode_gossip_subscribe() != 10882 {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if uniffi_iroh_ffi_checksum_method_irohnode_home_relay() != 3309 {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if uniffi_iroh_ffi_checksum_method_irohnode_my_rpc_addr() != 33640 {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if uniffi_iroh_ffi_checksum_method_irohnode_node_addr() != 20255 {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if uniffi_iroh_ffi_checksum_method_irohnode_node_id() != 46920 {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if uniffi_iroh_ffi_checksum_method_irohnode_shutdown() != 624 {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if uniffi_iroh_ffi_checksum_method_irohnode_stats() != 11985 {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if uniffi_iroh_ffi_checksum_method_irohnode_status() != 3356 {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if uniffi_iroh_ffi_checksum_method_irohnode_tags_delete() != 46770 {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if uniffi_iroh_ffi_checksum_method_irohnode_tags_list() != 567 {
         return InitializationResult.apiChecksumMismatch
     }
     if uniffi_iroh_ffi_checksum_method_liveevent_as_content_ready() != 6578 {
@@ -12416,6 +13038,36 @@ private var initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if uniffi_iroh_ffi_checksum_method_message_type() != 75 {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if uniffi_iroh_ffi_checksum_method_node_add_node_addr() != 48772 {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if uniffi_iroh_ffi_checksum_method_node_connection_info() != 19420 {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if uniffi_iroh_ffi_checksum_method_node_connections() != 60971 {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if uniffi_iroh_ffi_checksum_method_node_home_relay() != 39435 {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if uniffi_iroh_ffi_checksum_method_node_my_rpc_addr() != 34751 {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if uniffi_iroh_ffi_checksum_method_node_node_addr() != 55077 {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if uniffi_iroh_ffi_checksum_method_node_node_id() != 50937 {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if uniffi_iroh_ffi_checksum_method_node_shutdown() != 21075 {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if uniffi_iroh_ffi_checksum_method_node_stats() != 13439 {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if uniffi_iroh_ffi_checksum_method_node_status() != 21889 {
         return InitializationResult.apiChecksumMismatch
     }
     if uniffi_iroh_ffi_checksum_method_nodeaddr_direct_addresses() != 23787 {
@@ -12469,6 +13121,12 @@ private var initializationResult: InitializationResult = {
     if uniffi_iroh_ffi_checksum_method_subscribecallback_event() != 35520 {
         return InitializationResult.apiChecksumMismatch
     }
+    if uniffi_iroh_ffi_checksum_method_tags_delete() != 17755 {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if uniffi_iroh_ffi_checksum_method_tags_list() != 16151 {
+        return InitializationResult.apiChecksumMismatch
+    }
     if uniffi_iroh_ffi_checksum_constructor_author_from_string() != 63158 {
         return InitializationResult.apiChecksumMismatch
     }
@@ -12511,16 +13169,16 @@ private var initializationResult: InitializationResult = {
     if uniffi_iroh_ffi_checksum_constructor_hash_new() != 30613 {
         return InitializationResult.apiChecksumMismatch
     }
-    if uniffi_iroh_ffi_checksum_constructor_irohnode_memory() != 52721 {
+    if uniffi_iroh_ffi_checksum_constructor_iroh_memory() != 49939 {
         return InitializationResult.apiChecksumMismatch
     }
-    if uniffi_iroh_ffi_checksum_constructor_irohnode_memory_with_options() != 51113 {
+    if uniffi_iroh_ffi_checksum_constructor_iroh_memory_with_options() != 60437 {
         return InitializationResult.apiChecksumMismatch
     }
-    if uniffi_iroh_ffi_checksum_constructor_irohnode_persistent() != 9772 {
+    if uniffi_iroh_ffi_checksum_constructor_iroh_persistent() != 42623 {
         return InitializationResult.apiChecksumMismatch
     }
-    if uniffi_iroh_ffi_checksum_constructor_irohnode_persistent_with_options() != 11511 {
+    if uniffi_iroh_ffi_checksum_constructor_iroh_persistent_with_options() != 60788 {
         return InitializationResult.apiChecksumMismatch
     }
     if uniffi_iroh_ffi_checksum_constructor_nodeaddr_new() != 5759 {

--- a/IrohLib/Tests/IrohLibTests/IrohLibTests.swift
+++ b/IrohLib/Tests/IrohLibTests/IrohLibTests.swift
@@ -3,8 +3,8 @@ import XCTest
 
 final class IrohLibTests: XCTestCase {
     func testNodeId() async throws {
-        let node = try await IrohLib.IrohNode.memory()
-        let nodeId = try await node.nodeId()
+        let node = try await IrohLib.Iroh.memory()
+        let nodeId = try await node.node().nodeId()
         print(nodeId)
 
         XCTAssertEqual(true, true)

--- a/kotlin/author_test.kts
+++ b/kotlin/author_test.kts
@@ -3,30 +3,30 @@ import iroh.*
 
 kotlinx.coroutines.runBlocking {
     // create node
-    val node = IrohNode.memory()
+    val node = Iroh.memory()
 
     // creating a node also creates an author
-    assert(node.authorList().size == 1)
+    assert(node.authors().list().size == 1)
 
     // create
-    val authorId = node.authorCreate()
+    val authorId = node.authors().create()
 
     // list all authors on the node
-    assert(node.authorList().size == 2)
+    assert(node.authors().list().size == 2)
 
     // export the author
-    val author = node.authorExport(authorId)
+    val author = node.authors().export(authorId)
     assert(authorId.equal(author.id()))
 
     // remove that author from the node
-    node.authorDelete(authorId)
+    node.authors().delete(authorId)
 
     // check there are 1 authors on the node
-    assert(node.authorList().size == 1)
+    assert(node.authors().list().size == 1)
 
     // import the author back into the node
-    node.authorImport(author)
+    node.authors().import(author)
 
     // check there is 1 author on the node
-    assert(node.authorList().size == 2)
+    assert(node.authors().list().size == 2)
 }

--- a/kotlin/doc_test.kts
+++ b/kotlin/doc_test.kts
@@ -85,11 +85,11 @@ runBlocking {
 runBlocking {
     // create node
     val irohDir = kotlin.io.path.createTempDirectory("doc-test")
-    val node = IrohNode.persistent(irohDir.toString())
+    val node = Iroh.persistent(irohDir.toString())
 
     // create doc and author
-    val doc = node.docCreate()
-    val author = node.authorCreate()
+    val doc = node.docs().create()
+    val author = node.authors().create()
 
     // create entry
     val v = "hello world!".toByteArray()

--- a/kotlin/gossip_test.kts
+++ b/kotlin/gossip_test.kts
@@ -16,29 +16,29 @@ class Callback: GossipMessageCallback {
 runBlocking {
     setLogLevel(LogLevel.DEBUG)
 
-    val n0 = IrohNode.memory()
-    val n1 = IrohNode.memory()
+    val n0 = Iroh.memory()
+    val n1 = Iroh.memory()
 
     // Create a topic
     val topic = ByteArray(32) { i -> 1 }
 
     // Setup gossip on node 0
     val cb0 = Callback()
-    val n1Id = n1.nodeId()
-    val n1Addr = n1.nodeAddr()
-    n0.addNodeAddr(n1Addr)
+    val n1Id = n1.node().nodeId()
+    val n1Addr = n1.node().nodeAddr()
+    n0.node().addNodeAddr(n1Addr)
 
     println("subscribe n0")
-    val sink0 = n0.gossipSubscribe(topic, listOf(n1Id), cb0)
+    val sink0 = n0.gossip().subscribe(topic, listOf(n1Id), cb0)
 
     // Setup gossip on node 1
     val cb1 = Callback()
-    val n0Id = n0.nodeId()
-    val n0Addr = n0.nodeAddr()
-    n1.addNodeAddr(n0Addr)
+    val n0Id = n0.node().nodeId()
+    val n0Addr = n0.node().nodeAddr()
+    n1.node().addNodeAddr(n0Addr)
 
     println("subscribe n1")
-    val sink1 = n1.gossipSubscribe(topic, listOf(n0Id), cb1)
+    val sink1 = n1.gossip().subscribe(topic, listOf(n0Id), cb1)
 
     // Wait for n1 to show up for n0
     while (true) {

--- a/kotlin/iroh/iroh_ffi.kt
+++ b/kotlin/iroh/iroh_ffi.kt
@@ -1031,6 +1031,42 @@ internal interface UniffiLib : Library {
         uniffi_out_err: UniffiRustCallStatus,
     ): RustBuffer.ByValue
 
+    fun uniffi_iroh_ffi_fn_clone_authors(
+        `ptr`: Pointer,
+        uniffi_out_err: UniffiRustCallStatus,
+    ): Pointer
+
+    fun uniffi_iroh_ffi_fn_free_authors(
+        `ptr`: Pointer,
+        uniffi_out_err: UniffiRustCallStatus,
+    ): Unit
+
+    fun uniffi_iroh_ffi_fn_method_authors_create(`ptr`: Pointer): Long
+
+    fun uniffi_iroh_ffi_fn_method_authors_default(`ptr`: Pointer): Long
+
+    fun uniffi_iroh_ffi_fn_method_authors_delete(
+        `ptr`: Pointer,
+        `author`: Pointer,
+    ): Long
+
+    fun uniffi_iroh_ffi_fn_method_authors_export(
+        `ptr`: Pointer,
+        `author`: Pointer,
+    ): Long
+
+    fun uniffi_iroh_ffi_fn_method_authors_import(
+        `ptr`: Pointer,
+        `author`: Pointer,
+    ): Long
+
+    fun uniffi_iroh_ffi_fn_method_authors_import_author(
+        `ptr`: Pointer,
+        `author`: Pointer,
+    ): Long
+
+    fun uniffi_iroh_ffi_fn_method_authors_list(`ptr`: Pointer): Long
+
     fun uniffi_iroh_ffi_fn_clone_blobdownloadoptions(
         `ptr`: Pointer,
         uniffi_out_err: UniffiRustCallStatus,
@@ -1087,6 +1123,104 @@ internal interface UniffiLib : Library {
         `ptr`: Pointer,
         uniffi_out_err: UniffiRustCallStatus,
     ): Byte
+
+    fun uniffi_iroh_ffi_fn_clone_blobs(
+        `ptr`: Pointer,
+        uniffi_out_err: UniffiRustCallStatus,
+    ): Pointer
+
+    fun uniffi_iroh_ffi_fn_free_blobs(
+        `ptr`: Pointer,
+        uniffi_out_err: UniffiRustCallStatus,
+    ): Unit
+
+    fun uniffi_iroh_ffi_fn_method_blobs_add_bytes(
+        `ptr`: Pointer,
+        `bytes`: RustBuffer.ByValue,
+    ): Long
+
+    fun uniffi_iroh_ffi_fn_method_blobs_add_bytes_named(
+        `ptr`: Pointer,
+        `bytes`: RustBuffer.ByValue,
+        `name`: RustBuffer.ByValue,
+    ): Long
+
+    fun uniffi_iroh_ffi_fn_method_blobs_add_from_path(
+        `ptr`: Pointer,
+        `path`: RustBuffer.ByValue,
+        `inPlace`: Byte,
+        `tag`: Pointer,
+        `wrap`: Pointer,
+        `cb`: Pointer,
+    ): Long
+
+    fun uniffi_iroh_ffi_fn_method_blobs_create_collection(
+        `ptr`: Pointer,
+        `collection`: Pointer,
+        `tag`: Pointer,
+        `tagsToDelete`: RustBuffer.ByValue,
+    ): Long
+
+    fun uniffi_iroh_ffi_fn_method_blobs_delete_blob(
+        `ptr`: Pointer,
+        `hash`: Pointer,
+    ): Long
+
+    fun uniffi_iroh_ffi_fn_method_blobs_download(
+        `ptr`: Pointer,
+        `hash`: Pointer,
+        `opts`: Pointer,
+        `cb`: Pointer,
+    ): Long
+
+    fun uniffi_iroh_ffi_fn_method_blobs_export(
+        `ptr`: Pointer,
+        `hash`: Pointer,
+        `destination`: RustBuffer.ByValue,
+        `format`: RustBuffer.ByValue,
+        `mode`: RustBuffer.ByValue,
+    ): Long
+
+    fun uniffi_iroh_ffi_fn_method_blobs_get_collection(
+        `ptr`: Pointer,
+        `hash`: Pointer,
+    ): Long
+
+    fun uniffi_iroh_ffi_fn_method_blobs_list(`ptr`: Pointer): Long
+
+    fun uniffi_iroh_ffi_fn_method_blobs_list_collections(`ptr`: Pointer): Long
+
+    fun uniffi_iroh_ffi_fn_method_blobs_list_incomplete(`ptr`: Pointer): Long
+
+    fun uniffi_iroh_ffi_fn_method_blobs_read_at_to_bytes(
+        `ptr`: Pointer,
+        `hash`: Pointer,
+        `offset`: Long,
+        `len`: RustBuffer.ByValue,
+    ): Long
+
+    fun uniffi_iroh_ffi_fn_method_blobs_read_to_bytes(
+        `ptr`: Pointer,
+        `hash`: Pointer,
+    ): Long
+
+    fun uniffi_iroh_ffi_fn_method_blobs_share(
+        `ptr`: Pointer,
+        `hash`: Pointer,
+        `blobFormat`: RustBuffer.ByValue,
+        `ticketOptions`: RustBuffer.ByValue,
+    ): Long
+
+    fun uniffi_iroh_ffi_fn_method_blobs_size(
+        `ptr`: Pointer,
+        `hash`: Pointer,
+    ): Long
+
+    fun uniffi_iroh_ffi_fn_method_blobs_write_to_path(
+        `ptr`: Pointer,
+        `hash`: Pointer,
+        `path`: RustBuffer.ByValue,
+    ): Long
 
     fun uniffi_iroh_ffi_fn_clone_collection(
         `ptr`: Pointer,
@@ -1204,7 +1338,7 @@ internal interface UniffiLib : Library {
 
     fun uniffi_iroh_ffi_fn_method_doc_close_me(`ptr`: Pointer): Long
 
-    fun uniffi_iroh_ffi_fn_method_doc_del(
+    fun uniffi_iroh_ffi_fn_method_doc_delete_entry(
         `ptr`: Pointer,
         `authorId`: Pointer,
         `prefix`: RustBuffer.ByValue,
@@ -1396,6 +1530,41 @@ internal interface UniffiLib : Library {
         uniffi_out_err: UniffiRustCallStatus,
     ): RustBuffer.ByValue
 
+    fun uniffi_iroh_ffi_fn_clone_docs(
+        `ptr`: Pointer,
+        uniffi_out_err: UniffiRustCallStatus,
+    ): Pointer
+
+    fun uniffi_iroh_ffi_fn_free_docs(
+        `ptr`: Pointer,
+        uniffi_out_err: UniffiRustCallStatus,
+    ): Unit
+
+    fun uniffi_iroh_ffi_fn_method_docs_create(`ptr`: Pointer): Long
+
+    fun uniffi_iroh_ffi_fn_method_docs_drop_doc(
+        `ptr`: Pointer,
+        `docId`: RustBuffer.ByValue,
+    ): Long
+
+    fun uniffi_iroh_ffi_fn_method_docs_join(
+        `ptr`: Pointer,
+        `ticket`: RustBuffer.ByValue,
+    ): Long
+
+    fun uniffi_iroh_ffi_fn_method_docs_join_and_subscribe(
+        `ptr`: Pointer,
+        `ticket`: RustBuffer.ByValue,
+        `cb`: Pointer,
+    ): Long
+
+    fun uniffi_iroh_ffi_fn_method_docs_list(`ptr`: Pointer): Long
+
+    fun uniffi_iroh_ffi_fn_method_docs_open(
+        `ptr`: Pointer,
+        `id`: RustBuffer.ByValue,
+    ): Long
+
     fun uniffi_iroh_ffi_fn_clone_downloadcallback(
         `ptr`: Pointer,
         uniffi_out_err: UniffiRustCallStatus,
@@ -1558,6 +1727,23 @@ internal interface UniffiLib : Library {
         uniffi_out_err: UniffiRustCallStatus,
     ): Byte
 
+    fun uniffi_iroh_ffi_fn_clone_gossip(
+        `ptr`: Pointer,
+        uniffi_out_err: UniffiRustCallStatus,
+    ): Pointer
+
+    fun uniffi_iroh_ffi_fn_free_gossip(
+        `ptr`: Pointer,
+        uniffi_out_err: UniffiRustCallStatus,
+    ): Unit
+
+    fun uniffi_iroh_ffi_fn_method_gossip_subscribe(
+        `ptr`: Pointer,
+        `topic`: RustBuffer.ByValue,
+        `bootstrap`: RustBuffer.ByValue,
+        `cb`: Pointer,
+    ): Long
+
     fun uniffi_iroh_ffi_fn_clone_gossipmessagecallback(
         `ptr`: Pointer,
         uniffi_out_err: UniffiRustCallStatus,
@@ -1621,6 +1807,57 @@ internal interface UniffiLib : Library {
         uniffi_out_err: UniffiRustCallStatus,
     ): RustBuffer.ByValue
 
+    fun uniffi_iroh_ffi_fn_clone_iroh(
+        `ptr`: Pointer,
+        uniffi_out_err: UniffiRustCallStatus,
+    ): Pointer
+
+    fun uniffi_iroh_ffi_fn_free_iroh(
+        `ptr`: Pointer,
+        uniffi_out_err: UniffiRustCallStatus,
+    ): Unit
+
+    fun uniffi_iroh_ffi_fn_constructor_iroh_memory(): Long
+
+    fun uniffi_iroh_ffi_fn_constructor_iroh_memory_with_options(`options`: RustBuffer.ByValue): Long
+
+    fun uniffi_iroh_ffi_fn_constructor_iroh_persistent(`path`: RustBuffer.ByValue): Long
+
+    fun uniffi_iroh_ffi_fn_constructor_iroh_persistent_with_options(
+        `path`: RustBuffer.ByValue,
+        `options`: RustBuffer.ByValue,
+    ): Long
+
+    fun uniffi_iroh_ffi_fn_method_iroh_authors(
+        `ptr`: Pointer,
+        uniffi_out_err: UniffiRustCallStatus,
+    ): Pointer
+
+    fun uniffi_iroh_ffi_fn_method_iroh_blobs(
+        `ptr`: Pointer,
+        uniffi_out_err: UniffiRustCallStatus,
+    ): Pointer
+
+    fun uniffi_iroh_ffi_fn_method_iroh_docs(
+        `ptr`: Pointer,
+        uniffi_out_err: UniffiRustCallStatus,
+    ): Pointer
+
+    fun uniffi_iroh_ffi_fn_method_iroh_gossip(
+        `ptr`: Pointer,
+        uniffi_out_err: UniffiRustCallStatus,
+    ): Pointer
+
+    fun uniffi_iroh_ffi_fn_method_iroh_node(
+        `ptr`: Pointer,
+        uniffi_out_err: UniffiRustCallStatus,
+    ): Pointer
+
+    fun uniffi_iroh_ffi_fn_method_iroh_tags(
+        `ptr`: Pointer,
+        uniffi_out_err: UniffiRustCallStatus,
+    ): Pointer
+
     fun uniffi_iroh_ffi_fn_clone_iroherror(
         `ptr`: Pointer,
         uniffi_out_err: UniffiRustCallStatus,
@@ -1640,207 +1877,6 @@ internal interface UniffiLib : Library {
         `ptr`: Pointer,
         uniffi_out_err: UniffiRustCallStatus,
     ): RustBuffer.ByValue
-
-    fun uniffi_iroh_ffi_fn_clone_irohnode(
-        `ptr`: Pointer,
-        uniffi_out_err: UniffiRustCallStatus,
-    ): Pointer
-
-    fun uniffi_iroh_ffi_fn_free_irohnode(
-        `ptr`: Pointer,
-        uniffi_out_err: UniffiRustCallStatus,
-    ): Unit
-
-    fun uniffi_iroh_ffi_fn_constructor_irohnode_memory(): Long
-
-    fun uniffi_iroh_ffi_fn_constructor_irohnode_memory_with_options(`options`: RustBuffer.ByValue): Long
-
-    fun uniffi_iroh_ffi_fn_constructor_irohnode_persistent(`path`: RustBuffer.ByValue): Long
-
-    fun uniffi_iroh_ffi_fn_constructor_irohnode_persistent_with_options(
-        `path`: RustBuffer.ByValue,
-        `options`: RustBuffer.ByValue,
-    ): Long
-
-    fun uniffi_iroh_ffi_fn_method_irohnode_add_node_addr(
-        `ptr`: Pointer,
-        `addr`: Pointer,
-    ): Long
-
-    fun uniffi_iroh_ffi_fn_method_irohnode_author_create(`ptr`: Pointer): Long
-
-    fun uniffi_iroh_ffi_fn_method_irohnode_author_default(`ptr`: Pointer): Long
-
-    fun uniffi_iroh_ffi_fn_method_irohnode_author_delete(
-        `ptr`: Pointer,
-        `author`: Pointer,
-    ): Long
-
-    fun uniffi_iroh_ffi_fn_method_irohnode_author_export(
-        `ptr`: Pointer,
-        `author`: Pointer,
-    ): Long
-
-    fun uniffi_iroh_ffi_fn_method_irohnode_author_import(
-        `ptr`: Pointer,
-        `author`: Pointer,
-    ): Long
-
-    fun uniffi_iroh_ffi_fn_method_irohnode_author_list(`ptr`: Pointer): Long
-
-    fun uniffi_iroh_ffi_fn_method_irohnode_blobs_add_bytes(
-        `ptr`: Pointer,
-        `bytes`: RustBuffer.ByValue,
-    ): Long
-
-    fun uniffi_iroh_ffi_fn_method_irohnode_blobs_add_bytes_named(
-        `ptr`: Pointer,
-        `bytes`: RustBuffer.ByValue,
-        `name`: RustBuffer.ByValue,
-    ): Long
-
-    fun uniffi_iroh_ffi_fn_method_irohnode_blobs_add_from_path(
-        `ptr`: Pointer,
-        `path`: RustBuffer.ByValue,
-        `inPlace`: Byte,
-        `tag`: Pointer,
-        `wrap`: Pointer,
-        `cb`: Pointer,
-    ): Long
-
-    fun uniffi_iroh_ffi_fn_method_irohnode_blobs_create_collection(
-        `ptr`: Pointer,
-        `collection`: Pointer,
-        `tag`: Pointer,
-        `tagsToDelete`: RustBuffer.ByValue,
-    ): Long
-
-    fun uniffi_iroh_ffi_fn_method_irohnode_blobs_delete_blob(
-        `ptr`: Pointer,
-        `hash`: Pointer,
-    ): Long
-
-    fun uniffi_iroh_ffi_fn_method_irohnode_blobs_download(
-        `ptr`: Pointer,
-        `hash`: Pointer,
-        `opts`: Pointer,
-        `cb`: Pointer,
-    ): Long
-
-    fun uniffi_iroh_ffi_fn_method_irohnode_blobs_export(
-        `ptr`: Pointer,
-        `hash`: Pointer,
-        `destination`: RustBuffer.ByValue,
-        `format`: RustBuffer.ByValue,
-        `mode`: RustBuffer.ByValue,
-    ): Long
-
-    fun uniffi_iroh_ffi_fn_method_irohnode_blobs_get_collection(
-        `ptr`: Pointer,
-        `hash`: Pointer,
-    ): Long
-
-    fun uniffi_iroh_ffi_fn_method_irohnode_blobs_list(`ptr`: Pointer): Long
-
-    fun uniffi_iroh_ffi_fn_method_irohnode_blobs_list_collections(`ptr`: Pointer): Long
-
-    fun uniffi_iroh_ffi_fn_method_irohnode_blobs_list_incomplete(`ptr`: Pointer): Long
-
-    fun uniffi_iroh_ffi_fn_method_irohnode_blobs_read_at_to_bytes(
-        `ptr`: Pointer,
-        `hash`: Pointer,
-        `offset`: Long,
-        `len`: RustBuffer.ByValue,
-    ): Long
-
-    fun uniffi_iroh_ffi_fn_method_irohnode_blobs_read_to_bytes(
-        `ptr`: Pointer,
-        `hash`: Pointer,
-    ): Long
-
-    fun uniffi_iroh_ffi_fn_method_irohnode_blobs_share(
-        `ptr`: Pointer,
-        `hash`: Pointer,
-        `blobFormat`: RustBuffer.ByValue,
-        `ticketOptions`: RustBuffer.ByValue,
-    ): Long
-
-    fun uniffi_iroh_ffi_fn_method_irohnode_blobs_size(
-        `ptr`: Pointer,
-        `hash`: Pointer,
-    ): Long
-
-    fun uniffi_iroh_ffi_fn_method_irohnode_blobs_write_to_path(
-        `ptr`: Pointer,
-        `hash`: Pointer,
-        `path`: RustBuffer.ByValue,
-    ): Long
-
-    fun uniffi_iroh_ffi_fn_method_irohnode_connection_info(
-        `ptr`: Pointer,
-        `nodeId`: Pointer,
-    ): Long
-
-    fun uniffi_iroh_ffi_fn_method_irohnode_connections(`ptr`: Pointer): Long
-
-    fun uniffi_iroh_ffi_fn_method_irohnode_doc_create(`ptr`: Pointer): Long
-
-    fun uniffi_iroh_ffi_fn_method_irohnode_doc_drop(
-        `ptr`: Pointer,
-        `docId`: RustBuffer.ByValue,
-    ): Long
-
-    fun uniffi_iroh_ffi_fn_method_irohnode_doc_join(
-        `ptr`: Pointer,
-        `ticket`: RustBuffer.ByValue,
-    ): Long
-
-    fun uniffi_iroh_ffi_fn_method_irohnode_doc_join_and_subscribe(
-        `ptr`: Pointer,
-        `ticket`: RustBuffer.ByValue,
-        `cb`: Pointer,
-    ): Long
-
-    fun uniffi_iroh_ffi_fn_method_irohnode_doc_list(`ptr`: Pointer): Long
-
-    fun uniffi_iroh_ffi_fn_method_irohnode_doc_open(
-        `ptr`: Pointer,
-        `id`: RustBuffer.ByValue,
-    ): Long
-
-    fun uniffi_iroh_ffi_fn_method_irohnode_gossip_subscribe(
-        `ptr`: Pointer,
-        `topic`: RustBuffer.ByValue,
-        `bootstrap`: RustBuffer.ByValue,
-        `cb`: Pointer,
-    ): Long
-
-    fun uniffi_iroh_ffi_fn_method_irohnode_home_relay(`ptr`: Pointer): Long
-
-    fun uniffi_iroh_ffi_fn_method_irohnode_my_rpc_addr(
-        `ptr`: Pointer,
-        uniffi_out_err: UniffiRustCallStatus,
-    ): RustBuffer.ByValue
-
-    fun uniffi_iroh_ffi_fn_method_irohnode_node_addr(`ptr`: Pointer): Long
-
-    fun uniffi_iroh_ffi_fn_method_irohnode_node_id(`ptr`: Pointer): Long
-
-    fun uniffi_iroh_ffi_fn_method_irohnode_shutdown(
-        `ptr`: Pointer,
-        `force`: Byte,
-    ): Long
-
-    fun uniffi_iroh_ffi_fn_method_irohnode_stats(`ptr`: Pointer): Long
-
-    fun uniffi_iroh_ffi_fn_method_irohnode_status(`ptr`: Pointer): Long
-
-    fun uniffi_iroh_ffi_fn_method_irohnode_tags_delete(
-        `ptr`: Pointer,
-        `name`: RustBuffer.ByValue,
-    ): Long
-
-    fun uniffi_iroh_ffi_fn_method_irohnode_tags_list(`ptr`: Pointer): Long
 
     fun uniffi_iroh_ffi_fn_clone_liveevent(
         `ptr`: Pointer,
@@ -1921,6 +1957,48 @@ internal interface UniffiLib : Library {
         `ptr`: Pointer,
         uniffi_out_err: UniffiRustCallStatus,
     ): RustBuffer.ByValue
+
+    fun uniffi_iroh_ffi_fn_clone_node(
+        `ptr`: Pointer,
+        uniffi_out_err: UniffiRustCallStatus,
+    ): Pointer
+
+    fun uniffi_iroh_ffi_fn_free_node(
+        `ptr`: Pointer,
+        uniffi_out_err: UniffiRustCallStatus,
+    ): Unit
+
+    fun uniffi_iroh_ffi_fn_method_node_add_node_addr(
+        `ptr`: Pointer,
+        `addr`: Pointer,
+    ): Long
+
+    fun uniffi_iroh_ffi_fn_method_node_connection_info(
+        `ptr`: Pointer,
+        `nodeId`: Pointer,
+    ): Long
+
+    fun uniffi_iroh_ffi_fn_method_node_connections(`ptr`: Pointer): Long
+
+    fun uniffi_iroh_ffi_fn_method_node_home_relay(`ptr`: Pointer): Long
+
+    fun uniffi_iroh_ffi_fn_method_node_my_rpc_addr(
+        `ptr`: Pointer,
+        uniffi_out_err: UniffiRustCallStatus,
+    ): RustBuffer.ByValue
+
+    fun uniffi_iroh_ffi_fn_method_node_node_addr(`ptr`: Pointer): Long
+
+    fun uniffi_iroh_ffi_fn_method_node_node_id(`ptr`: Pointer): Long
+
+    fun uniffi_iroh_ffi_fn_method_node_shutdown(
+        `ptr`: Pointer,
+        `force`: Byte,
+    ): Long
+
+    fun uniffi_iroh_ffi_fn_method_node_stats(`ptr`: Pointer): Long
+
+    fun uniffi_iroh_ffi_fn_method_node_status(`ptr`: Pointer): Long
 
     fun uniffi_iroh_ffi_fn_clone_nodeaddr(
         `ptr`: Pointer,
@@ -2171,6 +2249,23 @@ internal interface UniffiLib : Library {
         `ptr`: Pointer,
         `event`: Pointer,
     ): Long
+
+    fun uniffi_iroh_ffi_fn_clone_tags(
+        `ptr`: Pointer,
+        uniffi_out_err: UniffiRustCallStatus,
+    ): Pointer
+
+    fun uniffi_iroh_ffi_fn_free_tags(
+        `ptr`: Pointer,
+        uniffi_out_err: UniffiRustCallStatus,
+    ): Unit
+
+    fun uniffi_iroh_ffi_fn_method_tags_delete(
+        `ptr`: Pointer,
+        `name`: RustBuffer.ByValue,
+    ): Long
+
+    fun uniffi_iroh_ffi_fn_method_tags_list(`ptr`: Pointer): Long
 
     fun uniffi_iroh_ffi_fn_clone_wrapoption(
         `ptr`: Pointer,
@@ -2452,6 +2547,20 @@ internal interface UniffiLib : Library {
 
     fun uniffi_iroh_ffi_checksum_method_authorid_equal(): Short
 
+    fun uniffi_iroh_ffi_checksum_method_authors_create(): Short
+
+    fun uniffi_iroh_ffi_checksum_method_authors_default(): Short
+
+    fun uniffi_iroh_ffi_checksum_method_authors_delete(): Short
+
+    fun uniffi_iroh_ffi_checksum_method_authors_export(): Short
+
+    fun uniffi_iroh_ffi_checksum_method_authors_import(): Short
+
+    fun uniffi_iroh_ffi_checksum_method_authors_import_author(): Short
+
+    fun uniffi_iroh_ffi_checksum_method_authors_list(): Short
+
     fun uniffi_iroh_ffi_checksum_method_blobticket_as_download_options(): Short
 
     fun uniffi_iroh_ffi_checksum_method_blobticket_format(): Short
@@ -2461,6 +2570,38 @@ internal interface UniffiLib : Library {
     fun uniffi_iroh_ffi_checksum_method_blobticket_node_addr(): Short
 
     fun uniffi_iroh_ffi_checksum_method_blobticket_recursive(): Short
+
+    fun uniffi_iroh_ffi_checksum_method_blobs_add_bytes(): Short
+
+    fun uniffi_iroh_ffi_checksum_method_blobs_add_bytes_named(): Short
+
+    fun uniffi_iroh_ffi_checksum_method_blobs_add_from_path(): Short
+
+    fun uniffi_iroh_ffi_checksum_method_blobs_create_collection(): Short
+
+    fun uniffi_iroh_ffi_checksum_method_blobs_delete_blob(): Short
+
+    fun uniffi_iroh_ffi_checksum_method_blobs_download(): Short
+
+    fun uniffi_iroh_ffi_checksum_method_blobs_export(): Short
+
+    fun uniffi_iroh_ffi_checksum_method_blobs_get_collection(): Short
+
+    fun uniffi_iroh_ffi_checksum_method_blobs_list(): Short
+
+    fun uniffi_iroh_ffi_checksum_method_blobs_list_collections(): Short
+
+    fun uniffi_iroh_ffi_checksum_method_blobs_list_incomplete(): Short
+
+    fun uniffi_iroh_ffi_checksum_method_blobs_read_at_to_bytes(): Short
+
+    fun uniffi_iroh_ffi_checksum_method_blobs_read_to_bytes(): Short
+
+    fun uniffi_iroh_ffi_checksum_method_blobs_share(): Short
+
+    fun uniffi_iroh_ffi_checksum_method_blobs_size(): Short
+
+    fun uniffi_iroh_ffi_checksum_method_blobs_write_to_path(): Short
 
     fun uniffi_iroh_ffi_checksum_method_collection_blobs(): Short
 
@@ -2492,7 +2633,7 @@ internal interface UniffiLib : Library {
 
     fun uniffi_iroh_ffi_checksum_method_doc_close_me(): Short
 
-    fun uniffi_iroh_ffi_checksum_method_doc_del(): Short
+    fun uniffi_iroh_ffi_checksum_method_doc_delete_entry(): Short
 
     fun uniffi_iroh_ffi_checksum_method_doc_export_file(): Short
 
@@ -2550,6 +2691,18 @@ internal interface UniffiLib : Library {
 
     fun uniffi_iroh_ffi_checksum_method_docimportprogress_type(): Short
 
+    fun uniffi_iroh_ffi_checksum_method_docs_create(): Short
+
+    fun uniffi_iroh_ffi_checksum_method_docs_drop_doc(): Short
+
+    fun uniffi_iroh_ffi_checksum_method_docs_join(): Short
+
+    fun uniffi_iroh_ffi_checksum_method_docs_join_and_subscribe(): Short
+
+    fun uniffi_iroh_ffi_checksum_method_docs_list(): Short
+
+    fun uniffi_iroh_ffi_checksum_method_docs_open(): Short
+
     fun uniffi_iroh_ffi_checksum_method_downloadcallback_progress(): Short
 
     fun uniffi_iroh_ffi_checksum_method_downloadprogress_as_abort(): Short
@@ -2584,6 +2737,8 @@ internal interface UniffiLib : Library {
 
     fun uniffi_iroh_ffi_checksum_method_filterkind_matches(): Short
 
+    fun uniffi_iroh_ffi_checksum_method_gossip_subscribe(): Short
+
     fun uniffi_iroh_ffi_checksum_method_gossipmessagecallback_on_message(): Short
 
     fun uniffi_iroh_ffi_checksum_method_hash_equal(): Short
@@ -2592,89 +2747,19 @@ internal interface UniffiLib : Library {
 
     fun uniffi_iroh_ffi_checksum_method_hash_to_hex(): Short
 
+    fun uniffi_iroh_ffi_checksum_method_iroh_authors(): Short
+
+    fun uniffi_iroh_ffi_checksum_method_iroh_blobs(): Short
+
+    fun uniffi_iroh_ffi_checksum_method_iroh_docs(): Short
+
+    fun uniffi_iroh_ffi_checksum_method_iroh_gossip(): Short
+
+    fun uniffi_iroh_ffi_checksum_method_iroh_node(): Short
+
+    fun uniffi_iroh_ffi_checksum_method_iroh_tags(): Short
+
     fun uniffi_iroh_ffi_checksum_method_iroherror_message(): Short
-
-    fun uniffi_iroh_ffi_checksum_method_irohnode_add_node_addr(): Short
-
-    fun uniffi_iroh_ffi_checksum_method_irohnode_author_create(): Short
-
-    fun uniffi_iroh_ffi_checksum_method_irohnode_author_default(): Short
-
-    fun uniffi_iroh_ffi_checksum_method_irohnode_author_delete(): Short
-
-    fun uniffi_iroh_ffi_checksum_method_irohnode_author_export(): Short
-
-    fun uniffi_iroh_ffi_checksum_method_irohnode_author_import(): Short
-
-    fun uniffi_iroh_ffi_checksum_method_irohnode_author_list(): Short
-
-    fun uniffi_iroh_ffi_checksum_method_irohnode_blobs_add_bytes(): Short
-
-    fun uniffi_iroh_ffi_checksum_method_irohnode_blobs_add_bytes_named(): Short
-
-    fun uniffi_iroh_ffi_checksum_method_irohnode_blobs_add_from_path(): Short
-
-    fun uniffi_iroh_ffi_checksum_method_irohnode_blobs_create_collection(): Short
-
-    fun uniffi_iroh_ffi_checksum_method_irohnode_blobs_delete_blob(): Short
-
-    fun uniffi_iroh_ffi_checksum_method_irohnode_blobs_download(): Short
-
-    fun uniffi_iroh_ffi_checksum_method_irohnode_blobs_export(): Short
-
-    fun uniffi_iroh_ffi_checksum_method_irohnode_blobs_get_collection(): Short
-
-    fun uniffi_iroh_ffi_checksum_method_irohnode_blobs_list(): Short
-
-    fun uniffi_iroh_ffi_checksum_method_irohnode_blobs_list_collections(): Short
-
-    fun uniffi_iroh_ffi_checksum_method_irohnode_blobs_list_incomplete(): Short
-
-    fun uniffi_iroh_ffi_checksum_method_irohnode_blobs_read_at_to_bytes(): Short
-
-    fun uniffi_iroh_ffi_checksum_method_irohnode_blobs_read_to_bytes(): Short
-
-    fun uniffi_iroh_ffi_checksum_method_irohnode_blobs_share(): Short
-
-    fun uniffi_iroh_ffi_checksum_method_irohnode_blobs_size(): Short
-
-    fun uniffi_iroh_ffi_checksum_method_irohnode_blobs_write_to_path(): Short
-
-    fun uniffi_iroh_ffi_checksum_method_irohnode_connection_info(): Short
-
-    fun uniffi_iroh_ffi_checksum_method_irohnode_connections(): Short
-
-    fun uniffi_iroh_ffi_checksum_method_irohnode_doc_create(): Short
-
-    fun uniffi_iroh_ffi_checksum_method_irohnode_doc_drop(): Short
-
-    fun uniffi_iroh_ffi_checksum_method_irohnode_doc_join(): Short
-
-    fun uniffi_iroh_ffi_checksum_method_irohnode_doc_join_and_subscribe(): Short
-
-    fun uniffi_iroh_ffi_checksum_method_irohnode_doc_list(): Short
-
-    fun uniffi_iroh_ffi_checksum_method_irohnode_doc_open(): Short
-
-    fun uniffi_iroh_ffi_checksum_method_irohnode_gossip_subscribe(): Short
-
-    fun uniffi_iroh_ffi_checksum_method_irohnode_home_relay(): Short
-
-    fun uniffi_iroh_ffi_checksum_method_irohnode_my_rpc_addr(): Short
-
-    fun uniffi_iroh_ffi_checksum_method_irohnode_node_addr(): Short
-
-    fun uniffi_iroh_ffi_checksum_method_irohnode_node_id(): Short
-
-    fun uniffi_iroh_ffi_checksum_method_irohnode_shutdown(): Short
-
-    fun uniffi_iroh_ffi_checksum_method_irohnode_stats(): Short
-
-    fun uniffi_iroh_ffi_checksum_method_irohnode_status(): Short
-
-    fun uniffi_iroh_ffi_checksum_method_irohnode_tags_delete(): Short
-
-    fun uniffi_iroh_ffi_checksum_method_irohnode_tags_list(): Short
 
     fun uniffi_iroh_ffi_checksum_method_liveevent_as_content_ready(): Short
 
@@ -2699,6 +2784,26 @@ internal interface UniffiLib : Library {
     fun uniffi_iroh_ffi_checksum_method_message_as_received(): Short
 
     fun uniffi_iroh_ffi_checksum_method_message_type(): Short
+
+    fun uniffi_iroh_ffi_checksum_method_node_add_node_addr(): Short
+
+    fun uniffi_iroh_ffi_checksum_method_node_connection_info(): Short
+
+    fun uniffi_iroh_ffi_checksum_method_node_connections(): Short
+
+    fun uniffi_iroh_ffi_checksum_method_node_home_relay(): Short
+
+    fun uniffi_iroh_ffi_checksum_method_node_my_rpc_addr(): Short
+
+    fun uniffi_iroh_ffi_checksum_method_node_node_addr(): Short
+
+    fun uniffi_iroh_ffi_checksum_method_node_node_id(): Short
+
+    fun uniffi_iroh_ffi_checksum_method_node_shutdown(): Short
+
+    fun uniffi_iroh_ffi_checksum_method_node_stats(): Short
+
+    fun uniffi_iroh_ffi_checksum_method_node_status(): Short
 
     fun uniffi_iroh_ffi_checksum_method_nodeaddr_direct_addresses(): Short
 
@@ -2734,6 +2839,10 @@ internal interface UniffiLib : Library {
 
     fun uniffi_iroh_ffi_checksum_method_subscribecallback_event(): Short
 
+    fun uniffi_iroh_ffi_checksum_method_tags_delete(): Short
+
+    fun uniffi_iroh_ffi_checksum_method_tags_list(): Short
+
     fun uniffi_iroh_ffi_checksum_constructor_author_from_string(): Short
 
     fun uniffi_iroh_ffi_checksum_constructor_authorid_from_string(): Short
@@ -2762,13 +2871,13 @@ internal interface UniffiLib : Library {
 
     fun uniffi_iroh_ffi_checksum_constructor_hash_new(): Short
 
-    fun uniffi_iroh_ffi_checksum_constructor_irohnode_memory(): Short
+    fun uniffi_iroh_ffi_checksum_constructor_iroh_memory(): Short
 
-    fun uniffi_iroh_ffi_checksum_constructor_irohnode_memory_with_options(): Short
+    fun uniffi_iroh_ffi_checksum_constructor_iroh_memory_with_options(): Short
 
-    fun uniffi_iroh_ffi_checksum_constructor_irohnode_persistent(): Short
+    fun uniffi_iroh_ffi_checksum_constructor_iroh_persistent(): Short
 
-    fun uniffi_iroh_ffi_checksum_constructor_irohnode_persistent_with_options(): Short
+    fun uniffi_iroh_ffi_checksum_constructor_iroh_persistent_with_options(): Short
 
     fun uniffi_iroh_ffi_checksum_constructor_nodeaddr_new(): Short
 
@@ -2856,6 +2965,27 @@ private fun uniffiCheckApiChecksums(lib: UniffiLib) {
     if (lib.uniffi_iroh_ffi_checksum_method_authorid_equal() != 56356.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
+    if (lib.uniffi_iroh_ffi_checksum_method_authors_create() != 47692.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_iroh_ffi_checksum_method_authors_default() != 6795.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_iroh_ffi_checksum_method_authors_delete() != 51040.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_iroh_ffi_checksum_method_authors_export() != 17391.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_iroh_ffi_checksum_method_authors_import() != 11067.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_iroh_ffi_checksum_method_authors_import_author() != 56460.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_iroh_ffi_checksum_method_authors_list() != 33930.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
     if (lib.uniffi_iroh_ffi_checksum_method_blobticket_as_download_options() != 18713.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
@@ -2869,6 +2999,54 @@ private fun uniffiCheckApiChecksums(lib: UniffiLib) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_iroh_ffi_checksum_method_blobticket_recursive() != 53797.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_iroh_ffi_checksum_method_blobs_add_bytes() != 16525.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_iroh_ffi_checksum_method_blobs_add_bytes_named() != 4623.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_iroh_ffi_checksum_method_blobs_add_from_path() != 12412.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_iroh_ffi_checksum_method_blobs_create_collection() != 63440.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_iroh_ffi_checksum_method_blobs_delete_blob() != 24901.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_iroh_ffi_checksum_method_blobs_download() != 14779.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_iroh_ffi_checksum_method_blobs_export() != 23697.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_iroh_ffi_checksum_method_blobs_get_collection() != 57130.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_iroh_ffi_checksum_method_blobs_list() != 9714.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_iroh_ffi_checksum_method_blobs_list_collections() != 22274.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_iroh_ffi_checksum_method_blobs_list_incomplete() != 31740.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_iroh_ffi_checksum_method_blobs_read_at_to_bytes() != 29675.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_iroh_ffi_checksum_method_blobs_read_to_bytes() != 13624.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_iroh_ffi_checksum_method_blobs_share() != 55307.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_iroh_ffi_checksum_method_blobs_size() != 20254.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_iroh_ffi_checksum_method_blobs_write_to_path() != 47517.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_iroh_ffi_checksum_method_collection_blobs() != 52509.toShort()) {
@@ -2916,7 +3094,7 @@ private fun uniffiCheckApiChecksums(lib: UniffiLib) {
     if (lib.uniffi_iroh_ffi_checksum_method_doc_close_me() != 13449.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_iroh_ffi_checksum_method_doc_del() != 7367.toShort()) {
+    if (lib.uniffi_iroh_ffi_checksum_method_doc_delete_entry() != 42178.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_iroh_ffi_checksum_method_doc_export_file() != 16067.toShort()) {
@@ -3003,6 +3181,24 @@ private fun uniffiCheckApiChecksums(lib: UniffiLib) {
     if (lib.uniffi_iroh_ffi_checksum_method_docimportprogress_type() != 48401.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
+    if (lib.uniffi_iroh_ffi_checksum_method_docs_create() != 54486.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_iroh_ffi_checksum_method_docs_drop_doc() != 5864.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_iroh_ffi_checksum_method_docs_join() != 29064.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_iroh_ffi_checksum_method_docs_join_and_subscribe() != 30619.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_iroh_ffi_checksum_method_docs_list() != 23866.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_iroh_ffi_checksum_method_docs_open() != 45928.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
     if (lib.uniffi_iroh_ffi_checksum_method_downloadcallback_progress() != 21881.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
@@ -3054,6 +3250,9 @@ private fun uniffiCheckApiChecksums(lib: UniffiLib) {
     if (lib.uniffi_iroh_ffi_checksum_method_filterkind_matches() != 24522.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
+    if (lib.uniffi_iroh_ffi_checksum_method_gossip_subscribe() != 6414.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
     if (lib.uniffi_iroh_ffi_checksum_method_gossipmessagecallback_on_message() != 49150.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
@@ -3066,130 +3265,25 @@ private fun uniffiCheckApiChecksums(lib: UniffiLib) {
     if (lib.uniffi_iroh_ffi_checksum_method_hash_to_hex() != 52108.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
+    if (lib.uniffi_iroh_ffi_checksum_method_iroh_authors() != 25106.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_iroh_ffi_checksum_method_iroh_blobs() != 50340.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_iroh_ffi_checksum_method_iroh_docs() != 17607.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_iroh_ffi_checksum_method_iroh_gossip() != 58884.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_iroh_ffi_checksum_method_iroh_node() != 12499.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_iroh_ffi_checksum_method_iroh_tags() != 59606.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
     if (lib.uniffi_iroh_ffi_checksum_method_iroherror_message() != 31085.toShort()) {
-        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    }
-    if (lib.uniffi_iroh_ffi_checksum_method_irohnode_add_node_addr() != 52679.toShort()) {
-        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    }
-    if (lib.uniffi_iroh_ffi_checksum_method_irohnode_author_create() != 28895.toShort()) {
-        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    }
-    if (lib.uniffi_iroh_ffi_checksum_method_irohnode_author_default() != 42499.toShort()) {
-        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    }
-    if (lib.uniffi_iroh_ffi_checksum_method_irohnode_author_delete() != 4225.toShort()) {
-        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    }
-    if (lib.uniffi_iroh_ffi_checksum_method_irohnode_author_export() != 37686.toShort()) {
-        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    }
-    if (lib.uniffi_iroh_ffi_checksum_method_irohnode_author_import() != 5607.toShort()) {
-        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    }
-    if (lib.uniffi_iroh_ffi_checksum_method_irohnode_author_list() != 62761.toShort()) {
-        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    }
-    if (lib.uniffi_iroh_ffi_checksum_method_irohnode_blobs_add_bytes() != 17203.toShort()) {
-        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    }
-    if (lib.uniffi_iroh_ffi_checksum_method_irohnode_blobs_add_bytes_named() != 63529.toShort()) {
-        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    }
-    if (lib.uniffi_iroh_ffi_checksum_method_irohnode_blobs_add_from_path() != 37809.toShort()) {
-        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    }
-    if (lib.uniffi_iroh_ffi_checksum_method_irohnode_blobs_create_collection() != 52712.toShort()) {
-        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    }
-    if (lib.uniffi_iroh_ffi_checksum_method_irohnode_blobs_delete_blob() != 37832.toShort()) {
-        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    }
-    if (lib.uniffi_iroh_ffi_checksum_method_irohnode_blobs_download() != 54471.toShort()) {
-        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    }
-    if (lib.uniffi_iroh_ffi_checksum_method_irohnode_blobs_export() != 19194.toShort()) {
-        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    }
-    if (lib.uniffi_iroh_ffi_checksum_method_irohnode_blobs_get_collection() != 22036.toShort()) {
-        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    }
-    if (lib.uniffi_iroh_ffi_checksum_method_irohnode_blobs_list() != 31880.toShort()) {
-        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    }
-    if (lib.uniffi_iroh_ffi_checksum_method_irohnode_blobs_list_collections() != 189.toShort()) {
-        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    }
-    if (lib.uniffi_iroh_ffi_checksum_method_irohnode_blobs_list_incomplete() != 31752.toShort()) {
-        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    }
-    if (lib.uniffi_iroh_ffi_checksum_method_irohnode_blobs_read_at_to_bytes() != 11107.toShort()) {
-        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    }
-    if (lib.uniffi_iroh_ffi_checksum_method_irohnode_blobs_read_to_bytes() != 15494.toShort()) {
-        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    }
-    if (lib.uniffi_iroh_ffi_checksum_method_irohnode_blobs_share() != 38899.toShort()) {
-        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    }
-    if (lib.uniffi_iroh_ffi_checksum_method_irohnode_blobs_size() != 39132.toShort()) {
-        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    }
-    if (lib.uniffi_iroh_ffi_checksum_method_irohnode_blobs_write_to_path() != 43769.toShort()) {
-        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    }
-    if (lib.uniffi_iroh_ffi_checksum_method_irohnode_connection_info() != 64141.toShort()) {
-        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    }
-    if (lib.uniffi_iroh_ffi_checksum_method_irohnode_connections() != 55452.toShort()) {
-        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    }
-    if (lib.uniffi_iroh_ffi_checksum_method_irohnode_doc_create() != 25418.toShort()) {
-        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    }
-    if (lib.uniffi_iroh_ffi_checksum_method_irohnode_doc_drop() != 41240.toShort()) {
-        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    }
-    if (lib.uniffi_iroh_ffi_checksum_method_irohnode_doc_join() != 61748.toShort()) {
-        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    }
-    if (lib.uniffi_iroh_ffi_checksum_method_irohnode_doc_join_and_subscribe() != 992.toShort()) {
-        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    }
-    if (lib.uniffi_iroh_ffi_checksum_method_irohnode_doc_list() != 63026.toShort()) {
-        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    }
-    if (lib.uniffi_iroh_ffi_checksum_method_irohnode_doc_open() != 16291.toShort()) {
-        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    }
-    if (lib.uniffi_iroh_ffi_checksum_method_irohnode_gossip_subscribe() != 10882.toShort()) {
-        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    }
-    if (lib.uniffi_iroh_ffi_checksum_method_irohnode_home_relay() != 3309.toShort()) {
-        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    }
-    if (lib.uniffi_iroh_ffi_checksum_method_irohnode_my_rpc_addr() != 33640.toShort()) {
-        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    }
-    if (lib.uniffi_iroh_ffi_checksum_method_irohnode_node_addr() != 20255.toShort()) {
-        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    }
-    if (lib.uniffi_iroh_ffi_checksum_method_irohnode_node_id() != 46920.toShort()) {
-        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    }
-    if (lib.uniffi_iroh_ffi_checksum_method_irohnode_shutdown() != 624.toShort()) {
-        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    }
-    if (lib.uniffi_iroh_ffi_checksum_method_irohnode_stats() != 11985.toShort()) {
-        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    }
-    if (lib.uniffi_iroh_ffi_checksum_method_irohnode_status() != 3356.toShort()) {
-        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    }
-    if (lib.uniffi_iroh_ffi_checksum_method_irohnode_tags_delete() != 46770.toShort()) {
-        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    }
-    if (lib.uniffi_iroh_ffi_checksum_method_irohnode_tags_list() != 567.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_iroh_ffi_checksum_method_liveevent_as_content_ready() != 6578.toShort()) {
@@ -3226,6 +3320,36 @@ private fun uniffiCheckApiChecksums(lib: UniffiLib) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_iroh_ffi_checksum_method_message_type() != 75.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_iroh_ffi_checksum_method_node_add_node_addr() != 48772.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_iroh_ffi_checksum_method_node_connection_info() != 19420.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_iroh_ffi_checksum_method_node_connections() != 60971.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_iroh_ffi_checksum_method_node_home_relay() != 39435.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_iroh_ffi_checksum_method_node_my_rpc_addr() != 34751.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_iroh_ffi_checksum_method_node_node_addr() != 55077.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_iroh_ffi_checksum_method_node_node_id() != 50937.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_iroh_ffi_checksum_method_node_shutdown() != 21075.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_iroh_ffi_checksum_method_node_stats() != 13439.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_iroh_ffi_checksum_method_node_status() != 21889.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_iroh_ffi_checksum_method_nodeaddr_direct_addresses() != 23787.toShort()) {
@@ -3279,6 +3403,12 @@ private fun uniffiCheckApiChecksums(lib: UniffiLib) {
     if (lib.uniffi_iroh_ffi_checksum_method_subscribecallback_event() != 35520.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
+    if (lib.uniffi_iroh_ffi_checksum_method_tags_delete() != 17755.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_iroh_ffi_checksum_method_tags_list() != 16151.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
     if (lib.uniffi_iroh_ffi_checksum_constructor_author_from_string() != 63158.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
@@ -3321,16 +3451,16 @@ private fun uniffiCheckApiChecksums(lib: UniffiLib) {
     if (lib.uniffi_iroh_ffi_checksum_constructor_hash_new() != 30613.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_iroh_ffi_checksum_constructor_irohnode_memory() != 52721.toShort()) {
+    if (lib.uniffi_iroh_ffi_checksum_constructor_iroh_memory() != 49939.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_iroh_ffi_checksum_constructor_irohnode_memory_with_options() != 51113.toShort()) {
+    if (lib.uniffi_iroh_ffi_checksum_constructor_iroh_memory_with_options() != 60437.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_iroh_ffi_checksum_constructor_irohnode_persistent() != 9772.toShort()) {
+    if (lib.uniffi_iroh_ffi_checksum_constructor_iroh_persistent() != 42623.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_iroh_ffi_checksum_constructor_irohnode_persistent_with_options() != 11511.toShort()) {
+    if (lib.uniffi_iroh_ffi_checksum_constructor_iroh_persistent_with_options() != 60788.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_iroh_ffi_checksum_constructor_nodeaddr_new() != 5759.toShort()) {
@@ -5129,6 +5259,453 @@ public object FfiConverterTypeAuthorId : FfiConverter<AuthorId, Pointer> {
 //
 
 /**
+ * Iroh authors client.
+ */
+public interface AuthorsInterface {
+    /**
+     * Create a new document author.
+     *
+     * You likely want to save the returned [`AuthorId`] somewhere so that you can use this author
+     * again.
+     *
+     * If you need only a single author, use [`Self::default`].
+     */
+    suspend fun `create`(): AuthorId
+
+    /**
+     * Returns the default document author of this node.
+     *
+     * On persistent nodes, the author is created on first start and its public key is saved
+     * in the data directory.
+     *
+     * The default author can be set with [`Self::set_default`].
+     */
+    suspend fun `default`(): AuthorId
+
+    /**
+     * Deletes the given author by id.
+     *
+     * Warning: This permanently removes this author.
+     */
+    suspend fun `delete`(`author`: AuthorId)
+
+    /**
+     * Export the given author.
+     *
+     * Warning: This contains sensitive data.
+     */
+    suspend fun `export`(`author`: AuthorId): Author
+
+    /**
+     * Import the given author.
+     *
+     * Warning: This contains sensitive data.
+     */
+    suspend fun `import`(`author`: Author): AuthorId
+
+    /**
+     * Import the given author.
+     *
+     * Warning: This contains sensitive data.
+     * `import` is reserved in python.
+     */
+    suspend fun `importAuthor`(`author`: Author): AuthorId
+
+    /**
+     * List all the AuthorIds that exist on this node.
+     */
+    suspend fun `list`(): List<AuthorId>
+
+    companion object
+}
+
+/**
+ * Iroh authors client.
+ */
+open class Authors :
+    Disposable,
+    AutoCloseable,
+    AuthorsInterface {
+    constructor(pointer: Pointer) {
+        this.pointer = pointer
+        this.cleanable = UniffiLib.CLEANER.register(this, UniffiCleanAction(pointer))
+    }
+
+    /**
+     * This constructor can be used to instantiate a fake object. Only used for tests. Any
+     * attempt to actually use an object constructed this way will fail as there is no
+     * connected Rust object.
+     */
+    @Suppress("UNUSED_PARAMETER")
+    constructor(noPointer: NoPointer) {
+        this.pointer = null
+        this.cleanable = UniffiLib.CLEANER.register(this, UniffiCleanAction(pointer))
+    }
+
+    protected val pointer: Pointer?
+    protected val cleanable: UniffiCleaner.Cleanable
+
+    private val wasDestroyed = AtomicBoolean(false)
+    private val callCounter = AtomicLong(1)
+
+    override fun destroy() {
+        // Only allow a single call to this method.
+        // TODO: maybe we should log a warning if called more than once?
+        if (this.wasDestroyed.compareAndSet(false, true)) {
+            // This decrement always matches the initial count of 1 given at creation time.
+            if (this.callCounter.decrementAndGet() == 0L) {
+                cleanable.clean()
+            }
+        }
+    }
+
+    @Synchronized
+    override fun close() {
+        this.destroy()
+    }
+
+    internal inline fun <R> callWithPointer(block: (ptr: Pointer) -> R): R {
+        // Check and increment the call counter, to keep the object alive.
+        // This needs a compare-and-set retry loop in case of concurrent updates.
+        do {
+            val c = this.callCounter.get()
+            if (c == 0L) {
+                throw IllegalStateException("${this.javaClass.simpleName} object has already been destroyed")
+            }
+            if (c == Long.MAX_VALUE) {
+                throw IllegalStateException("${this.javaClass.simpleName} call counter would overflow")
+            }
+        } while (!this.callCounter.compareAndSet(c, c + 1L))
+        // Now we can safely do the method call without the pointer being freed concurrently.
+        try {
+            return block(this.uniffiClonePointer())
+        } finally {
+            // This decrement always matches the increment we performed above.
+            if (this.callCounter.decrementAndGet() == 0L) {
+                cleanable.clean()
+            }
+        }
+    }
+
+    // Use a static inner class instead of a closure so as not to accidentally
+    // capture `this` as part of the cleanable's action.
+    private class UniffiCleanAction(
+        private val pointer: Pointer?,
+    ) : Runnable {
+        override fun run() {
+            pointer?.let { ptr ->
+                uniffiRustCall { status ->
+                    UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_free_authors(ptr, status)
+                }
+            }
+        }
+    }
+
+    fun uniffiClonePointer(): Pointer =
+        uniffiRustCall { status ->
+            UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_clone_authors(pointer!!, status)
+        }
+
+    /**
+     * Create a new document author.
+     *
+     * You likely want to save the returned [`AuthorId`] somewhere so that you can use this author
+     * again.
+     *
+     * If you need only a single author, use [`Self::default`].
+     */
+    @Throws(IrohException::class)
+    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
+    override suspend fun `create`(): AuthorId =
+        uniffiRustCallAsync(
+            callWithPointer { thisPtr ->
+                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_authors_create(
+                    thisPtr,
+                )
+            },
+            { future, callback, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_pointer(future, callback, continuation) },
+            { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_pointer(future, continuation) },
+            { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_pointer(future) },
+            // lift function
+            { FfiConverterTypeAuthorId.lift(it) },
+            // Error FFI converter
+            IrohException.ErrorHandler,
+        )
+
+    /**
+     * Returns the default document author of this node.
+     *
+     * On persistent nodes, the author is created on first start and its public key is saved
+     * in the data directory.
+     *
+     * The default author can be set with [`Self::set_default`].
+     */
+    @Throws(IrohException::class)
+    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
+    override suspend fun `default`(): AuthorId =
+        uniffiRustCallAsync(
+            callWithPointer { thisPtr ->
+                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_authors_default(
+                    thisPtr,
+                )
+            },
+            { future, callback, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_pointer(future, callback, continuation) },
+            { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_pointer(future, continuation) },
+            { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_pointer(future) },
+            // lift function
+            { FfiConverterTypeAuthorId.lift(it) },
+            // Error FFI converter
+            IrohException.ErrorHandler,
+        )
+
+    /**
+     * Deletes the given author by id.
+     *
+     * Warning: This permanently removes this author.
+     */
+    @Throws(IrohException::class)
+    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
+    override suspend fun `delete`(`author`: AuthorId) =
+        uniffiRustCallAsync(
+            callWithPointer { thisPtr ->
+                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_authors_delete(
+                    thisPtr,
+                    FfiConverterTypeAuthorId.lower(`author`),
+                )
+            },
+            { future, callback, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_void(future, callback, continuation) },
+            { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_void(future, continuation) },
+            { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_void(future) },
+            // lift function
+            { Unit },
+            // Error FFI converter
+            IrohException.ErrorHandler,
+        )
+
+    /**
+     * Export the given author.
+     *
+     * Warning: This contains sensitive data.
+     */
+    @Throws(IrohException::class)
+    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
+    override suspend fun `export`(`author`: AuthorId): Author =
+        uniffiRustCallAsync(
+            callWithPointer { thisPtr ->
+                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_authors_export(
+                    thisPtr,
+                    FfiConverterTypeAuthorId.lower(`author`),
+                )
+            },
+            { future, callback, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_pointer(future, callback, continuation) },
+            { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_pointer(future, continuation) },
+            { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_pointer(future) },
+            // lift function
+            { FfiConverterTypeAuthor.lift(it) },
+            // Error FFI converter
+            IrohException.ErrorHandler,
+        )
+
+    /**
+     * Import the given author.
+     *
+     * Warning: This contains sensitive data.
+     */
+    @Throws(IrohException::class)
+    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
+    override suspend fun `import`(`author`: Author): AuthorId =
+        uniffiRustCallAsync(
+            callWithPointer { thisPtr ->
+                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_authors_import(
+                    thisPtr,
+                    FfiConverterTypeAuthor.lower(`author`),
+                )
+            },
+            { future, callback, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_pointer(future, callback, continuation) },
+            { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_pointer(future, continuation) },
+            { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_pointer(future) },
+            // lift function
+            { FfiConverterTypeAuthorId.lift(it) },
+            // Error FFI converter
+            IrohException.ErrorHandler,
+        )
+
+    /**
+     * Import the given author.
+     *
+     * Warning: This contains sensitive data.
+     * `import` is reserved in python.
+     */
+    @Throws(IrohException::class)
+    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
+    override suspend fun `importAuthor`(`author`: Author): AuthorId =
+        uniffiRustCallAsync(
+            callWithPointer { thisPtr ->
+                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_authors_import_author(
+                    thisPtr,
+                    FfiConverterTypeAuthor.lower(`author`),
+                )
+            },
+            { future, callback, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_pointer(future, callback, continuation) },
+            { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_pointer(future, continuation) },
+            { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_pointer(future) },
+            // lift function
+            { FfiConverterTypeAuthorId.lift(it) },
+            // Error FFI converter
+            IrohException.ErrorHandler,
+        )
+
+    /**
+     * List all the AuthorIds that exist on this node.
+     */
+    @Throws(IrohException::class)
+    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
+    override suspend fun `list`(): List<AuthorId> =
+        uniffiRustCallAsync(
+            callWithPointer { thisPtr ->
+                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_authors_list(
+                    thisPtr,
+                )
+            },
+            {
+                    future,
+                    callback,
+                    continuation,
+                ->
+                UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_rust_buffer(future, callback, continuation)
+            },
+            { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_rust_buffer(future, continuation) },
+            { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_rust_buffer(future) },
+            // lift function
+            { FfiConverterSequenceTypeAuthorId.lift(it) },
+            // Error FFI converter
+            IrohException.ErrorHandler,
+        )
+
+    companion object
+}
+
+public object FfiConverterTypeAuthors : FfiConverter<Authors, Pointer> {
+    override fun lower(value: Authors): Pointer = value.uniffiClonePointer()
+
+    override fun lift(value: Pointer): Authors = Authors(value)
+
+    override fun read(buf: ByteBuffer): Authors {
+        // The Rust code always writes pointers as 8 bytes, and will
+        // fail to compile if they don't fit.
+        return lift(Pointer(buf.getLong()))
+    }
+
+    override fun allocationSize(value: Authors) = 8UL
+
+    override fun write(
+        value: Authors,
+        buf: ByteBuffer,
+    ) {
+        // The Rust code always expects pointers written as 8 bytes,
+        // and will fail to compile if they don't fit.
+        buf.putLong(Pointer.nativeValue(lower(value)))
+    }
+}
+
+// This template implements a class for working with a Rust struct via a Pointer/Arc<T>
+// to the live Rust struct on the other side of the FFI.
+//
+// Each instance implements core operations for working with the Rust `Arc<T>` and the
+// Kotlin Pointer to work with the live Rust struct on the other side of the FFI.
+//
+// There's some subtlety here, because we have to be careful not to operate on a Rust
+// struct after it has been dropped, and because we must expose a public API for freeing
+// theq Kotlin wrapper object in lieu of reliable finalizers. The core requirements are:
+//
+//   * Each instance holds an opaque pointer to the underlying Rust struct.
+//     Method calls need to read this pointer from the object's state and pass it in to
+//     the Rust FFI.
+//
+//   * When an instance is no longer needed, its pointer should be passed to a
+//     special destructor function provided by the Rust FFI, which will drop the
+//     underlying Rust struct.
+//
+//   * Given an instance, calling code is expected to call the special
+//     `destroy` method in order to free it after use, either by calling it explicitly
+//     or by using a higher-level helper like the `use` method. Failing to do so risks
+//     leaking the underlying Rust struct.
+//
+//   * We can't assume that calling code will do the right thing, and must be prepared
+//     to handle Kotlin method calls executing concurrently with or even after a call to
+//     `destroy`, and to handle multiple (possibly concurrent!) calls to `destroy`.
+//
+//   * We must never allow Rust code to operate on the underlying Rust struct after
+//     the destructor has been called, and must never call the destructor more than once.
+//     Doing so may trigger memory unsafety.
+//
+//   * To mitigate many of the risks of leaking memory and use-after-free unsafety, a `Cleaner`
+//     is implemented to call the destructor when the Kotlin object becomes unreachable.
+//     This is done in a background thread. This is not a panacea, and client code should be aware that
+//      1. the thread may starve if some there are objects that have poorly performing
+//     `drop` methods or do significant work in their `drop` methods.
+//      2. the thread is shared across the whole library. This can be tuned by using `android_cleaner = true`,
+//         or `android = true` in the [`kotlin` section of the `uniffi.toml` file](https://mozilla.github.io/uniffi-rs/kotlin/configuration.html).
+//
+// If we try to implement this with mutual exclusion on access to the pointer, there is the
+// possibility of a race between a method call and a concurrent call to `destroy`:
+//
+//    * Thread A starts a method call, reads the value of the pointer, but is interrupted
+//      before it can pass the pointer over the FFI to Rust.
+//    * Thread B calls `destroy` and frees the underlying Rust struct.
+//    * Thread A resumes, passing the already-read pointer value to Rust and triggering
+//      a use-after-free.
+//
+// One possible solution would be to use a `ReadWriteLock`, with each method call taking
+// a read lock (and thus allowed to run concurrently) and the special `destroy` method
+// taking a write lock (and thus blocking on live method calls). However, we aim not to
+// generate methods with any hidden blocking semantics, and a `destroy` method that might
+// block if called incorrectly seems to meet that bar.
+//
+// So, we achieve our goals by giving each instance an associated `AtomicLong` counter to track
+// the number of in-flight method calls, and an `AtomicBoolean` flag to indicate whether `destroy`
+// has been called. These are updated according to the following rules:
+//
+//    * The initial value of the counter is 1, indicating a live object with no in-flight calls.
+//      The initial value for the flag is false.
+//
+//    * At the start of each method call, we atomically check the counter.
+//      If it is 0 then the underlying Rust struct has already been destroyed and the call is aborted.
+//      If it is nonzero them we atomically increment it by 1 and proceed with the method call.
+//
+//    * At the end of each method call, we atomically decrement and check the counter.
+//      If it has reached zero then we destroy the underlying Rust struct.
+//
+//    * When `destroy` is called, we atomically flip the flag from false to true.
+//      If the flag was already true we silently fail.
+//      Otherwise we atomically decrement and check the counter.
+//      If it has reached zero then we destroy the underlying Rust struct.
+//
+// Astute readers may observe that this all sounds very similar to the way that Rust's `Arc<T>` works,
+// and indeed it is, with the addition of a flag to guard against multiple calls to `destroy`.
+//
+// The overall effect is that the underlying Rust struct is destroyed only when `destroy` has been
+// called *and* all in-flight method calls have completed, avoiding violating any of the expectations
+// of the underlying Rust code.
+//
+// This makes a cleaner a better alternative to _not_ calling `destroy()` as
+// and when the object is finished with, but the abstraction is not perfect: if the Rust object's `drop`
+// method is slow, and/or there are many objects to cleanup, and it's on a low end Android device, then the cleaner
+// thread may be starved, and the app will leak memory.
+//
+// In this case, `destroy`ing manually may be a better solution.
+//
+// The cleaner can live side by side with the manual calling of `destroy`. In the order of responsiveness, uniffi objects
+// with Rust peers are reclaimed:
+//
+// 1. By calling the `destroy` method of the object, which calls `rustObject.free()`. If that doesn't happen:
+// 2. When the object becomes unreachable, AND the Cleaner thread gets to call `rustObject.free()`. If the thread is starved then:
+// 3. The memory is reclaimed when the process terminates.
+//
+// [1] https://stackoverflow.com/questions/24376768/can-java-finalize-an-object-when-it-is-still-in-scope/24380219
+//
+
+/**
  * Options to download  data specified by the hash.
  */
 public interface BlobDownloadOptionsInterface {
@@ -5585,6 +6162,857 @@ public object FfiConverterTypeBlobTicket : FfiConverter<BlobTicket, Pointer> {
 
     override fun write(
         value: BlobTicket,
+        buf: ByteBuffer,
+    ) {
+        // The Rust code always expects pointers written as 8 bytes,
+        // and will fail to compile if they don't fit.
+        buf.putLong(Pointer.nativeValue(lower(value)))
+    }
+}
+
+// This template implements a class for working with a Rust struct via a Pointer/Arc<T>
+// to the live Rust struct on the other side of the FFI.
+//
+// Each instance implements core operations for working with the Rust `Arc<T>` and the
+// Kotlin Pointer to work with the live Rust struct on the other side of the FFI.
+//
+// There's some subtlety here, because we have to be careful not to operate on a Rust
+// struct after it has been dropped, and because we must expose a public API for freeing
+// theq Kotlin wrapper object in lieu of reliable finalizers. The core requirements are:
+//
+//   * Each instance holds an opaque pointer to the underlying Rust struct.
+//     Method calls need to read this pointer from the object's state and pass it in to
+//     the Rust FFI.
+//
+//   * When an instance is no longer needed, its pointer should be passed to a
+//     special destructor function provided by the Rust FFI, which will drop the
+//     underlying Rust struct.
+//
+//   * Given an instance, calling code is expected to call the special
+//     `destroy` method in order to free it after use, either by calling it explicitly
+//     or by using a higher-level helper like the `use` method. Failing to do so risks
+//     leaking the underlying Rust struct.
+//
+//   * We can't assume that calling code will do the right thing, and must be prepared
+//     to handle Kotlin method calls executing concurrently with or even after a call to
+//     `destroy`, and to handle multiple (possibly concurrent!) calls to `destroy`.
+//
+//   * We must never allow Rust code to operate on the underlying Rust struct after
+//     the destructor has been called, and must never call the destructor more than once.
+//     Doing so may trigger memory unsafety.
+//
+//   * To mitigate many of the risks of leaking memory and use-after-free unsafety, a `Cleaner`
+//     is implemented to call the destructor when the Kotlin object becomes unreachable.
+//     This is done in a background thread. This is not a panacea, and client code should be aware that
+//      1. the thread may starve if some there are objects that have poorly performing
+//     `drop` methods or do significant work in their `drop` methods.
+//      2. the thread is shared across the whole library. This can be tuned by using `android_cleaner = true`,
+//         or `android = true` in the [`kotlin` section of the `uniffi.toml` file](https://mozilla.github.io/uniffi-rs/kotlin/configuration.html).
+//
+// If we try to implement this with mutual exclusion on access to the pointer, there is the
+// possibility of a race between a method call and a concurrent call to `destroy`:
+//
+//    * Thread A starts a method call, reads the value of the pointer, but is interrupted
+//      before it can pass the pointer over the FFI to Rust.
+//    * Thread B calls `destroy` and frees the underlying Rust struct.
+//    * Thread A resumes, passing the already-read pointer value to Rust and triggering
+//      a use-after-free.
+//
+// One possible solution would be to use a `ReadWriteLock`, with each method call taking
+// a read lock (and thus allowed to run concurrently) and the special `destroy` method
+// taking a write lock (and thus blocking on live method calls). However, we aim not to
+// generate methods with any hidden blocking semantics, and a `destroy` method that might
+// block if called incorrectly seems to meet that bar.
+//
+// So, we achieve our goals by giving each instance an associated `AtomicLong` counter to track
+// the number of in-flight method calls, and an `AtomicBoolean` flag to indicate whether `destroy`
+// has been called. These are updated according to the following rules:
+//
+//    * The initial value of the counter is 1, indicating a live object with no in-flight calls.
+//      The initial value for the flag is false.
+//
+//    * At the start of each method call, we atomically check the counter.
+//      If it is 0 then the underlying Rust struct has already been destroyed and the call is aborted.
+//      If it is nonzero them we atomically increment it by 1 and proceed with the method call.
+//
+//    * At the end of each method call, we atomically decrement and check the counter.
+//      If it has reached zero then we destroy the underlying Rust struct.
+//
+//    * When `destroy` is called, we atomically flip the flag from false to true.
+//      If the flag was already true we silently fail.
+//      Otherwise we atomically decrement and check the counter.
+//      If it has reached zero then we destroy the underlying Rust struct.
+//
+// Astute readers may observe that this all sounds very similar to the way that Rust's `Arc<T>` works,
+// and indeed it is, with the addition of a flag to guard against multiple calls to `destroy`.
+//
+// The overall effect is that the underlying Rust struct is destroyed only when `destroy` has been
+// called *and* all in-flight method calls have completed, avoiding violating any of the expectations
+// of the underlying Rust code.
+//
+// This makes a cleaner a better alternative to _not_ calling `destroy()` as
+// and when the object is finished with, but the abstraction is not perfect: if the Rust object's `drop`
+// method is slow, and/or there are many objects to cleanup, and it's on a low end Android device, then the cleaner
+// thread may be starved, and the app will leak memory.
+//
+// In this case, `destroy`ing manually may be a better solution.
+//
+// The cleaner can live side by side with the manual calling of `destroy`. In the order of responsiveness, uniffi objects
+// with Rust peers are reclaimed:
+//
+// 1. By calling the `destroy` method of the object, which calls `rustObject.free()`. If that doesn't happen:
+// 2. When the object becomes unreachable, AND the Cleaner thread gets to call `rustObject.free()`. If the thread is starved then:
+// 3. The memory is reclaimed when the process terminates.
+//
+// [1] https://stackoverflow.com/questions/24376768/can-java-finalize-an-object-when-it-is-still-in-scope/24380219
+//
+
+/**
+ * Iroh blobs client.
+ */
+public interface BlobsInterface {
+    /**
+     * Write a blob by passing bytes.
+     */
+    suspend fun `addBytes`(`bytes`: kotlin.ByteArray): BlobAddOutcome
+
+    /**
+     * Write a blob by passing bytes, setting an explicit tag name.
+     */
+    suspend fun `addBytesNamed`(
+        `bytes`: kotlin.ByteArray,
+        `name`: kotlin.String,
+    ): BlobAddOutcome
+
+    /**
+     * Import a blob from a filesystem path.
+     *
+     * `path` should be an absolute path valid for the file system on which
+     * the node runs.
+     * If `in_place` is true, Iroh will assume that the data will not change and will share it in
+     * place without copying to the Iroh data directory.
+     */
+    suspend fun `addFromPath`(
+        `path`: kotlin.String,
+        `inPlace`: kotlin.Boolean,
+        `tag`: SetTagOption,
+        `wrap`: WrapOption,
+        `cb`: AddCallback,
+    )
+
+    /**
+     * Create a collection from already existing blobs.
+     *
+     * To automatically clear the tags for the passed in blobs you can set
+     * `tags_to_delete` on those tags, and they will be deleted once the collection is created.
+     */
+    suspend fun `createCollection`(
+        `collection`: Collection,
+        `tag`: SetTagOption,
+        `tagsToDelete`: List<kotlin.String>,
+    ): HashAndTag
+
+    /**
+     * Delete a blob.
+     */
+    suspend fun `deleteBlob`(`hash`: Hash)
+
+    /**
+     * Download a blob from another node and add it to the local database.
+     */
+    suspend fun `download`(
+        `hash`: Hash,
+        `opts`: BlobDownloadOptions,
+        `cb`: DownloadCallback,
+    )
+
+    /**
+     * Export a blob from the internal blob store to a path on the node's filesystem.
+     *
+     * `destination` should be a writeable, absolute path on the local node's filesystem.
+     *
+     * If `format` is set to [`ExportFormat::Collection`], and the `hash` refers to a collection,
+     * all children of the collection will be exported. See [`ExportFormat`] for details.
+     *
+     * The `mode` argument defines if the blob should be copied to the target location or moved out of
+     * the internal store into the target location. See [`ExportMode`] for details.
+     */
+    suspend fun `export`(
+        `hash`: Hash,
+        `destination`: kotlin.String,
+        `format`: BlobExportFormat,
+        `mode`: BlobExportMode,
+    )
+
+    /**
+     * Read the content of a collection
+     */
+    suspend fun `getCollection`(`hash`: Hash): Collection
+
+    /**
+     * List all complete blobs.
+     *
+     * Note: this allocates for each `BlobListResponse`, if you have many `BlobListReponse`s this may be a prohibitively large list.
+     * Please file an [issue](https://github.com/n0-computer/iroh-ffi/issues/new) if you run into this issue
+     */
+    suspend fun `list`(): List<Hash>
+
+    /**
+     * List all collections.
+     *
+     * Note: this allocates for each `BlobListCollectionsResponse`, if you have many `BlobListCollectionsResponse`s this may be a prohibitively large list.
+     * Please file an [issue](https://github.com/n0-computer/iroh-ffi/issues/new) if you run into this issue
+     */
+    suspend fun `listCollections`(): List<CollectionInfo>
+
+    /**
+     * List all incomplete (partial) blobs.
+     *
+     * Note: this allocates for each `BlobListIncompleteResponse`, if you have many `BlobListIncompleteResponse`s this may be a prohibitively large list.
+     * Please file an [issue](https://github.com/n0-computer/iroh-ffi/issues/new) if you run into this issue
+     */
+    suspend fun `listIncomplete`(): List<IncompleteBlobInfo>
+
+    /**
+     * Read all bytes of single blob at `offset` for length `len`.
+     *
+     * This allocates a buffer for the full length `len`. Use only if you know that the blob you're
+     * reading is small. If not sure, use [`Self::blobs_size`] and check the size with
+     * before calling [`Self::blobs_read_at_to_bytes`].
+     */
+    suspend fun `readAtToBytes`(
+        `hash`: Hash,
+        `offset`: kotlin.ULong,
+        `len`: kotlin.ULong?,
+    ): kotlin.ByteArray
+
+    /**
+     * Read all bytes of single blob.
+     *
+     * This allocates a buffer for the full blob. Use only if you know that the blob you're
+     * reading is small. If not sure, use [`Self::blobs_size`] and check the size with
+     * before calling [`Self::blobs_read_to_bytes`].
+     */
+    suspend fun `readToBytes`(`hash`: Hash): kotlin.ByteArray
+
+    /**
+     * Create a ticket for sharing a blob from this node.
+     */
+    suspend fun `share`(
+        `hash`: Hash,
+        `blobFormat`: BlobFormat,
+        `ticketOptions`: AddrInfoOptions,
+    ): kotlin.String
+
+    /**
+     * Get the size information on a single blob.
+     *
+     * Method only exists in FFI
+     */
+    suspend fun `size`(`hash`: Hash): kotlin.ULong
+
+    /**
+     * Export the blob contents to a file path
+     * The `path` field is expected to be the absolute path.
+     */
+    suspend fun `writeToPath`(
+        `hash`: Hash,
+        `path`: kotlin.String,
+    )
+
+    companion object
+}
+
+/**
+ * Iroh blobs client.
+ */
+open class Blobs :
+    Disposable,
+    AutoCloseable,
+    BlobsInterface {
+    constructor(pointer: Pointer) {
+        this.pointer = pointer
+        this.cleanable = UniffiLib.CLEANER.register(this, UniffiCleanAction(pointer))
+    }
+
+    /**
+     * This constructor can be used to instantiate a fake object. Only used for tests. Any
+     * attempt to actually use an object constructed this way will fail as there is no
+     * connected Rust object.
+     */
+    @Suppress("UNUSED_PARAMETER")
+    constructor(noPointer: NoPointer) {
+        this.pointer = null
+        this.cleanable = UniffiLib.CLEANER.register(this, UniffiCleanAction(pointer))
+    }
+
+    protected val pointer: Pointer?
+    protected val cleanable: UniffiCleaner.Cleanable
+
+    private val wasDestroyed = AtomicBoolean(false)
+    private val callCounter = AtomicLong(1)
+
+    override fun destroy() {
+        // Only allow a single call to this method.
+        // TODO: maybe we should log a warning if called more than once?
+        if (this.wasDestroyed.compareAndSet(false, true)) {
+            // This decrement always matches the initial count of 1 given at creation time.
+            if (this.callCounter.decrementAndGet() == 0L) {
+                cleanable.clean()
+            }
+        }
+    }
+
+    @Synchronized
+    override fun close() {
+        this.destroy()
+    }
+
+    internal inline fun <R> callWithPointer(block: (ptr: Pointer) -> R): R {
+        // Check and increment the call counter, to keep the object alive.
+        // This needs a compare-and-set retry loop in case of concurrent updates.
+        do {
+            val c = this.callCounter.get()
+            if (c == 0L) {
+                throw IllegalStateException("${this.javaClass.simpleName} object has already been destroyed")
+            }
+            if (c == Long.MAX_VALUE) {
+                throw IllegalStateException("${this.javaClass.simpleName} call counter would overflow")
+            }
+        } while (!this.callCounter.compareAndSet(c, c + 1L))
+        // Now we can safely do the method call without the pointer being freed concurrently.
+        try {
+            return block(this.uniffiClonePointer())
+        } finally {
+            // This decrement always matches the increment we performed above.
+            if (this.callCounter.decrementAndGet() == 0L) {
+                cleanable.clean()
+            }
+        }
+    }
+
+    // Use a static inner class instead of a closure so as not to accidentally
+    // capture `this` as part of the cleanable's action.
+    private class UniffiCleanAction(
+        private val pointer: Pointer?,
+    ) : Runnable {
+        override fun run() {
+            pointer?.let { ptr ->
+                uniffiRustCall { status ->
+                    UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_free_blobs(ptr, status)
+                }
+            }
+        }
+    }
+
+    fun uniffiClonePointer(): Pointer =
+        uniffiRustCall { status ->
+            UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_clone_blobs(pointer!!, status)
+        }
+
+    /**
+     * Write a blob by passing bytes.
+     */
+    @Throws(IrohException::class)
+    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
+    override suspend fun `addBytes`(`bytes`: kotlin.ByteArray): BlobAddOutcome =
+        uniffiRustCallAsync(
+            callWithPointer { thisPtr ->
+                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_blobs_add_bytes(
+                    thisPtr,
+                    FfiConverterByteArray.lower(`bytes`),
+                )
+            },
+            {
+                    future,
+                    callback,
+                    continuation,
+                ->
+                UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_rust_buffer(future, callback, continuation)
+            },
+            { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_rust_buffer(future, continuation) },
+            { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_rust_buffer(future) },
+            // lift function
+            { FfiConverterTypeBlobAddOutcome.lift(it) },
+            // Error FFI converter
+            IrohException.ErrorHandler,
+        )
+
+    /**
+     * Write a blob by passing bytes, setting an explicit tag name.
+     */
+    @Throws(IrohException::class)
+    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
+    override suspend fun `addBytesNamed`(
+        `bytes`: kotlin.ByteArray,
+        `name`: kotlin.String,
+    ): BlobAddOutcome =
+        uniffiRustCallAsync(
+            callWithPointer { thisPtr ->
+                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_blobs_add_bytes_named(
+                    thisPtr,
+                    FfiConverterByteArray.lower(`bytes`),
+                    FfiConverterString.lower(`name`),
+                )
+            },
+            {
+                    future,
+                    callback,
+                    continuation,
+                ->
+                UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_rust_buffer(future, callback, continuation)
+            },
+            { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_rust_buffer(future, continuation) },
+            { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_rust_buffer(future) },
+            // lift function
+            { FfiConverterTypeBlobAddOutcome.lift(it) },
+            // Error FFI converter
+            IrohException.ErrorHandler,
+        )
+
+    /**
+     * Import a blob from a filesystem path.
+     *
+     * `path` should be an absolute path valid for the file system on which
+     * the node runs.
+     * If `in_place` is true, Iroh will assume that the data will not change and will share it in
+     * place without copying to the Iroh data directory.
+     */
+    @Throws(IrohException::class)
+    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
+    override suspend fun `addFromPath`(
+        `path`: kotlin.String,
+        `inPlace`: kotlin.Boolean,
+        `tag`: SetTagOption,
+        `wrap`: WrapOption,
+        `cb`: AddCallback,
+    ) = uniffiRustCallAsync(
+        callWithPointer { thisPtr ->
+            UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_blobs_add_from_path(
+                thisPtr,
+                FfiConverterString.lower(`path`),
+                FfiConverterBoolean.lower(`inPlace`),
+                FfiConverterTypeSetTagOption.lower(`tag`),
+                FfiConverterTypeWrapOption.lower(`wrap`),
+                FfiConverterTypeAddCallback.lower(`cb`),
+            )
+        },
+        { future, callback, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_void(future, callback, continuation) },
+        { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_void(future, continuation) },
+        { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_void(future) },
+        // lift function
+        { Unit },
+        // Error FFI converter
+        IrohException.ErrorHandler,
+    )
+
+    /**
+     * Create a collection from already existing blobs.
+     *
+     * To automatically clear the tags for the passed in blobs you can set
+     * `tags_to_delete` on those tags, and they will be deleted once the collection is created.
+     */
+    @Throws(IrohException::class)
+    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
+    override suspend fun `createCollection`(
+        `collection`: Collection,
+        `tag`: SetTagOption,
+        `tagsToDelete`: List<kotlin.String>,
+    ): HashAndTag =
+        uniffiRustCallAsync(
+            callWithPointer { thisPtr ->
+                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_blobs_create_collection(
+                    thisPtr,
+                    FfiConverterTypeCollection.lower(`collection`),
+                    FfiConverterTypeSetTagOption.lower(`tag`),
+                    FfiConverterSequenceString.lower(`tagsToDelete`),
+                )
+            },
+            {
+                    future,
+                    callback,
+                    continuation,
+                ->
+                UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_rust_buffer(future, callback, continuation)
+            },
+            { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_rust_buffer(future, continuation) },
+            { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_rust_buffer(future) },
+            // lift function
+            { FfiConverterTypeHashAndTag.lift(it) },
+            // Error FFI converter
+            IrohException.ErrorHandler,
+        )
+
+    /**
+     * Delete a blob.
+     */
+    @Throws(IrohException::class)
+    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
+    override suspend fun `deleteBlob`(`hash`: Hash) =
+        uniffiRustCallAsync(
+            callWithPointer { thisPtr ->
+                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_blobs_delete_blob(
+                    thisPtr,
+                    FfiConverterTypeHash.lower(`hash`),
+                )
+            },
+            { future, callback, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_void(future, callback, continuation) },
+            { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_void(future, continuation) },
+            { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_void(future) },
+            // lift function
+            { Unit },
+            // Error FFI converter
+            IrohException.ErrorHandler,
+        )
+
+    /**
+     * Download a blob from another node and add it to the local database.
+     */
+    @Throws(IrohException::class)
+    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
+    override suspend fun `download`(
+        `hash`: Hash,
+        `opts`: BlobDownloadOptions,
+        `cb`: DownloadCallback,
+    ) = uniffiRustCallAsync(
+        callWithPointer { thisPtr ->
+            UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_blobs_download(
+                thisPtr,
+                FfiConverterTypeHash.lower(`hash`),
+                FfiConverterTypeBlobDownloadOptions.lower(`opts`),
+                FfiConverterTypeDownloadCallback.lower(`cb`),
+            )
+        },
+        { future, callback, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_void(future, callback, continuation) },
+        { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_void(future, continuation) },
+        { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_void(future) },
+        // lift function
+        { Unit },
+        // Error FFI converter
+        IrohException.ErrorHandler,
+    )
+
+    /**
+     * Export a blob from the internal blob store to a path on the node's filesystem.
+     *
+     * `destination` should be a writeable, absolute path on the local node's filesystem.
+     *
+     * If `format` is set to [`ExportFormat::Collection`], and the `hash` refers to a collection,
+     * all children of the collection will be exported. See [`ExportFormat`] for details.
+     *
+     * The `mode` argument defines if the blob should be copied to the target location or moved out of
+     * the internal store into the target location. See [`ExportMode`] for details.
+     */
+    @Throws(IrohException::class)
+    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
+    override suspend fun `export`(
+        `hash`: Hash,
+        `destination`: kotlin.String,
+        `format`: BlobExportFormat,
+        `mode`: BlobExportMode,
+    ) = uniffiRustCallAsync(
+        callWithPointer { thisPtr ->
+            UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_blobs_export(
+                thisPtr,
+                FfiConverterTypeHash.lower(`hash`),
+                FfiConverterString.lower(`destination`),
+                FfiConverterTypeBlobExportFormat.lower(`format`),
+                FfiConverterTypeBlobExportMode.lower(`mode`),
+            )
+        },
+        { future, callback, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_void(future, callback, continuation) },
+        { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_void(future, continuation) },
+        { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_void(future) },
+        // lift function
+        { Unit },
+        // Error FFI converter
+        IrohException.ErrorHandler,
+    )
+
+    /**
+     * Read the content of a collection
+     */
+    @Throws(IrohException::class)
+    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
+    override suspend fun `getCollection`(`hash`: Hash): Collection =
+        uniffiRustCallAsync(
+            callWithPointer { thisPtr ->
+                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_blobs_get_collection(
+                    thisPtr,
+                    FfiConverterTypeHash.lower(`hash`),
+                )
+            },
+            { future, callback, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_pointer(future, callback, continuation) },
+            { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_pointer(future, continuation) },
+            { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_pointer(future) },
+            // lift function
+            { FfiConverterTypeCollection.lift(it) },
+            // Error FFI converter
+            IrohException.ErrorHandler,
+        )
+
+    /**
+     * List all complete blobs.
+     *
+     * Note: this allocates for each `BlobListResponse`, if you have many `BlobListReponse`s this may be a prohibitively large list.
+     * Please file an [issue](https://github.com/n0-computer/iroh-ffi/issues/new) if you run into this issue
+     */
+    @Throws(IrohException::class)
+    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
+    override suspend fun `list`(): List<Hash> =
+        uniffiRustCallAsync(
+            callWithPointer { thisPtr ->
+                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_blobs_list(
+                    thisPtr,
+                )
+            },
+            {
+                    future,
+                    callback,
+                    continuation,
+                ->
+                UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_rust_buffer(future, callback, continuation)
+            },
+            { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_rust_buffer(future, continuation) },
+            { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_rust_buffer(future) },
+            // lift function
+            { FfiConverterSequenceTypeHash.lift(it) },
+            // Error FFI converter
+            IrohException.ErrorHandler,
+        )
+
+    /**
+     * List all collections.
+     *
+     * Note: this allocates for each `BlobListCollectionsResponse`, if you have many `BlobListCollectionsResponse`s this may be a prohibitively large list.
+     * Please file an [issue](https://github.com/n0-computer/iroh-ffi/issues/new) if you run into this issue
+     */
+    @Throws(IrohException::class)
+    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
+    override suspend fun `listCollections`(): List<CollectionInfo> =
+        uniffiRustCallAsync(
+            callWithPointer { thisPtr ->
+                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_blobs_list_collections(
+                    thisPtr,
+                )
+            },
+            {
+                    future,
+                    callback,
+                    continuation,
+                ->
+                UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_rust_buffer(future, callback, continuation)
+            },
+            { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_rust_buffer(future, continuation) },
+            { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_rust_buffer(future) },
+            // lift function
+            { FfiConverterSequenceTypeCollectionInfo.lift(it) },
+            // Error FFI converter
+            IrohException.ErrorHandler,
+        )
+
+    /**
+     * List all incomplete (partial) blobs.
+     *
+     * Note: this allocates for each `BlobListIncompleteResponse`, if you have many `BlobListIncompleteResponse`s this may be a prohibitively large list.
+     * Please file an [issue](https://github.com/n0-computer/iroh-ffi/issues/new) if you run into this issue
+     */
+    @Throws(IrohException::class)
+    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
+    override suspend fun `listIncomplete`(): List<IncompleteBlobInfo> =
+        uniffiRustCallAsync(
+            callWithPointer { thisPtr ->
+                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_blobs_list_incomplete(
+                    thisPtr,
+                )
+            },
+            {
+                    future,
+                    callback,
+                    continuation,
+                ->
+                UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_rust_buffer(future, callback, continuation)
+            },
+            { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_rust_buffer(future, continuation) },
+            { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_rust_buffer(future) },
+            // lift function
+            { FfiConverterSequenceTypeIncompleteBlobInfo.lift(it) },
+            // Error FFI converter
+            IrohException.ErrorHandler,
+        )
+
+    /**
+     * Read all bytes of single blob at `offset` for length `len`.
+     *
+     * This allocates a buffer for the full length `len`. Use only if you know that the blob you're
+     * reading is small. If not sure, use [`Self::blobs_size`] and check the size with
+     * before calling [`Self::blobs_read_at_to_bytes`].
+     */
+    @Throws(IrohException::class)
+    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
+    override suspend fun `readAtToBytes`(
+        `hash`: Hash,
+        `offset`: kotlin.ULong,
+        `len`: kotlin.ULong?,
+    ): kotlin.ByteArray =
+        uniffiRustCallAsync(
+            callWithPointer { thisPtr ->
+                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_blobs_read_at_to_bytes(
+                    thisPtr,
+                    FfiConverterTypeHash.lower(`hash`),
+                    FfiConverterULong.lower(`offset`),
+                    FfiConverterOptionalULong.lower(`len`),
+                )
+            },
+            {
+                    future,
+                    callback,
+                    continuation,
+                ->
+                UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_rust_buffer(future, callback, continuation)
+            },
+            { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_rust_buffer(future, continuation) },
+            { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_rust_buffer(future) },
+            // lift function
+            { FfiConverterByteArray.lift(it) },
+            // Error FFI converter
+            IrohException.ErrorHandler,
+        )
+
+    /**
+     * Read all bytes of single blob.
+     *
+     * This allocates a buffer for the full blob. Use only if you know that the blob you're
+     * reading is small. If not sure, use [`Self::blobs_size`] and check the size with
+     * before calling [`Self::blobs_read_to_bytes`].
+     */
+    @Throws(IrohException::class)
+    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
+    override suspend fun `readToBytes`(`hash`: Hash): kotlin.ByteArray =
+        uniffiRustCallAsync(
+            callWithPointer { thisPtr ->
+                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_blobs_read_to_bytes(
+                    thisPtr,
+                    FfiConverterTypeHash.lower(`hash`),
+                )
+            },
+            {
+                    future,
+                    callback,
+                    continuation,
+                ->
+                UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_rust_buffer(future, callback, continuation)
+            },
+            { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_rust_buffer(future, continuation) },
+            { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_rust_buffer(future) },
+            // lift function
+            { FfiConverterByteArray.lift(it) },
+            // Error FFI converter
+            IrohException.ErrorHandler,
+        )
+
+    /**
+     * Create a ticket for sharing a blob from this node.
+     */
+    @Throws(IrohException::class)
+    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
+    override suspend fun `share`(
+        `hash`: Hash,
+        `blobFormat`: BlobFormat,
+        `ticketOptions`: AddrInfoOptions,
+    ): kotlin.String =
+        uniffiRustCallAsync(
+            callWithPointer { thisPtr ->
+                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_blobs_share(
+                    thisPtr,
+                    FfiConverterTypeHash.lower(`hash`),
+                    FfiConverterTypeBlobFormat.lower(`blobFormat`),
+                    FfiConverterTypeAddrInfoOptions.lower(`ticketOptions`),
+                )
+            },
+            {
+                    future,
+                    callback,
+                    continuation,
+                ->
+                UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_rust_buffer(future, callback, continuation)
+            },
+            { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_rust_buffer(future, continuation) },
+            { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_rust_buffer(future) },
+            // lift function
+            { FfiConverterString.lift(it) },
+            // Error FFI converter
+            IrohException.ErrorHandler,
+        )
+
+    /**
+     * Get the size information on a single blob.
+     *
+     * Method only exists in FFI
+     */
+    @Throws(IrohException::class)
+    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
+    override suspend fun `size`(`hash`: Hash): kotlin.ULong =
+        uniffiRustCallAsync(
+            callWithPointer { thisPtr ->
+                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_blobs_size(
+                    thisPtr,
+                    FfiConverterTypeHash.lower(`hash`),
+                )
+            },
+            { future, callback, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_u64(future, callback, continuation) },
+            { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_u64(future, continuation) },
+            { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_u64(future) },
+            // lift function
+            { FfiConverterULong.lift(it) },
+            // Error FFI converter
+            IrohException.ErrorHandler,
+        )
+
+    /**
+     * Export the blob contents to a file path
+     * The `path` field is expected to be the absolute path.
+     */
+    @Throws(IrohException::class)
+    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
+    override suspend fun `writeToPath`(
+        `hash`: Hash,
+        `path`: kotlin.String,
+    ) = uniffiRustCallAsync(
+        callWithPointer { thisPtr ->
+            UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_blobs_write_to_path(
+                thisPtr,
+                FfiConverterTypeHash.lower(`hash`),
+                FfiConverterString.lower(`path`),
+            )
+        },
+        { future, callback, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_void(future, callback, continuation) },
+        { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_void(future, continuation) },
+        { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_void(future) },
+        // lift function
+        { Unit },
+        // Error FFI converter
+        IrohException.ErrorHandler,
+    )
+
+    companion object
+}
+
+public object FfiConverterTypeBlobs : FfiConverter<Blobs, Pointer> {
+    override fun lower(value: Blobs): Pointer = value.uniffiClonePointer()
+
+    override fun lift(value: Pointer): Blobs = Blobs(value)
+
+    override fun read(buf: ByteBuffer): Blobs {
+        // The Rust code always writes pointers as 8 bytes, and will
+        // fail to compile if they don't fit.
+        return lift(Pointer(buf.getLong()))
+    }
+
+    override fun allocationSize(value: Blobs) = 8UL
+
+    override fun write(
+        value: Blobs,
         buf: ByteBuffer,
     ) {
         // The Rust code always expects pointers written as 8 bytes,
@@ -6673,7 +8101,7 @@ public interface DocInterface {
      *
      * Returns the number of entries deleted.
      */
-    suspend fun `del`(
+    suspend fun `deleteEntry`(
         `authorId`: AuthorId,
         `prefix`: kotlin.ByteArray,
     ): kotlin.ULong
@@ -6908,13 +8336,13 @@ open class Doc :
      */
     @Throws(IrohException::class)
     @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
-    override suspend fun `del`(
+    override suspend fun `deleteEntry`(
         `authorId`: AuthorId,
         `prefix`: kotlin.ByteArray,
     ): kotlin.ULong =
         uniffiRustCallAsync(
             callWithPointer { thisPtr ->
-                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_doc_del(
+                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_doc_delete_entry(
                     thisPtr,
                     FfiConverterTypeAuthorId.lower(`authorId`),
                     FfiConverterByteArray.lower(`prefix`),
@@ -8718,6 +10146,414 @@ public object FfiConverterTypeDocImportProgress : FfiConverter<DocImportProgress
 //
 
 /**
+ * Iroh docs client.
+ */
+public interface DocsInterface {
+    /**
+     * Create a new doc.
+     */
+    suspend fun `create`(): Doc
+
+    /**
+     * Delete a document from the local node.
+     *
+     * This is a destructive operation. Both the document secret key and all entries in the
+     * document will be permanently deleted from the node's storage. Content blobs will be deleted
+     * through garbage collection unless they are referenced from another document or tag.
+     */
+    suspend fun `dropDoc`(`docId`: kotlin.String)
+
+    /**
+     * Join and sync with an already existing document.
+     */
+    suspend fun `join`(`ticket`: kotlin.String): Doc
+
+    /**
+     * Join and sync with an already existing document and subscribe to events on that document.
+     */
+    suspend fun `joinAndSubscribe`(
+        `ticket`: kotlin.String,
+        `cb`: SubscribeCallback,
+    ): Doc
+
+    /**
+     * List all the docs we have access to on this node.
+     */
+    suspend fun `list`(): List<NamespaceAndCapability>
+
+    /**
+     * Get a [`Doc`].
+     *
+     * Returns None if the document cannot be found.
+     */
+    suspend fun `open`(`id`: kotlin.String): Doc?
+
+    companion object
+}
+
+/**
+ * Iroh docs client.
+ */
+open class Docs :
+    Disposable,
+    AutoCloseable,
+    DocsInterface {
+    constructor(pointer: Pointer) {
+        this.pointer = pointer
+        this.cleanable = UniffiLib.CLEANER.register(this, UniffiCleanAction(pointer))
+    }
+
+    /**
+     * This constructor can be used to instantiate a fake object. Only used for tests. Any
+     * attempt to actually use an object constructed this way will fail as there is no
+     * connected Rust object.
+     */
+    @Suppress("UNUSED_PARAMETER")
+    constructor(noPointer: NoPointer) {
+        this.pointer = null
+        this.cleanable = UniffiLib.CLEANER.register(this, UniffiCleanAction(pointer))
+    }
+
+    protected val pointer: Pointer?
+    protected val cleanable: UniffiCleaner.Cleanable
+
+    private val wasDestroyed = AtomicBoolean(false)
+    private val callCounter = AtomicLong(1)
+
+    override fun destroy() {
+        // Only allow a single call to this method.
+        // TODO: maybe we should log a warning if called more than once?
+        if (this.wasDestroyed.compareAndSet(false, true)) {
+            // This decrement always matches the initial count of 1 given at creation time.
+            if (this.callCounter.decrementAndGet() == 0L) {
+                cleanable.clean()
+            }
+        }
+    }
+
+    @Synchronized
+    override fun close() {
+        this.destroy()
+    }
+
+    internal inline fun <R> callWithPointer(block: (ptr: Pointer) -> R): R {
+        // Check and increment the call counter, to keep the object alive.
+        // This needs a compare-and-set retry loop in case of concurrent updates.
+        do {
+            val c = this.callCounter.get()
+            if (c == 0L) {
+                throw IllegalStateException("${this.javaClass.simpleName} object has already been destroyed")
+            }
+            if (c == Long.MAX_VALUE) {
+                throw IllegalStateException("${this.javaClass.simpleName} call counter would overflow")
+            }
+        } while (!this.callCounter.compareAndSet(c, c + 1L))
+        // Now we can safely do the method call without the pointer being freed concurrently.
+        try {
+            return block(this.uniffiClonePointer())
+        } finally {
+            // This decrement always matches the increment we performed above.
+            if (this.callCounter.decrementAndGet() == 0L) {
+                cleanable.clean()
+            }
+        }
+    }
+
+    // Use a static inner class instead of a closure so as not to accidentally
+    // capture `this` as part of the cleanable's action.
+    private class UniffiCleanAction(
+        private val pointer: Pointer?,
+    ) : Runnable {
+        override fun run() {
+            pointer?.let { ptr ->
+                uniffiRustCall { status ->
+                    UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_free_docs(ptr, status)
+                }
+            }
+        }
+    }
+
+    fun uniffiClonePointer(): Pointer =
+        uniffiRustCall { status ->
+            UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_clone_docs(pointer!!, status)
+        }
+
+    /**
+     * Create a new doc.
+     */
+    @Throws(IrohException::class)
+    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
+    override suspend fun `create`(): Doc =
+        uniffiRustCallAsync(
+            callWithPointer { thisPtr ->
+                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_docs_create(
+                    thisPtr,
+                )
+            },
+            { future, callback, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_pointer(future, callback, continuation) },
+            { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_pointer(future, continuation) },
+            { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_pointer(future) },
+            // lift function
+            { FfiConverterTypeDoc.lift(it) },
+            // Error FFI converter
+            IrohException.ErrorHandler,
+        )
+
+    /**
+     * Delete a document from the local node.
+     *
+     * This is a destructive operation. Both the document secret key and all entries in the
+     * document will be permanently deleted from the node's storage. Content blobs will be deleted
+     * through garbage collection unless they are referenced from another document or tag.
+     */
+    @Throws(IrohException::class)
+    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
+    override suspend fun `dropDoc`(`docId`: kotlin.String) =
+        uniffiRustCallAsync(
+            callWithPointer { thisPtr ->
+                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_docs_drop_doc(
+                    thisPtr,
+                    FfiConverterString.lower(`docId`),
+                )
+            },
+            { future, callback, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_void(future, callback, continuation) },
+            { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_void(future, continuation) },
+            { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_void(future) },
+            // lift function
+            { Unit },
+            // Error FFI converter
+            IrohException.ErrorHandler,
+        )
+
+    /**
+     * Join and sync with an already existing document.
+     */
+    @Throws(IrohException::class)
+    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
+    override suspend fun `join`(`ticket`: kotlin.String): Doc =
+        uniffiRustCallAsync(
+            callWithPointer { thisPtr ->
+                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_docs_join(
+                    thisPtr,
+                    FfiConverterString.lower(`ticket`),
+                )
+            },
+            { future, callback, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_pointer(future, callback, continuation) },
+            { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_pointer(future, continuation) },
+            { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_pointer(future) },
+            // lift function
+            { FfiConverterTypeDoc.lift(it) },
+            // Error FFI converter
+            IrohException.ErrorHandler,
+        )
+
+    /**
+     * Join and sync with an already existing document and subscribe to events on that document.
+     */
+    @Throws(IrohException::class)
+    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
+    override suspend fun `joinAndSubscribe`(
+        `ticket`: kotlin.String,
+        `cb`: SubscribeCallback,
+    ): Doc =
+        uniffiRustCallAsync(
+            callWithPointer { thisPtr ->
+                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_docs_join_and_subscribe(
+                    thisPtr,
+                    FfiConverterString.lower(`ticket`),
+                    FfiConverterTypeSubscribeCallback.lower(`cb`),
+                )
+            },
+            { future, callback, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_pointer(future, callback, continuation) },
+            { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_pointer(future, continuation) },
+            { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_pointer(future) },
+            // lift function
+            { FfiConverterTypeDoc.lift(it) },
+            // Error FFI converter
+            IrohException.ErrorHandler,
+        )
+
+    /**
+     * List all the docs we have access to on this node.
+     */
+    @Throws(IrohException::class)
+    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
+    override suspend fun `list`(): List<NamespaceAndCapability> =
+        uniffiRustCallAsync(
+            callWithPointer { thisPtr ->
+                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_docs_list(
+                    thisPtr,
+                )
+            },
+            {
+                    future,
+                    callback,
+                    continuation,
+                ->
+                UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_rust_buffer(future, callback, continuation)
+            },
+            { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_rust_buffer(future, continuation) },
+            { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_rust_buffer(future) },
+            // lift function
+            { FfiConverterSequenceTypeNamespaceAndCapability.lift(it) },
+            // Error FFI converter
+            IrohException.ErrorHandler,
+        )
+
+    /**
+     * Get a [`Doc`].
+     *
+     * Returns None if the document cannot be found.
+     */
+    @Throws(IrohException::class)
+    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
+    override suspend fun `open`(`id`: kotlin.String): Doc? =
+        uniffiRustCallAsync(
+            callWithPointer { thisPtr ->
+                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_docs_open(
+                    thisPtr,
+                    FfiConverterString.lower(`id`),
+                )
+            },
+            {
+                    future,
+                    callback,
+                    continuation,
+                ->
+                UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_rust_buffer(future, callback, continuation)
+            },
+            { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_rust_buffer(future, continuation) },
+            { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_rust_buffer(future) },
+            // lift function
+            { FfiConverterOptionalTypeDoc.lift(it) },
+            // Error FFI converter
+            IrohException.ErrorHandler,
+        )
+
+    companion object
+}
+
+public object FfiConverterTypeDocs : FfiConverter<Docs, Pointer> {
+    override fun lower(value: Docs): Pointer = value.uniffiClonePointer()
+
+    override fun lift(value: Pointer): Docs = Docs(value)
+
+    override fun read(buf: ByteBuffer): Docs {
+        // The Rust code always writes pointers as 8 bytes, and will
+        // fail to compile if they don't fit.
+        return lift(Pointer(buf.getLong()))
+    }
+
+    override fun allocationSize(value: Docs) = 8UL
+
+    override fun write(
+        value: Docs,
+        buf: ByteBuffer,
+    ) {
+        // The Rust code always expects pointers written as 8 bytes,
+        // and will fail to compile if they don't fit.
+        buf.putLong(Pointer.nativeValue(lower(value)))
+    }
+}
+
+// This template implements a class for working with a Rust struct via a Pointer/Arc<T>
+// to the live Rust struct on the other side of the FFI.
+//
+// Each instance implements core operations for working with the Rust `Arc<T>` and the
+// Kotlin Pointer to work with the live Rust struct on the other side of the FFI.
+//
+// There's some subtlety here, because we have to be careful not to operate on a Rust
+// struct after it has been dropped, and because we must expose a public API for freeing
+// theq Kotlin wrapper object in lieu of reliable finalizers. The core requirements are:
+//
+//   * Each instance holds an opaque pointer to the underlying Rust struct.
+//     Method calls need to read this pointer from the object's state and pass it in to
+//     the Rust FFI.
+//
+//   * When an instance is no longer needed, its pointer should be passed to a
+//     special destructor function provided by the Rust FFI, which will drop the
+//     underlying Rust struct.
+//
+//   * Given an instance, calling code is expected to call the special
+//     `destroy` method in order to free it after use, either by calling it explicitly
+//     or by using a higher-level helper like the `use` method. Failing to do so risks
+//     leaking the underlying Rust struct.
+//
+//   * We can't assume that calling code will do the right thing, and must be prepared
+//     to handle Kotlin method calls executing concurrently with or even after a call to
+//     `destroy`, and to handle multiple (possibly concurrent!) calls to `destroy`.
+//
+//   * We must never allow Rust code to operate on the underlying Rust struct after
+//     the destructor has been called, and must never call the destructor more than once.
+//     Doing so may trigger memory unsafety.
+//
+//   * To mitigate many of the risks of leaking memory and use-after-free unsafety, a `Cleaner`
+//     is implemented to call the destructor when the Kotlin object becomes unreachable.
+//     This is done in a background thread. This is not a panacea, and client code should be aware that
+//      1. the thread may starve if some there are objects that have poorly performing
+//     `drop` methods or do significant work in their `drop` methods.
+//      2. the thread is shared across the whole library. This can be tuned by using `android_cleaner = true`,
+//         or `android = true` in the [`kotlin` section of the `uniffi.toml` file](https://mozilla.github.io/uniffi-rs/kotlin/configuration.html).
+//
+// If we try to implement this with mutual exclusion on access to the pointer, there is the
+// possibility of a race between a method call and a concurrent call to `destroy`:
+//
+//    * Thread A starts a method call, reads the value of the pointer, but is interrupted
+//      before it can pass the pointer over the FFI to Rust.
+//    * Thread B calls `destroy` and frees the underlying Rust struct.
+//    * Thread A resumes, passing the already-read pointer value to Rust and triggering
+//      a use-after-free.
+//
+// One possible solution would be to use a `ReadWriteLock`, with each method call taking
+// a read lock (and thus allowed to run concurrently) and the special `destroy` method
+// taking a write lock (and thus blocking on live method calls). However, we aim not to
+// generate methods with any hidden blocking semantics, and a `destroy` method that might
+// block if called incorrectly seems to meet that bar.
+//
+// So, we achieve our goals by giving each instance an associated `AtomicLong` counter to track
+// the number of in-flight method calls, and an `AtomicBoolean` flag to indicate whether `destroy`
+// has been called. These are updated according to the following rules:
+//
+//    * The initial value of the counter is 1, indicating a live object with no in-flight calls.
+//      The initial value for the flag is false.
+//
+//    * At the start of each method call, we atomically check the counter.
+//      If it is 0 then the underlying Rust struct has already been destroyed and the call is aborted.
+//      If it is nonzero them we atomically increment it by 1 and proceed with the method call.
+//
+//    * At the end of each method call, we atomically decrement and check the counter.
+//      If it has reached zero then we destroy the underlying Rust struct.
+//
+//    * When `destroy` is called, we atomically flip the flag from false to true.
+//      If the flag was already true we silently fail.
+//      Otherwise we atomically decrement and check the counter.
+//      If it has reached zero then we destroy the underlying Rust struct.
+//
+// Astute readers may observe that this all sounds very similar to the way that Rust's `Arc<T>` works,
+// and indeed it is, with the addition of a flag to guard against multiple calls to `destroy`.
+//
+// The overall effect is that the underlying Rust struct is destroyed only when `destroy` has been
+// called *and* all in-flight method calls have completed, avoiding violating any of the expectations
+// of the underlying Rust code.
+//
+// This makes a cleaner a better alternative to _not_ calling `destroy()` as
+// and when the object is finished with, but the abstraction is not perfect: if the Rust object's `drop`
+// method is slow, and/or there are many objects to cleanup, and it's on a low end Android device, then the cleaner
+// thread may be starved, and the app will leak memory.
+//
+// In this case, `destroy`ing manually may be a better solution.
+//
+// The cleaner can live side by side with the manual calling of `destroy`. In the order of responsiveness, uniffi objects
+// with Rust peers are reclaimed:
+//
+// 1. By calling the `destroy` method of the object, which calls `rustObject.free()`. If that doesn't happen:
+// 2. When the object becomes unreachable, AND the Cleaner thread gets to call `rustObject.free()`. If the thread is starved then:
+// 3. The memory is reclaimed when the process terminates.
+//
+// [1] https://stackoverflow.com/questions/24376768/can-java-finalize-an-object-when-it-is-still-in-scope/24380219
+//
+
+/**
  * The `progress` method will be called for each `DownloadProgress` event that is emitted during
  * a `node.blobs_download`. Use the `DownloadProgress.type()` method to check the
  * `DownloadProgressType` of the event.
@@ -10318,6 +12154,254 @@ public object FfiConverterTypeFilterKind : FfiConverter<FilterKind, Pointer> {
 // [1] https://stackoverflow.com/questions/24376768/can-java-finalize-an-object-when-it-is-still-in-scope/24380219
 //
 
+/**
+ * Iroh gossip client.
+ */
+public interface GossipInterface {
+    suspend fun `subscribe`(
+        `topic`: kotlin.ByteArray,
+        `bootstrap`: List<kotlin.String>,
+        `cb`: GossipMessageCallback,
+    ): Sender
+
+    companion object
+}
+
+/**
+ * Iroh gossip client.
+ */
+open class Gossip :
+    Disposable,
+    AutoCloseable,
+    GossipInterface {
+    constructor(pointer: Pointer) {
+        this.pointer = pointer
+        this.cleanable = UniffiLib.CLEANER.register(this, UniffiCleanAction(pointer))
+    }
+
+    /**
+     * This constructor can be used to instantiate a fake object. Only used for tests. Any
+     * attempt to actually use an object constructed this way will fail as there is no
+     * connected Rust object.
+     */
+    @Suppress("UNUSED_PARAMETER")
+    constructor(noPointer: NoPointer) {
+        this.pointer = null
+        this.cleanable = UniffiLib.CLEANER.register(this, UniffiCleanAction(pointer))
+    }
+
+    protected val pointer: Pointer?
+    protected val cleanable: UniffiCleaner.Cleanable
+
+    private val wasDestroyed = AtomicBoolean(false)
+    private val callCounter = AtomicLong(1)
+
+    override fun destroy() {
+        // Only allow a single call to this method.
+        // TODO: maybe we should log a warning if called more than once?
+        if (this.wasDestroyed.compareAndSet(false, true)) {
+            // This decrement always matches the initial count of 1 given at creation time.
+            if (this.callCounter.decrementAndGet() == 0L) {
+                cleanable.clean()
+            }
+        }
+    }
+
+    @Synchronized
+    override fun close() {
+        this.destroy()
+    }
+
+    internal inline fun <R> callWithPointer(block: (ptr: Pointer) -> R): R {
+        // Check and increment the call counter, to keep the object alive.
+        // This needs a compare-and-set retry loop in case of concurrent updates.
+        do {
+            val c = this.callCounter.get()
+            if (c == 0L) {
+                throw IllegalStateException("${this.javaClass.simpleName} object has already been destroyed")
+            }
+            if (c == Long.MAX_VALUE) {
+                throw IllegalStateException("${this.javaClass.simpleName} call counter would overflow")
+            }
+        } while (!this.callCounter.compareAndSet(c, c + 1L))
+        // Now we can safely do the method call without the pointer being freed concurrently.
+        try {
+            return block(this.uniffiClonePointer())
+        } finally {
+            // This decrement always matches the increment we performed above.
+            if (this.callCounter.decrementAndGet() == 0L) {
+                cleanable.clean()
+            }
+        }
+    }
+
+    // Use a static inner class instead of a closure so as not to accidentally
+    // capture `this` as part of the cleanable's action.
+    private class UniffiCleanAction(
+        private val pointer: Pointer?,
+    ) : Runnable {
+        override fun run() {
+            pointer?.let { ptr ->
+                uniffiRustCall { status ->
+                    UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_free_gossip(ptr, status)
+                }
+            }
+        }
+    }
+
+    fun uniffiClonePointer(): Pointer =
+        uniffiRustCall { status ->
+            UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_clone_gossip(pointer!!, status)
+        }
+
+    @Throws(IrohException::class)
+    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
+    override suspend fun `subscribe`(
+        `topic`: kotlin.ByteArray,
+        `bootstrap`: List<kotlin.String>,
+        `cb`: GossipMessageCallback,
+    ): Sender =
+        uniffiRustCallAsync(
+            callWithPointer { thisPtr ->
+                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_gossip_subscribe(
+                    thisPtr,
+                    FfiConverterByteArray.lower(`topic`),
+                    FfiConverterSequenceString.lower(`bootstrap`),
+                    FfiConverterTypeGossipMessageCallback.lower(`cb`),
+                )
+            },
+            { future, callback, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_pointer(future, callback, continuation) },
+            { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_pointer(future, continuation) },
+            { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_pointer(future) },
+            // lift function
+            { FfiConverterTypeSender.lift(it) },
+            // Error FFI converter
+            IrohException.ErrorHandler,
+        )
+
+    companion object
+}
+
+public object FfiConverterTypeGossip : FfiConverter<Gossip, Pointer> {
+    override fun lower(value: Gossip): Pointer = value.uniffiClonePointer()
+
+    override fun lift(value: Pointer): Gossip = Gossip(value)
+
+    override fun read(buf: ByteBuffer): Gossip {
+        // The Rust code always writes pointers as 8 bytes, and will
+        // fail to compile if they don't fit.
+        return lift(Pointer(buf.getLong()))
+    }
+
+    override fun allocationSize(value: Gossip) = 8UL
+
+    override fun write(
+        value: Gossip,
+        buf: ByteBuffer,
+    ) {
+        // The Rust code always expects pointers written as 8 bytes,
+        // and will fail to compile if they don't fit.
+        buf.putLong(Pointer.nativeValue(lower(value)))
+    }
+}
+
+// This template implements a class for working with a Rust struct via a Pointer/Arc<T>
+// to the live Rust struct on the other side of the FFI.
+//
+// Each instance implements core operations for working with the Rust `Arc<T>` and the
+// Kotlin Pointer to work with the live Rust struct on the other side of the FFI.
+//
+// There's some subtlety here, because we have to be careful not to operate on a Rust
+// struct after it has been dropped, and because we must expose a public API for freeing
+// theq Kotlin wrapper object in lieu of reliable finalizers. The core requirements are:
+//
+//   * Each instance holds an opaque pointer to the underlying Rust struct.
+//     Method calls need to read this pointer from the object's state and pass it in to
+//     the Rust FFI.
+//
+//   * When an instance is no longer needed, its pointer should be passed to a
+//     special destructor function provided by the Rust FFI, which will drop the
+//     underlying Rust struct.
+//
+//   * Given an instance, calling code is expected to call the special
+//     `destroy` method in order to free it after use, either by calling it explicitly
+//     or by using a higher-level helper like the `use` method. Failing to do so risks
+//     leaking the underlying Rust struct.
+//
+//   * We can't assume that calling code will do the right thing, and must be prepared
+//     to handle Kotlin method calls executing concurrently with or even after a call to
+//     `destroy`, and to handle multiple (possibly concurrent!) calls to `destroy`.
+//
+//   * We must never allow Rust code to operate on the underlying Rust struct after
+//     the destructor has been called, and must never call the destructor more than once.
+//     Doing so may trigger memory unsafety.
+//
+//   * To mitigate many of the risks of leaking memory and use-after-free unsafety, a `Cleaner`
+//     is implemented to call the destructor when the Kotlin object becomes unreachable.
+//     This is done in a background thread. This is not a panacea, and client code should be aware that
+//      1. the thread may starve if some there are objects that have poorly performing
+//     `drop` methods or do significant work in their `drop` methods.
+//      2. the thread is shared across the whole library. This can be tuned by using `android_cleaner = true`,
+//         or `android = true` in the [`kotlin` section of the `uniffi.toml` file](https://mozilla.github.io/uniffi-rs/kotlin/configuration.html).
+//
+// If we try to implement this with mutual exclusion on access to the pointer, there is the
+// possibility of a race between a method call and a concurrent call to `destroy`:
+//
+//    * Thread A starts a method call, reads the value of the pointer, but is interrupted
+//      before it can pass the pointer over the FFI to Rust.
+//    * Thread B calls `destroy` and frees the underlying Rust struct.
+//    * Thread A resumes, passing the already-read pointer value to Rust and triggering
+//      a use-after-free.
+//
+// One possible solution would be to use a `ReadWriteLock`, with each method call taking
+// a read lock (and thus allowed to run concurrently) and the special `destroy` method
+// taking a write lock (and thus blocking on live method calls). However, we aim not to
+// generate methods with any hidden blocking semantics, and a `destroy` method that might
+// block if called incorrectly seems to meet that bar.
+//
+// So, we achieve our goals by giving each instance an associated `AtomicLong` counter to track
+// the number of in-flight method calls, and an `AtomicBoolean` flag to indicate whether `destroy`
+// has been called. These are updated according to the following rules:
+//
+//    * The initial value of the counter is 1, indicating a live object with no in-flight calls.
+//      The initial value for the flag is false.
+//
+//    * At the start of each method call, we atomically check the counter.
+//      If it is 0 then the underlying Rust struct has already been destroyed and the call is aborted.
+//      If it is nonzero them we atomically increment it by 1 and proceed with the method call.
+//
+//    * At the end of each method call, we atomically decrement and check the counter.
+//      If it has reached zero then we destroy the underlying Rust struct.
+//
+//    * When `destroy` is called, we atomically flip the flag from false to true.
+//      If the flag was already true we silently fail.
+//      Otherwise we atomically decrement and check the counter.
+//      If it has reached zero then we destroy the underlying Rust struct.
+//
+// Astute readers may observe that this all sounds very similar to the way that Rust's `Arc<T>` works,
+// and indeed it is, with the addition of a flag to guard against multiple calls to `destroy`.
+//
+// The overall effect is that the underlying Rust struct is destroyed only when `destroy` has been
+// called *and* all in-flight method calls have completed, avoiding violating any of the expectations
+// of the underlying Rust code.
+//
+// This makes a cleaner a better alternative to _not_ calling `destroy()` as
+// and when the object is finished with, but the abstraction is not perfect: if the Rust object's `drop`
+// method is slow, and/or there are many objects to cleanup, and it's on a low end Android device, then the cleaner
+// thread may be starved, and the app will leak memory.
+//
+// In this case, `destroy`ing manually may be a better solution.
+//
+// The cleaner can live side by side with the manual calling of `destroy`. In the order of responsiveness, uniffi objects
+// with Rust peers are reclaimed:
+//
+// 1. By calling the `destroy` method of the object, which calls `rustObject.free()`. If that doesn't happen:
+// 2. When the object becomes unreachable, AND the Cleaner thread gets to call `rustObject.free()`. If the thread is starved then:
+// 3. The memory is reclaimed when the process terminates.
+//
+// [1] https://stackoverflow.com/questions/24376768/can-java-finalize-an-object-when-it-is-still-in-scope/24380219
+//
+
 public interface GossipMessageCallback {
     suspend fun `onMessage`(`msg`: Message)
 
@@ -10947,6 +13031,446 @@ public object FfiConverterTypeHash : FfiConverter<Hash, Pointer> {
 //
 
 /**
+ * An Iroh node. Allows you to sync, store, and transfer data.
+ */
+public interface IrohInterface {
+    /**
+     * Access to authors specific funtionaliy.
+     */
+    fun `authors`(): Authors
+
+    /**
+     * Access to blob specific funtionaliy.
+     */
+    fun `blobs`(): Blobs
+
+    /**
+     * Access to docs specific funtionaliy.
+     */
+    fun `docs`(): Docs
+
+    /**
+     * Access to gossip specific funtionaliy.
+     */
+    fun `gossip`(): Gossip
+
+    /**
+     * Access to node specific funtionaliy.
+     */
+    fun `node`(): Node
+
+    /**
+     * Access to tags specific funtionaliy.
+     */
+    fun `tags`(): Tags
+
+    companion object
+}
+
+/**
+ * An Iroh node. Allows you to sync, store, and transfer data.
+ */
+open class Iroh :
+    Disposable,
+    AutoCloseable,
+    IrohInterface {
+    constructor(pointer: Pointer) {
+        this.pointer = pointer
+        this.cleanable = UniffiLib.CLEANER.register(this, UniffiCleanAction(pointer))
+    }
+
+    /**
+     * This constructor can be used to instantiate a fake object. Only used for tests. Any
+     * attempt to actually use an object constructed this way will fail as there is no
+     * connected Rust object.
+     */
+    @Suppress("UNUSED_PARAMETER")
+    constructor(noPointer: NoPointer) {
+        this.pointer = null
+        this.cleanable = UniffiLib.CLEANER.register(this, UniffiCleanAction(pointer))
+    }
+
+    protected val pointer: Pointer?
+    protected val cleanable: UniffiCleaner.Cleanable
+
+    private val wasDestroyed = AtomicBoolean(false)
+    private val callCounter = AtomicLong(1)
+
+    override fun destroy() {
+        // Only allow a single call to this method.
+        // TODO: maybe we should log a warning if called more than once?
+        if (this.wasDestroyed.compareAndSet(false, true)) {
+            // This decrement always matches the initial count of 1 given at creation time.
+            if (this.callCounter.decrementAndGet() == 0L) {
+                cleanable.clean()
+            }
+        }
+    }
+
+    @Synchronized
+    override fun close() {
+        this.destroy()
+    }
+
+    internal inline fun <R> callWithPointer(block: (ptr: Pointer) -> R): R {
+        // Check and increment the call counter, to keep the object alive.
+        // This needs a compare-and-set retry loop in case of concurrent updates.
+        do {
+            val c = this.callCounter.get()
+            if (c == 0L) {
+                throw IllegalStateException("${this.javaClass.simpleName} object has already been destroyed")
+            }
+            if (c == Long.MAX_VALUE) {
+                throw IllegalStateException("${this.javaClass.simpleName} call counter would overflow")
+            }
+        } while (!this.callCounter.compareAndSet(c, c + 1L))
+        // Now we can safely do the method call without the pointer being freed concurrently.
+        try {
+            return block(this.uniffiClonePointer())
+        } finally {
+            // This decrement always matches the increment we performed above.
+            if (this.callCounter.decrementAndGet() == 0L) {
+                cleanable.clean()
+            }
+        }
+    }
+
+    // Use a static inner class instead of a closure so as not to accidentally
+    // capture `this` as part of the cleanable's action.
+    private class UniffiCleanAction(
+        private val pointer: Pointer?,
+    ) : Runnable {
+        override fun run() {
+            pointer?.let { ptr ->
+                uniffiRustCall { status ->
+                    UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_free_iroh(ptr, status)
+                }
+            }
+        }
+    }
+
+    fun uniffiClonePointer(): Pointer =
+        uniffiRustCall { status ->
+            UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_clone_iroh(pointer!!, status)
+        }
+
+    /**
+     * Access to authors specific funtionaliy.
+     */
+    override fun `authors`(): Authors =
+        FfiConverterTypeAuthors.lift(
+            callWithPointer {
+                uniffiRustCall { _status ->
+                    UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_iroh_authors(
+                        it,
+                        _status,
+                    )
+                }
+            },
+        )
+
+    /**
+     * Access to blob specific funtionaliy.
+     */
+    override fun `blobs`(): Blobs =
+        FfiConverterTypeBlobs.lift(
+            callWithPointer {
+                uniffiRustCall { _status ->
+                    UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_iroh_blobs(
+                        it,
+                        _status,
+                    )
+                }
+            },
+        )
+
+    /**
+     * Access to docs specific funtionaliy.
+     */
+    override fun `docs`(): Docs =
+        FfiConverterTypeDocs.lift(
+            callWithPointer {
+                uniffiRustCall { _status ->
+                    UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_iroh_docs(
+                        it,
+                        _status,
+                    )
+                }
+            },
+        )
+
+    /**
+     * Access to gossip specific funtionaliy.
+     */
+    override fun `gossip`(): Gossip =
+        FfiConverterTypeGossip.lift(
+            callWithPointer {
+                uniffiRustCall { _status ->
+                    UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_iroh_gossip(
+                        it,
+                        _status,
+                    )
+                }
+            },
+        )
+
+    /**
+     * Access to node specific funtionaliy.
+     */
+    override fun `node`(): Node =
+        FfiConverterTypeNode.lift(
+            callWithPointer {
+                uniffiRustCall { _status ->
+                    UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_iroh_node(
+                        it,
+                        _status,
+                    )
+                }
+            },
+        )
+
+    /**
+     * Access to tags specific funtionaliy.
+     */
+    override fun `tags`(): Tags =
+        FfiConverterTypeTags.lift(
+            callWithPointer {
+                uniffiRustCall { _status ->
+                    UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_iroh_tags(
+                        it,
+                        _status,
+                    )
+                }
+            },
+        )
+
+    companion object {
+        /**
+         * Create a new iroh node.
+         *
+         * All data will be only persistet in memory.
+         */
+        @Throws(IrohException::class)
+        @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
+        suspend fun `memory`(): Iroh =
+            uniffiRustCallAsync(
+                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_constructor_iroh_memory(),
+                {
+                        future,
+                        callback,
+                        continuation,
+                    ->
+                    UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_pointer(future, callback, continuation)
+                },
+                { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_pointer(future, continuation) },
+                { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_pointer(future) },
+                // lift function
+                { FfiConverterTypeIroh.lift(it) },
+                // Error FFI converter
+                IrohException.ErrorHandler,
+            )
+
+        /**
+         * Create a new in memory iroh node with options.
+         */
+        @Throws(IrohException::class)
+        @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
+        suspend fun `memoryWithOptions`(`options`: NodeOptions): Iroh =
+            uniffiRustCallAsync(
+                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_constructor_iroh_memory_with_options(FfiConverterTypeNodeOptions.lower(`options`)),
+                {
+                        future,
+                        callback,
+                        continuation,
+                    ->
+                    UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_pointer(future, callback, continuation)
+                },
+                { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_pointer(future, continuation) },
+                { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_pointer(future) },
+                // lift function
+                { FfiConverterTypeIroh.lift(it) },
+                // Error FFI converter
+                IrohException.ErrorHandler,
+            )
+
+        /**
+         * Create a new iroh node.
+         *
+         * The `path` param should be a directory where we can store or load
+         * iroh data from a previous session.
+         */
+        @Throws(IrohException::class)
+        @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
+        suspend fun `persistent`(`path`: kotlin.String): Iroh =
+            uniffiRustCallAsync(
+                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_constructor_iroh_persistent(FfiConverterString.lower(`path`)),
+                {
+                        future,
+                        callback,
+                        continuation,
+                    ->
+                    UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_pointer(future, callback, continuation)
+                },
+                { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_pointer(future, continuation) },
+                { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_pointer(future) },
+                // lift function
+                { FfiConverterTypeIroh.lift(it) },
+                // Error FFI converter
+                IrohException.ErrorHandler,
+            )
+
+        /**
+         * Create a new iroh node with options.
+         */
+        @Throws(IrohException::class)
+        @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
+        suspend fun `persistentWithOptions`(
+            `path`: kotlin.String,
+            `options`: NodeOptions,
+        ): Iroh =
+            uniffiRustCallAsync(
+                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_constructor_iroh_persistent_with_options(
+                    FfiConverterString.lower(`path`),
+                    FfiConverterTypeNodeOptions.lower(`options`),
+                ),
+                {
+                        future,
+                        callback,
+                        continuation,
+                    ->
+                    UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_pointer(future, callback, continuation)
+                },
+                { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_pointer(future, continuation) },
+                { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_pointer(future) },
+                // lift function
+                { FfiConverterTypeIroh.lift(it) },
+                // Error FFI converter
+                IrohException.ErrorHandler,
+            )
+    }
+}
+
+public object FfiConverterTypeIroh : FfiConverter<Iroh, Pointer> {
+    override fun lower(value: Iroh): Pointer = value.uniffiClonePointer()
+
+    override fun lift(value: Pointer): Iroh = Iroh(value)
+
+    override fun read(buf: ByteBuffer): Iroh {
+        // The Rust code always writes pointers as 8 bytes, and will
+        // fail to compile if they don't fit.
+        return lift(Pointer(buf.getLong()))
+    }
+
+    override fun allocationSize(value: Iroh) = 8UL
+
+    override fun write(
+        value: Iroh,
+        buf: ByteBuffer,
+    ) {
+        // The Rust code always expects pointers written as 8 bytes,
+        // and will fail to compile if they don't fit.
+        buf.putLong(Pointer.nativeValue(lower(value)))
+    }
+}
+
+// This template implements a class for working with a Rust struct via a Pointer/Arc<T>
+// to the live Rust struct on the other side of the FFI.
+//
+// Each instance implements core operations for working with the Rust `Arc<T>` and the
+// Kotlin Pointer to work with the live Rust struct on the other side of the FFI.
+//
+// There's some subtlety here, because we have to be careful not to operate on a Rust
+// struct after it has been dropped, and because we must expose a public API for freeing
+// theq Kotlin wrapper object in lieu of reliable finalizers. The core requirements are:
+//
+//   * Each instance holds an opaque pointer to the underlying Rust struct.
+//     Method calls need to read this pointer from the object's state and pass it in to
+//     the Rust FFI.
+//
+//   * When an instance is no longer needed, its pointer should be passed to a
+//     special destructor function provided by the Rust FFI, which will drop the
+//     underlying Rust struct.
+//
+//   * Given an instance, calling code is expected to call the special
+//     `destroy` method in order to free it after use, either by calling it explicitly
+//     or by using a higher-level helper like the `use` method. Failing to do so risks
+//     leaking the underlying Rust struct.
+//
+//   * We can't assume that calling code will do the right thing, and must be prepared
+//     to handle Kotlin method calls executing concurrently with or even after a call to
+//     `destroy`, and to handle multiple (possibly concurrent!) calls to `destroy`.
+//
+//   * We must never allow Rust code to operate on the underlying Rust struct after
+//     the destructor has been called, and must never call the destructor more than once.
+//     Doing so may trigger memory unsafety.
+//
+//   * To mitigate many of the risks of leaking memory and use-after-free unsafety, a `Cleaner`
+//     is implemented to call the destructor when the Kotlin object becomes unreachable.
+//     This is done in a background thread. This is not a panacea, and client code should be aware that
+//      1. the thread may starve if some there are objects that have poorly performing
+//     `drop` methods or do significant work in their `drop` methods.
+//      2. the thread is shared across the whole library. This can be tuned by using `android_cleaner = true`,
+//         or `android = true` in the [`kotlin` section of the `uniffi.toml` file](https://mozilla.github.io/uniffi-rs/kotlin/configuration.html).
+//
+// If we try to implement this with mutual exclusion on access to the pointer, there is the
+// possibility of a race between a method call and a concurrent call to `destroy`:
+//
+//    * Thread A starts a method call, reads the value of the pointer, but is interrupted
+//      before it can pass the pointer over the FFI to Rust.
+//    * Thread B calls `destroy` and frees the underlying Rust struct.
+//    * Thread A resumes, passing the already-read pointer value to Rust and triggering
+//      a use-after-free.
+//
+// One possible solution would be to use a `ReadWriteLock`, with each method call taking
+// a read lock (and thus allowed to run concurrently) and the special `destroy` method
+// taking a write lock (and thus blocking on live method calls). However, we aim not to
+// generate methods with any hidden blocking semantics, and a `destroy` method that might
+// block if called incorrectly seems to meet that bar.
+//
+// So, we achieve our goals by giving each instance an associated `AtomicLong` counter to track
+// the number of in-flight method calls, and an `AtomicBoolean` flag to indicate whether `destroy`
+// has been called. These are updated according to the following rules:
+//
+//    * The initial value of the counter is 1, indicating a live object with no in-flight calls.
+//      The initial value for the flag is false.
+//
+//    * At the start of each method call, we atomically check the counter.
+//      If it is 0 then the underlying Rust struct has already been destroyed and the call is aborted.
+//      If it is nonzero them we atomically increment it by 1 and proceed with the method call.
+//
+//    * At the end of each method call, we atomically decrement and check the counter.
+//      If it has reached zero then we destroy the underlying Rust struct.
+//
+//    * When `destroy` is called, we atomically flip the flag from false to true.
+//      If the flag was already true we silently fail.
+//      Otherwise we atomically decrement and check the counter.
+//      If it has reached zero then we destroy the underlying Rust struct.
+//
+// Astute readers may observe that this all sounds very similar to the way that Rust's `Arc<T>` works,
+// and indeed it is, with the addition of a flag to guard against multiple calls to `destroy`.
+//
+// The overall effect is that the underlying Rust struct is destroyed only when `destroy` has been
+// called *and* all in-flight method calls have completed, avoiding violating any of the expectations
+// of the underlying Rust code.
+//
+// This makes a cleaner a better alternative to _not_ calling `destroy()` as
+// and when the object is finished with, but the abstraction is not perfect: if the Rust object's `drop`
+// method is slow, and/or there are many objects to cleanup, and it's on a low end Android device, then the cleaner
+// thread may be starved, and the app will leak memory.
+//
+// In this case, `destroy`ing manually may be a better solution.
+//
+// The cleaner can live side by side with the manual calling of `destroy`. In the order of responsiveness, uniffi objects
+// with Rust peers are reclaimed:
+//
+// 1. By calling the `destroy` method of the object, which calls `rustObject.free()`. If that doesn't happen:
+// 2. When the object becomes unreachable, AND the Cleaner thread gets to call `rustObject.free()`. If the thread is starved then:
+// 3. The memory is reclaimed when the process terminates.
+//
+// [1] https://stackoverflow.com/questions/24376768/can-java-finalize-an-object-when-it-is-still-in-scope/24380219
+//
+
+/**
  * An Error.
  */
 public interface IrohExceptionInterface {
@@ -11083,1733 +13607,6 @@ public object FfiConverterTypeIrohError : FfiConverter<IrohException, Pointer> {
 
     override fun write(
         value: IrohException,
-        buf: ByteBuffer,
-    ) {
-        // The Rust code always expects pointers written as 8 bytes,
-        // and will fail to compile if they don't fit.
-        buf.putLong(Pointer.nativeValue(lower(value)))
-    }
-}
-
-// This template implements a class for working with a Rust struct via a Pointer/Arc<T>
-// to the live Rust struct on the other side of the FFI.
-//
-// Each instance implements core operations for working with the Rust `Arc<T>` and the
-// Kotlin Pointer to work with the live Rust struct on the other side of the FFI.
-//
-// There's some subtlety here, because we have to be careful not to operate on a Rust
-// struct after it has been dropped, and because we must expose a public API for freeing
-// theq Kotlin wrapper object in lieu of reliable finalizers. The core requirements are:
-//
-//   * Each instance holds an opaque pointer to the underlying Rust struct.
-//     Method calls need to read this pointer from the object's state and pass it in to
-//     the Rust FFI.
-//
-//   * When an instance is no longer needed, its pointer should be passed to a
-//     special destructor function provided by the Rust FFI, which will drop the
-//     underlying Rust struct.
-//
-//   * Given an instance, calling code is expected to call the special
-//     `destroy` method in order to free it after use, either by calling it explicitly
-//     or by using a higher-level helper like the `use` method. Failing to do so risks
-//     leaking the underlying Rust struct.
-//
-//   * We can't assume that calling code will do the right thing, and must be prepared
-//     to handle Kotlin method calls executing concurrently with or even after a call to
-//     `destroy`, and to handle multiple (possibly concurrent!) calls to `destroy`.
-//
-//   * We must never allow Rust code to operate on the underlying Rust struct after
-//     the destructor has been called, and must never call the destructor more than once.
-//     Doing so may trigger memory unsafety.
-//
-//   * To mitigate many of the risks of leaking memory and use-after-free unsafety, a `Cleaner`
-//     is implemented to call the destructor when the Kotlin object becomes unreachable.
-//     This is done in a background thread. This is not a panacea, and client code should be aware that
-//      1. the thread may starve if some there are objects that have poorly performing
-//     `drop` methods or do significant work in their `drop` methods.
-//      2. the thread is shared across the whole library. This can be tuned by using `android_cleaner = true`,
-//         or `android = true` in the [`kotlin` section of the `uniffi.toml` file](https://mozilla.github.io/uniffi-rs/kotlin/configuration.html).
-//
-// If we try to implement this with mutual exclusion on access to the pointer, there is the
-// possibility of a race between a method call and a concurrent call to `destroy`:
-//
-//    * Thread A starts a method call, reads the value of the pointer, but is interrupted
-//      before it can pass the pointer over the FFI to Rust.
-//    * Thread B calls `destroy` and frees the underlying Rust struct.
-//    * Thread A resumes, passing the already-read pointer value to Rust and triggering
-//      a use-after-free.
-//
-// One possible solution would be to use a `ReadWriteLock`, with each method call taking
-// a read lock (and thus allowed to run concurrently) and the special `destroy` method
-// taking a write lock (and thus blocking on live method calls). However, we aim not to
-// generate methods with any hidden blocking semantics, and a `destroy` method that might
-// block if called incorrectly seems to meet that bar.
-//
-// So, we achieve our goals by giving each instance an associated `AtomicLong` counter to track
-// the number of in-flight method calls, and an `AtomicBoolean` flag to indicate whether `destroy`
-// has been called. These are updated according to the following rules:
-//
-//    * The initial value of the counter is 1, indicating a live object with no in-flight calls.
-//      The initial value for the flag is false.
-//
-//    * At the start of each method call, we atomically check the counter.
-//      If it is 0 then the underlying Rust struct has already been destroyed and the call is aborted.
-//      If it is nonzero them we atomically increment it by 1 and proceed with the method call.
-//
-//    * At the end of each method call, we atomically decrement and check the counter.
-//      If it has reached zero then we destroy the underlying Rust struct.
-//
-//    * When `destroy` is called, we atomically flip the flag from false to true.
-//      If the flag was already true we silently fail.
-//      Otherwise we atomically decrement and check the counter.
-//      If it has reached zero then we destroy the underlying Rust struct.
-//
-// Astute readers may observe that this all sounds very similar to the way that Rust's `Arc<T>` works,
-// and indeed it is, with the addition of a flag to guard against multiple calls to `destroy`.
-//
-// The overall effect is that the underlying Rust struct is destroyed only when `destroy` has been
-// called *and* all in-flight method calls have completed, avoiding violating any of the expectations
-// of the underlying Rust code.
-//
-// This makes a cleaner a better alternative to _not_ calling `destroy()` as
-// and when the object is finished with, but the abstraction is not perfect: if the Rust object's `drop`
-// method is slow, and/or there are many objects to cleanup, and it's on a low end Android device, then the cleaner
-// thread may be starved, and the app will leak memory.
-//
-// In this case, `destroy`ing manually may be a better solution.
-//
-// The cleaner can live side by side with the manual calling of `destroy`. In the order of responsiveness, uniffi objects
-// with Rust peers are reclaimed:
-//
-// 1. By calling the `destroy` method of the object, which calls `rustObject.free()`. If that doesn't happen:
-// 2. When the object becomes unreachable, AND the Cleaner thread gets to call `rustObject.free()`. If the thread is starved then:
-// 3. The memory is reclaimed when the process terminates.
-//
-// [1] https://stackoverflow.com/questions/24376768/can-java-finalize-an-object-when-it-is-still-in-scope/24380219
-//
-
-/**
- * An Iroh node. Allows you to sync, store, and transfer data.
- */
-public interface IrohNodeInterface {
-    /**
-     * Add a known node address to the node.
-     */
-    suspend fun `addNodeAddr`(`addr`: NodeAddr)
-
-    /**
-     * Create a new document author.
-     *
-     * You likely want to save the returned [`AuthorId`] somewhere so that you can use this author
-     * again.
-     *
-     * If you need only a single author, use [`Self::default`].
-     */
-    suspend fun `authorCreate`(): AuthorId
-
-    /**
-     * Returns the default document author of this node.
-     *
-     * On persistent nodes, the author is created on first start and its public key is saved
-     * in the data directory.
-     *
-     * The default author can be set with [`Self::set_default`].
-     */
-    suspend fun `authorDefault`(): AuthorId
-
-    /**
-     * Deletes the given author by id.
-     *
-     * Warning: This permanently removes this author.
-     */
-    suspend fun `authorDelete`(`author`: AuthorId)
-
-    /**
-     * Export the given author.
-     *
-     * Warning: This contains sensitive data.
-     */
-    suspend fun `authorExport`(`author`: AuthorId): Author
-
-    /**
-     * Import the given author.
-     *
-     * Warning: This contains sensitive data.
-     */
-    suspend fun `authorImport`(`author`: Author): AuthorId
-
-    /**
-     * List all the AuthorIds that exist on this node.
-     */
-    suspend fun `authorList`(): List<AuthorId>
-
-    /**
-     * Write a blob by passing bytes.
-     */
-    suspend fun `blobsAddBytes`(`bytes`: kotlin.ByteArray): BlobAddOutcome
-
-    /**
-     * Write a blob by passing bytes, setting an explicit tag name.
-     */
-    suspend fun `blobsAddBytesNamed`(
-        `bytes`: kotlin.ByteArray,
-        `name`: kotlin.String,
-    ): BlobAddOutcome
-
-    /**
-     * Import a blob from a filesystem path.
-     *
-     * `path` should be an absolute path valid for the file system on which
-     * the node runs.
-     * If `in_place` is true, Iroh will assume that the data will not change and will share it in
-     * place without copying to the Iroh data directory.
-     */
-    suspend fun `blobsAddFromPath`(
-        `path`: kotlin.String,
-        `inPlace`: kotlin.Boolean,
-        `tag`: SetTagOption,
-        `wrap`: WrapOption,
-        `cb`: AddCallback,
-    )
-
-    /**
-     * Create a collection from already existing blobs.
-     *
-     * To automatically clear the tags for the passed in blobs you can set
-     * `tags_to_delete` on those tags, and they will be deleted once the collection is created.
-     */
-    suspend fun `blobsCreateCollection`(
-        `collection`: Collection,
-        `tag`: SetTagOption,
-        `tagsToDelete`: List<kotlin.String>,
-    ): HashAndTag
-
-    /**
-     * Delete a blob.
-     */
-    suspend fun `blobsDeleteBlob`(`hash`: Hash)
-
-    /**
-     * Download a blob from another node and add it to the local database.
-     */
-    suspend fun `blobsDownload`(
-        `hash`: Hash,
-        `opts`: BlobDownloadOptions,
-        `cb`: DownloadCallback,
-    )
-
-    /**
-     * Export a blob from the internal blob store to a path on the node's filesystem.
-     *
-     * `destination` should be a writeable, absolute path on the local node's filesystem.
-     *
-     * If `format` is set to [`ExportFormat::Collection`], and the `hash` refers to a collection,
-     * all children of the collection will be exported. See [`ExportFormat`] for details.
-     *
-     * The `mode` argument defines if the blob should be copied to the target location or moved out of
-     * the internal store into the target location. See [`ExportMode`] for details.
-     */
-    suspend fun `blobsExport`(
-        `hash`: Hash,
-        `destination`: kotlin.String,
-        `format`: BlobExportFormat,
-        `mode`: BlobExportMode,
-    )
-
-    /**
-     * Read the content of a collection
-     */
-    suspend fun `blobsGetCollection`(`hash`: Hash): Collection
-
-    /**
-     * List all complete blobs.
-     *
-     * Note: this allocates for each `BlobListResponse`, if you have many `BlobListReponse`s this may be a prohibitively large list.
-     * Please file an [issue](https://github.com/n0-computer/iroh-ffi/issues/new) if you run into this issue
-     */
-    suspend fun `blobsList`(): List<Hash>
-
-    /**
-     * List all collections.
-     *
-     * Note: this allocates for each `BlobListCollectionsResponse`, if you have many `BlobListCollectionsResponse`s this may be a prohibitively large list.
-     * Please file an [issue](https://github.com/n0-computer/iroh-ffi/issues/new) if you run into this issue
-     */
-    suspend fun `blobsListCollections`(): List<CollectionInfo>
-
-    /**
-     * List all incomplete (partial) blobs.
-     *
-     * Note: this allocates for each `BlobListIncompleteResponse`, if you have many `BlobListIncompleteResponse`s this may be a prohibitively large list.
-     * Please file an [issue](https://github.com/n0-computer/iroh-ffi/issues/new) if you run into this issue
-     */
-    suspend fun `blobsListIncomplete`(): List<IncompleteBlobInfo>
-
-    /**
-     * Read all bytes of single blob at `offset` for length `len`.
-     *
-     * This allocates a buffer for the full length `len`. Use only if you know that the blob you're
-     * reading is small. If not sure, use [`Self::blobs_size`] and check the size with
-     * before calling [`Self::blobs_read_at_to_bytes`].
-     */
-    suspend fun `blobsReadAtToBytes`(
-        `hash`: Hash,
-        `offset`: kotlin.ULong,
-        `len`: kotlin.ULong?,
-    ): kotlin.ByteArray
-
-    /**
-     * Read all bytes of single blob.
-     *
-     * This allocates a buffer for the full blob. Use only if you know that the blob you're
-     * reading is small. If not sure, use [`Self::blobs_size`] and check the size with
-     * before calling [`Self::blobs_read_to_bytes`].
-     */
-    suspend fun `blobsReadToBytes`(`hash`: Hash): kotlin.ByteArray
-
-    /**
-     * Create a ticket for sharing a blob from this node.
-     */
-    suspend fun `blobsShare`(
-        `hash`: Hash,
-        `blobFormat`: BlobFormat,
-        `ticketOptions`: AddrInfoOptions,
-    ): kotlin.String
-
-    /**
-     * Get the size information on a single blob.
-     *
-     * Method only exists in FFI
-     */
-    suspend fun `blobsSize`(`hash`: Hash): kotlin.ULong
-
-    /**
-     * Export the blob contents to a file path
-     * The `path` field is expected to be the absolute path.
-     */
-    suspend fun `blobsWriteToPath`(
-        `hash`: Hash,
-        `path`: kotlin.String,
-    )
-
-    /**
-     * Return connection information on the currently running node.
-     */
-    suspend fun `connectionInfo`(`nodeId`: PublicKey): ConnectionInfo?
-
-    /**
-     * Return `ConnectionInfo`s for each connection we have to another iroh node.
-     */
-    suspend fun `connections`(): List<ConnectionInfo>
-
-    /**
-     * Create a new doc.
-     */
-    suspend fun `docCreate`(): Doc
-
-    /**
-     * Delete a document from the local node.
-     *
-     * This is a destructive operation. Both the document secret key and all entries in the
-     * document will be permanently deleted from the node's storage. Content blobs will be deleted
-     * through garbage collection unless they are referenced from another document or tag.
-     */
-    suspend fun `docDrop`(`docId`: kotlin.String)
-
-    /**
-     * Join and sync with an already existing document.
-     */
-    suspend fun `docJoin`(`ticket`: kotlin.String): Doc
-
-    /**
-     * Join and sync with an already existing document and subscribe to events on that document.
-     */
-    suspend fun `docJoinAndSubscribe`(
-        `ticket`: kotlin.String,
-        `cb`: SubscribeCallback,
-    ): Doc
-
-    /**
-     * List all the docs we have access to on this node.
-     */
-    suspend fun `docList`(): List<NamespaceAndCapability>
-
-    /**
-     * Get a [`Doc`].
-     *
-     * Returns None if the document cannot be found.
-     */
-    suspend fun `docOpen`(`id`: kotlin.String): Doc?
-
-    suspend fun `gossipSubscribe`(
-        `topic`: kotlin.ByteArray,
-        `bootstrap`: List<kotlin.String>,
-        `cb`: GossipMessageCallback,
-    ): Sender
-
-    /**
-     * Get the relay server we are connected to.
-     */
-    suspend fun `homeRelay`(): kotlin.String?
-
-    /**
-     * Returns `Some(addr)` if an RPC endpoint is running, `None` otherwise.
-     */
-    fun `myRpcAddr`(): kotlin.String?
-
-    /**
-     * Return the [`NodeAddr`] for this node.
-     */
-    suspend fun `nodeAddr`(): NodeAddr
-
-    /**
-     * The string representation of the PublicKey of this node.
-     */
-    suspend fun `nodeId`(): kotlin.String
-
-    /**
-     * Shutdown this iroh node.
-     */
-    suspend fun `shutdown`(`force`: kotlin.Boolean)
-
-    /**
-     * Get statistics of the running node.
-     */
-    suspend fun `stats`(): Map<kotlin.String, CounterStats>
-
-    /**
-     * Get status information about a node
-     */
-    suspend fun `status`(): NodeStatus
-
-    /**
-     * Delete a tag
-     */
-    suspend fun `tagsDelete`(`name`: kotlin.ByteArray)
-
-    /**
-     * List all tags
-     *
-     * Note: this allocates for each `ListTagsResponse`, if you have many `Tags`s this may be a prohibitively large list.
-     * Please file an [issue](https://github.com/n0-computer/iroh-ffi/issues/new) if you run into this issue
-     */
-    suspend fun `tagsList`(): List<TagInfo>
-
-    companion object
-}
-
-/**
- * An Iroh node. Allows you to sync, store, and transfer data.
- */
-open class IrohNode :
-    Disposable,
-    AutoCloseable,
-    IrohNodeInterface {
-    constructor(pointer: Pointer) {
-        this.pointer = pointer
-        this.cleanable = UniffiLib.CLEANER.register(this, UniffiCleanAction(pointer))
-    }
-
-    /**
-     * This constructor can be used to instantiate a fake object. Only used for tests. Any
-     * attempt to actually use an object constructed this way will fail as there is no
-     * connected Rust object.
-     */
-    @Suppress("UNUSED_PARAMETER")
-    constructor(noPointer: NoPointer) {
-        this.pointer = null
-        this.cleanable = UniffiLib.CLEANER.register(this, UniffiCleanAction(pointer))
-    }
-
-    protected val pointer: Pointer?
-    protected val cleanable: UniffiCleaner.Cleanable
-
-    private val wasDestroyed = AtomicBoolean(false)
-    private val callCounter = AtomicLong(1)
-
-    override fun destroy() {
-        // Only allow a single call to this method.
-        // TODO: maybe we should log a warning if called more than once?
-        if (this.wasDestroyed.compareAndSet(false, true)) {
-            // This decrement always matches the initial count of 1 given at creation time.
-            if (this.callCounter.decrementAndGet() == 0L) {
-                cleanable.clean()
-            }
-        }
-    }
-
-    @Synchronized
-    override fun close() {
-        this.destroy()
-    }
-
-    internal inline fun <R> callWithPointer(block: (ptr: Pointer) -> R): R {
-        // Check and increment the call counter, to keep the object alive.
-        // This needs a compare-and-set retry loop in case of concurrent updates.
-        do {
-            val c = this.callCounter.get()
-            if (c == 0L) {
-                throw IllegalStateException("${this.javaClass.simpleName} object has already been destroyed")
-            }
-            if (c == Long.MAX_VALUE) {
-                throw IllegalStateException("${this.javaClass.simpleName} call counter would overflow")
-            }
-        } while (!this.callCounter.compareAndSet(c, c + 1L))
-        // Now we can safely do the method call without the pointer being freed concurrently.
-        try {
-            return block(this.uniffiClonePointer())
-        } finally {
-            // This decrement always matches the increment we performed above.
-            if (this.callCounter.decrementAndGet() == 0L) {
-                cleanable.clean()
-            }
-        }
-    }
-
-    // Use a static inner class instead of a closure so as not to accidentally
-    // capture `this` as part of the cleanable's action.
-    private class UniffiCleanAction(
-        private val pointer: Pointer?,
-    ) : Runnable {
-        override fun run() {
-            pointer?.let { ptr ->
-                uniffiRustCall { status ->
-                    UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_free_irohnode(ptr, status)
-                }
-            }
-        }
-    }
-
-    fun uniffiClonePointer(): Pointer =
-        uniffiRustCall { status ->
-            UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_clone_irohnode(pointer!!, status)
-        }
-
-    /**
-     * Add a known node address to the node.
-     */
-    @Throws(IrohException::class)
-    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
-    override suspend fun `addNodeAddr`(`addr`: NodeAddr) =
-        uniffiRustCallAsync(
-            callWithPointer { thisPtr ->
-                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_irohnode_add_node_addr(
-                    thisPtr,
-                    FfiConverterTypeNodeAddr.lower(`addr`),
-                )
-            },
-            { future, callback, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_void(future, callback, continuation) },
-            { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_void(future, continuation) },
-            { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_void(future) },
-            // lift function
-            { Unit },
-            // Error FFI converter
-            IrohException.ErrorHandler,
-        )
-
-    /**
-     * Create a new document author.
-     *
-     * You likely want to save the returned [`AuthorId`] somewhere so that you can use this author
-     * again.
-     *
-     * If you need only a single author, use [`Self::default`].
-     */
-    @Throws(IrohException::class)
-    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
-    override suspend fun `authorCreate`(): AuthorId =
-        uniffiRustCallAsync(
-            callWithPointer { thisPtr ->
-                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_irohnode_author_create(
-                    thisPtr,
-                )
-            },
-            { future, callback, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_pointer(future, callback, continuation) },
-            { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_pointer(future, continuation) },
-            { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_pointer(future) },
-            // lift function
-            { FfiConverterTypeAuthorId.lift(it) },
-            // Error FFI converter
-            IrohException.ErrorHandler,
-        )
-
-    /**
-     * Returns the default document author of this node.
-     *
-     * On persistent nodes, the author is created on first start and its public key is saved
-     * in the data directory.
-     *
-     * The default author can be set with [`Self::set_default`].
-     */
-    @Throws(IrohException::class)
-    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
-    override suspend fun `authorDefault`(): AuthorId =
-        uniffiRustCallAsync(
-            callWithPointer { thisPtr ->
-                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_irohnode_author_default(
-                    thisPtr,
-                )
-            },
-            { future, callback, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_pointer(future, callback, continuation) },
-            { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_pointer(future, continuation) },
-            { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_pointer(future) },
-            // lift function
-            { FfiConverterTypeAuthorId.lift(it) },
-            // Error FFI converter
-            IrohException.ErrorHandler,
-        )
-
-    /**
-     * Deletes the given author by id.
-     *
-     * Warning: This permanently removes this author.
-     */
-    @Throws(IrohException::class)
-    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
-    override suspend fun `authorDelete`(`author`: AuthorId) =
-        uniffiRustCallAsync(
-            callWithPointer { thisPtr ->
-                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_irohnode_author_delete(
-                    thisPtr,
-                    FfiConverterTypeAuthorId.lower(`author`),
-                )
-            },
-            { future, callback, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_void(future, callback, continuation) },
-            { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_void(future, continuation) },
-            { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_void(future) },
-            // lift function
-            { Unit },
-            // Error FFI converter
-            IrohException.ErrorHandler,
-        )
-
-    /**
-     * Export the given author.
-     *
-     * Warning: This contains sensitive data.
-     */
-    @Throws(IrohException::class)
-    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
-    override suspend fun `authorExport`(`author`: AuthorId): Author =
-        uniffiRustCallAsync(
-            callWithPointer { thisPtr ->
-                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_irohnode_author_export(
-                    thisPtr,
-                    FfiConverterTypeAuthorId.lower(`author`),
-                )
-            },
-            { future, callback, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_pointer(future, callback, continuation) },
-            { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_pointer(future, continuation) },
-            { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_pointer(future) },
-            // lift function
-            { FfiConverterTypeAuthor.lift(it) },
-            // Error FFI converter
-            IrohException.ErrorHandler,
-        )
-
-    /**
-     * Import the given author.
-     *
-     * Warning: This contains sensitive data.
-     */
-    @Throws(IrohException::class)
-    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
-    override suspend fun `authorImport`(`author`: Author): AuthorId =
-        uniffiRustCallAsync(
-            callWithPointer { thisPtr ->
-                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_irohnode_author_import(
-                    thisPtr,
-                    FfiConverterTypeAuthor.lower(`author`),
-                )
-            },
-            { future, callback, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_pointer(future, callback, continuation) },
-            { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_pointer(future, continuation) },
-            { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_pointer(future) },
-            // lift function
-            { FfiConverterTypeAuthorId.lift(it) },
-            // Error FFI converter
-            IrohException.ErrorHandler,
-        )
-
-    /**
-     * List all the AuthorIds that exist on this node.
-     */
-    @Throws(IrohException::class)
-    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
-    override suspend fun `authorList`(): List<AuthorId> =
-        uniffiRustCallAsync(
-            callWithPointer { thisPtr ->
-                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_irohnode_author_list(
-                    thisPtr,
-                )
-            },
-            {
-                    future,
-                    callback,
-                    continuation,
-                ->
-                UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_rust_buffer(future, callback, continuation)
-            },
-            { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_rust_buffer(future, continuation) },
-            { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_rust_buffer(future) },
-            // lift function
-            { FfiConverterSequenceTypeAuthorId.lift(it) },
-            // Error FFI converter
-            IrohException.ErrorHandler,
-        )
-
-    /**
-     * Write a blob by passing bytes.
-     */
-    @Throws(IrohException::class)
-    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
-    override suspend fun `blobsAddBytes`(`bytes`: kotlin.ByteArray): BlobAddOutcome =
-        uniffiRustCallAsync(
-            callWithPointer { thisPtr ->
-                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_irohnode_blobs_add_bytes(
-                    thisPtr,
-                    FfiConverterByteArray.lower(`bytes`),
-                )
-            },
-            {
-                    future,
-                    callback,
-                    continuation,
-                ->
-                UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_rust_buffer(future, callback, continuation)
-            },
-            { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_rust_buffer(future, continuation) },
-            { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_rust_buffer(future) },
-            // lift function
-            { FfiConverterTypeBlobAddOutcome.lift(it) },
-            // Error FFI converter
-            IrohException.ErrorHandler,
-        )
-
-    /**
-     * Write a blob by passing bytes, setting an explicit tag name.
-     */
-    @Throws(IrohException::class)
-    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
-    override suspend fun `blobsAddBytesNamed`(
-        `bytes`: kotlin.ByteArray,
-        `name`: kotlin.String,
-    ): BlobAddOutcome =
-        uniffiRustCallAsync(
-            callWithPointer { thisPtr ->
-                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_irohnode_blobs_add_bytes_named(
-                    thisPtr,
-                    FfiConverterByteArray.lower(`bytes`),
-                    FfiConverterString.lower(`name`),
-                )
-            },
-            {
-                    future,
-                    callback,
-                    continuation,
-                ->
-                UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_rust_buffer(future, callback, continuation)
-            },
-            { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_rust_buffer(future, continuation) },
-            { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_rust_buffer(future) },
-            // lift function
-            { FfiConverterTypeBlobAddOutcome.lift(it) },
-            // Error FFI converter
-            IrohException.ErrorHandler,
-        )
-
-    /**
-     * Import a blob from a filesystem path.
-     *
-     * `path` should be an absolute path valid for the file system on which
-     * the node runs.
-     * If `in_place` is true, Iroh will assume that the data will not change and will share it in
-     * place without copying to the Iroh data directory.
-     */
-    @Throws(IrohException::class)
-    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
-    override suspend fun `blobsAddFromPath`(
-        `path`: kotlin.String,
-        `inPlace`: kotlin.Boolean,
-        `tag`: SetTagOption,
-        `wrap`: WrapOption,
-        `cb`: AddCallback,
-    ) = uniffiRustCallAsync(
-        callWithPointer { thisPtr ->
-            UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_irohnode_blobs_add_from_path(
-                thisPtr,
-                FfiConverterString.lower(`path`),
-                FfiConverterBoolean.lower(`inPlace`),
-                FfiConverterTypeSetTagOption.lower(`tag`),
-                FfiConverterTypeWrapOption.lower(`wrap`),
-                FfiConverterTypeAddCallback.lower(`cb`),
-            )
-        },
-        { future, callback, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_void(future, callback, continuation) },
-        { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_void(future, continuation) },
-        { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_void(future) },
-        // lift function
-        { Unit },
-        // Error FFI converter
-        IrohException.ErrorHandler,
-    )
-
-    /**
-     * Create a collection from already existing blobs.
-     *
-     * To automatically clear the tags for the passed in blobs you can set
-     * `tags_to_delete` on those tags, and they will be deleted once the collection is created.
-     */
-    @Throws(IrohException::class)
-    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
-    override suspend fun `blobsCreateCollection`(
-        `collection`: Collection,
-        `tag`: SetTagOption,
-        `tagsToDelete`: List<kotlin.String>,
-    ): HashAndTag =
-        uniffiRustCallAsync(
-            callWithPointer { thisPtr ->
-                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_irohnode_blobs_create_collection(
-                    thisPtr,
-                    FfiConverterTypeCollection.lower(`collection`),
-                    FfiConverterTypeSetTagOption.lower(`tag`),
-                    FfiConverterSequenceString.lower(`tagsToDelete`),
-                )
-            },
-            {
-                    future,
-                    callback,
-                    continuation,
-                ->
-                UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_rust_buffer(future, callback, continuation)
-            },
-            { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_rust_buffer(future, continuation) },
-            { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_rust_buffer(future) },
-            // lift function
-            { FfiConverterTypeHashAndTag.lift(it) },
-            // Error FFI converter
-            IrohException.ErrorHandler,
-        )
-
-    /**
-     * Delete a blob.
-     */
-    @Throws(IrohException::class)
-    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
-    override suspend fun `blobsDeleteBlob`(`hash`: Hash) =
-        uniffiRustCallAsync(
-            callWithPointer { thisPtr ->
-                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_irohnode_blobs_delete_blob(
-                    thisPtr,
-                    FfiConverterTypeHash.lower(`hash`),
-                )
-            },
-            { future, callback, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_void(future, callback, continuation) },
-            { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_void(future, continuation) },
-            { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_void(future) },
-            // lift function
-            { Unit },
-            // Error FFI converter
-            IrohException.ErrorHandler,
-        )
-
-    /**
-     * Download a blob from another node and add it to the local database.
-     */
-    @Throws(IrohException::class)
-    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
-    override suspend fun `blobsDownload`(
-        `hash`: Hash,
-        `opts`: BlobDownloadOptions,
-        `cb`: DownloadCallback,
-    ) = uniffiRustCallAsync(
-        callWithPointer { thisPtr ->
-            UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_irohnode_blobs_download(
-                thisPtr,
-                FfiConverterTypeHash.lower(`hash`),
-                FfiConverterTypeBlobDownloadOptions.lower(`opts`),
-                FfiConverterTypeDownloadCallback.lower(`cb`),
-            )
-        },
-        { future, callback, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_void(future, callback, continuation) },
-        { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_void(future, continuation) },
-        { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_void(future) },
-        // lift function
-        { Unit },
-        // Error FFI converter
-        IrohException.ErrorHandler,
-    )
-
-    /**
-     * Export a blob from the internal blob store to a path on the node's filesystem.
-     *
-     * `destination` should be a writeable, absolute path on the local node's filesystem.
-     *
-     * If `format` is set to [`ExportFormat::Collection`], and the `hash` refers to a collection,
-     * all children of the collection will be exported. See [`ExportFormat`] for details.
-     *
-     * The `mode` argument defines if the blob should be copied to the target location or moved out of
-     * the internal store into the target location. See [`ExportMode`] for details.
-     */
-    @Throws(IrohException::class)
-    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
-    override suspend fun `blobsExport`(
-        `hash`: Hash,
-        `destination`: kotlin.String,
-        `format`: BlobExportFormat,
-        `mode`: BlobExportMode,
-    ) = uniffiRustCallAsync(
-        callWithPointer { thisPtr ->
-            UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_irohnode_blobs_export(
-                thisPtr,
-                FfiConverterTypeHash.lower(`hash`),
-                FfiConverterString.lower(`destination`),
-                FfiConverterTypeBlobExportFormat.lower(`format`),
-                FfiConverterTypeBlobExportMode.lower(`mode`),
-            )
-        },
-        { future, callback, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_void(future, callback, continuation) },
-        { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_void(future, continuation) },
-        { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_void(future) },
-        // lift function
-        { Unit },
-        // Error FFI converter
-        IrohException.ErrorHandler,
-    )
-
-    /**
-     * Read the content of a collection
-     */
-    @Throws(IrohException::class)
-    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
-    override suspend fun `blobsGetCollection`(`hash`: Hash): Collection =
-        uniffiRustCallAsync(
-            callWithPointer { thisPtr ->
-                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_irohnode_blobs_get_collection(
-                    thisPtr,
-                    FfiConverterTypeHash.lower(`hash`),
-                )
-            },
-            { future, callback, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_pointer(future, callback, continuation) },
-            { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_pointer(future, continuation) },
-            { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_pointer(future) },
-            // lift function
-            { FfiConverterTypeCollection.lift(it) },
-            // Error FFI converter
-            IrohException.ErrorHandler,
-        )
-
-    /**
-     * List all complete blobs.
-     *
-     * Note: this allocates for each `BlobListResponse`, if you have many `BlobListReponse`s this may be a prohibitively large list.
-     * Please file an [issue](https://github.com/n0-computer/iroh-ffi/issues/new) if you run into this issue
-     */
-    @Throws(IrohException::class)
-    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
-    override suspend fun `blobsList`(): List<Hash> =
-        uniffiRustCallAsync(
-            callWithPointer { thisPtr ->
-                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_irohnode_blobs_list(
-                    thisPtr,
-                )
-            },
-            {
-                    future,
-                    callback,
-                    continuation,
-                ->
-                UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_rust_buffer(future, callback, continuation)
-            },
-            { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_rust_buffer(future, continuation) },
-            { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_rust_buffer(future) },
-            // lift function
-            { FfiConverterSequenceTypeHash.lift(it) },
-            // Error FFI converter
-            IrohException.ErrorHandler,
-        )
-
-    /**
-     * List all collections.
-     *
-     * Note: this allocates for each `BlobListCollectionsResponse`, if you have many `BlobListCollectionsResponse`s this may be a prohibitively large list.
-     * Please file an [issue](https://github.com/n0-computer/iroh-ffi/issues/new) if you run into this issue
-     */
-    @Throws(IrohException::class)
-    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
-    override suspend fun `blobsListCollections`(): List<CollectionInfo> =
-        uniffiRustCallAsync(
-            callWithPointer { thisPtr ->
-                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_irohnode_blobs_list_collections(
-                    thisPtr,
-                )
-            },
-            {
-                    future,
-                    callback,
-                    continuation,
-                ->
-                UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_rust_buffer(future, callback, continuation)
-            },
-            { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_rust_buffer(future, continuation) },
-            { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_rust_buffer(future) },
-            // lift function
-            { FfiConverterSequenceTypeCollectionInfo.lift(it) },
-            // Error FFI converter
-            IrohException.ErrorHandler,
-        )
-
-    /**
-     * List all incomplete (partial) blobs.
-     *
-     * Note: this allocates for each `BlobListIncompleteResponse`, if you have many `BlobListIncompleteResponse`s this may be a prohibitively large list.
-     * Please file an [issue](https://github.com/n0-computer/iroh-ffi/issues/new) if you run into this issue
-     */
-    @Throws(IrohException::class)
-    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
-    override suspend fun `blobsListIncomplete`(): List<IncompleteBlobInfo> =
-        uniffiRustCallAsync(
-            callWithPointer { thisPtr ->
-                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_irohnode_blobs_list_incomplete(
-                    thisPtr,
-                )
-            },
-            {
-                    future,
-                    callback,
-                    continuation,
-                ->
-                UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_rust_buffer(future, callback, continuation)
-            },
-            { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_rust_buffer(future, continuation) },
-            { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_rust_buffer(future) },
-            // lift function
-            { FfiConverterSequenceTypeIncompleteBlobInfo.lift(it) },
-            // Error FFI converter
-            IrohException.ErrorHandler,
-        )
-
-    /**
-     * Read all bytes of single blob at `offset` for length `len`.
-     *
-     * This allocates a buffer for the full length `len`. Use only if you know that the blob you're
-     * reading is small. If not sure, use [`Self::blobs_size`] and check the size with
-     * before calling [`Self::blobs_read_at_to_bytes`].
-     */
-    @Throws(IrohException::class)
-    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
-    override suspend fun `blobsReadAtToBytes`(
-        `hash`: Hash,
-        `offset`: kotlin.ULong,
-        `len`: kotlin.ULong?,
-    ): kotlin.ByteArray =
-        uniffiRustCallAsync(
-            callWithPointer { thisPtr ->
-                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_irohnode_blobs_read_at_to_bytes(
-                    thisPtr,
-                    FfiConverterTypeHash.lower(`hash`),
-                    FfiConverterULong.lower(`offset`),
-                    FfiConverterOptionalULong.lower(`len`),
-                )
-            },
-            {
-                    future,
-                    callback,
-                    continuation,
-                ->
-                UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_rust_buffer(future, callback, continuation)
-            },
-            { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_rust_buffer(future, continuation) },
-            { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_rust_buffer(future) },
-            // lift function
-            { FfiConverterByteArray.lift(it) },
-            // Error FFI converter
-            IrohException.ErrorHandler,
-        )
-
-    /**
-     * Read all bytes of single blob.
-     *
-     * This allocates a buffer for the full blob. Use only if you know that the blob you're
-     * reading is small. If not sure, use [`Self::blobs_size`] and check the size with
-     * before calling [`Self::blobs_read_to_bytes`].
-     */
-    @Throws(IrohException::class)
-    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
-    override suspend fun `blobsReadToBytes`(`hash`: Hash): kotlin.ByteArray =
-        uniffiRustCallAsync(
-            callWithPointer { thisPtr ->
-                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_irohnode_blobs_read_to_bytes(
-                    thisPtr,
-                    FfiConverterTypeHash.lower(`hash`),
-                )
-            },
-            {
-                    future,
-                    callback,
-                    continuation,
-                ->
-                UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_rust_buffer(future, callback, continuation)
-            },
-            { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_rust_buffer(future, continuation) },
-            { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_rust_buffer(future) },
-            // lift function
-            { FfiConverterByteArray.lift(it) },
-            // Error FFI converter
-            IrohException.ErrorHandler,
-        )
-
-    /**
-     * Create a ticket for sharing a blob from this node.
-     */
-    @Throws(IrohException::class)
-    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
-    override suspend fun `blobsShare`(
-        `hash`: Hash,
-        `blobFormat`: BlobFormat,
-        `ticketOptions`: AddrInfoOptions,
-    ): kotlin.String =
-        uniffiRustCallAsync(
-            callWithPointer { thisPtr ->
-                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_irohnode_blobs_share(
-                    thisPtr,
-                    FfiConverterTypeHash.lower(`hash`),
-                    FfiConverterTypeBlobFormat.lower(`blobFormat`),
-                    FfiConverterTypeAddrInfoOptions.lower(`ticketOptions`),
-                )
-            },
-            {
-                    future,
-                    callback,
-                    continuation,
-                ->
-                UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_rust_buffer(future, callback, continuation)
-            },
-            { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_rust_buffer(future, continuation) },
-            { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_rust_buffer(future) },
-            // lift function
-            { FfiConverterString.lift(it) },
-            // Error FFI converter
-            IrohException.ErrorHandler,
-        )
-
-    /**
-     * Get the size information on a single blob.
-     *
-     * Method only exists in FFI
-     */
-    @Throws(IrohException::class)
-    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
-    override suspend fun `blobsSize`(`hash`: Hash): kotlin.ULong =
-        uniffiRustCallAsync(
-            callWithPointer { thisPtr ->
-                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_irohnode_blobs_size(
-                    thisPtr,
-                    FfiConverterTypeHash.lower(`hash`),
-                )
-            },
-            { future, callback, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_u64(future, callback, continuation) },
-            { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_u64(future, continuation) },
-            { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_u64(future) },
-            // lift function
-            { FfiConverterULong.lift(it) },
-            // Error FFI converter
-            IrohException.ErrorHandler,
-        )
-
-    /**
-     * Export the blob contents to a file path
-     * The `path` field is expected to be the absolute path.
-     */
-    @Throws(IrohException::class)
-    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
-    override suspend fun `blobsWriteToPath`(
-        `hash`: Hash,
-        `path`: kotlin.String,
-    ) = uniffiRustCallAsync(
-        callWithPointer { thisPtr ->
-            UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_irohnode_blobs_write_to_path(
-                thisPtr,
-                FfiConverterTypeHash.lower(`hash`),
-                FfiConverterString.lower(`path`),
-            )
-        },
-        { future, callback, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_void(future, callback, continuation) },
-        { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_void(future, continuation) },
-        { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_void(future) },
-        // lift function
-        { Unit },
-        // Error FFI converter
-        IrohException.ErrorHandler,
-    )
-
-    /**
-     * Return connection information on the currently running node.
-     */
-    @Throws(IrohException::class)
-    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
-    override suspend fun `connectionInfo`(`nodeId`: PublicKey): ConnectionInfo? =
-        uniffiRustCallAsync(
-            callWithPointer { thisPtr ->
-                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_irohnode_connection_info(
-                    thisPtr,
-                    FfiConverterTypePublicKey.lower(`nodeId`),
-                )
-            },
-            {
-                    future,
-                    callback,
-                    continuation,
-                ->
-                UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_rust_buffer(future, callback, continuation)
-            },
-            { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_rust_buffer(future, continuation) },
-            { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_rust_buffer(future) },
-            // lift function
-            { FfiConverterOptionalTypeConnectionInfo.lift(it) },
-            // Error FFI converter
-            IrohException.ErrorHandler,
-        )
-
-    /**
-     * Return `ConnectionInfo`s for each connection we have to another iroh node.
-     */
-    @Throws(IrohException::class)
-    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
-    override suspend fun `connections`(): List<ConnectionInfo> =
-        uniffiRustCallAsync(
-            callWithPointer { thisPtr ->
-                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_irohnode_connections(
-                    thisPtr,
-                )
-            },
-            {
-                    future,
-                    callback,
-                    continuation,
-                ->
-                UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_rust_buffer(future, callback, continuation)
-            },
-            { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_rust_buffer(future, continuation) },
-            { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_rust_buffer(future) },
-            // lift function
-            { FfiConverterSequenceTypeConnectionInfo.lift(it) },
-            // Error FFI converter
-            IrohException.ErrorHandler,
-        )
-
-    /**
-     * Create a new doc.
-     */
-    @Throws(IrohException::class)
-    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
-    override suspend fun `docCreate`(): Doc =
-        uniffiRustCallAsync(
-            callWithPointer { thisPtr ->
-                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_irohnode_doc_create(
-                    thisPtr,
-                )
-            },
-            { future, callback, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_pointer(future, callback, continuation) },
-            { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_pointer(future, continuation) },
-            { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_pointer(future) },
-            // lift function
-            { FfiConverterTypeDoc.lift(it) },
-            // Error FFI converter
-            IrohException.ErrorHandler,
-        )
-
-    /**
-     * Delete a document from the local node.
-     *
-     * This is a destructive operation. Both the document secret key and all entries in the
-     * document will be permanently deleted from the node's storage. Content blobs will be deleted
-     * through garbage collection unless they are referenced from another document or tag.
-     */
-    @Throws(IrohException::class)
-    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
-    override suspend fun `docDrop`(`docId`: kotlin.String) =
-        uniffiRustCallAsync(
-            callWithPointer { thisPtr ->
-                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_irohnode_doc_drop(
-                    thisPtr,
-                    FfiConverterString.lower(`docId`),
-                )
-            },
-            { future, callback, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_void(future, callback, continuation) },
-            { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_void(future, continuation) },
-            { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_void(future) },
-            // lift function
-            { Unit },
-            // Error FFI converter
-            IrohException.ErrorHandler,
-        )
-
-    /**
-     * Join and sync with an already existing document.
-     */
-    @Throws(IrohException::class)
-    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
-    override suspend fun `docJoin`(`ticket`: kotlin.String): Doc =
-        uniffiRustCallAsync(
-            callWithPointer { thisPtr ->
-                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_irohnode_doc_join(
-                    thisPtr,
-                    FfiConverterString.lower(`ticket`),
-                )
-            },
-            { future, callback, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_pointer(future, callback, continuation) },
-            { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_pointer(future, continuation) },
-            { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_pointer(future) },
-            // lift function
-            { FfiConverterTypeDoc.lift(it) },
-            // Error FFI converter
-            IrohException.ErrorHandler,
-        )
-
-    /**
-     * Join and sync with an already existing document and subscribe to events on that document.
-     */
-    @Throws(IrohException::class)
-    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
-    override suspend fun `docJoinAndSubscribe`(
-        `ticket`: kotlin.String,
-        `cb`: SubscribeCallback,
-    ): Doc =
-        uniffiRustCallAsync(
-            callWithPointer { thisPtr ->
-                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_irohnode_doc_join_and_subscribe(
-                    thisPtr,
-                    FfiConverterString.lower(`ticket`),
-                    FfiConverterTypeSubscribeCallback.lower(`cb`),
-                )
-            },
-            { future, callback, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_pointer(future, callback, continuation) },
-            { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_pointer(future, continuation) },
-            { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_pointer(future) },
-            // lift function
-            { FfiConverterTypeDoc.lift(it) },
-            // Error FFI converter
-            IrohException.ErrorHandler,
-        )
-
-    /**
-     * List all the docs we have access to on this node.
-     */
-    @Throws(IrohException::class)
-    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
-    override suspend fun `docList`(): List<NamespaceAndCapability> =
-        uniffiRustCallAsync(
-            callWithPointer { thisPtr ->
-                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_irohnode_doc_list(
-                    thisPtr,
-                )
-            },
-            {
-                    future,
-                    callback,
-                    continuation,
-                ->
-                UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_rust_buffer(future, callback, continuation)
-            },
-            { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_rust_buffer(future, continuation) },
-            { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_rust_buffer(future) },
-            // lift function
-            { FfiConverterSequenceTypeNamespaceAndCapability.lift(it) },
-            // Error FFI converter
-            IrohException.ErrorHandler,
-        )
-
-    /**
-     * Get a [`Doc`].
-     *
-     * Returns None if the document cannot be found.
-     */
-    @Throws(IrohException::class)
-    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
-    override suspend fun `docOpen`(`id`: kotlin.String): Doc? =
-        uniffiRustCallAsync(
-            callWithPointer { thisPtr ->
-                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_irohnode_doc_open(
-                    thisPtr,
-                    FfiConverterString.lower(`id`),
-                )
-            },
-            {
-                    future,
-                    callback,
-                    continuation,
-                ->
-                UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_rust_buffer(future, callback, continuation)
-            },
-            { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_rust_buffer(future, continuation) },
-            { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_rust_buffer(future) },
-            // lift function
-            { FfiConverterOptionalTypeDoc.lift(it) },
-            // Error FFI converter
-            IrohException.ErrorHandler,
-        )
-
-    @Throws(IrohException::class)
-    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
-    override suspend fun `gossipSubscribe`(
-        `topic`: kotlin.ByteArray,
-        `bootstrap`: List<kotlin.String>,
-        `cb`: GossipMessageCallback,
-    ): Sender =
-        uniffiRustCallAsync(
-            callWithPointer { thisPtr ->
-                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_irohnode_gossip_subscribe(
-                    thisPtr,
-                    FfiConverterByteArray.lower(`topic`),
-                    FfiConverterSequenceString.lower(`bootstrap`),
-                    FfiConverterTypeGossipMessageCallback.lower(`cb`),
-                )
-            },
-            { future, callback, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_pointer(future, callback, continuation) },
-            { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_pointer(future, continuation) },
-            { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_pointer(future) },
-            // lift function
-            { FfiConverterTypeSender.lift(it) },
-            // Error FFI converter
-            IrohException.ErrorHandler,
-        )
-
-    /**
-     * Get the relay server we are connected to.
-     */
-    @Throws(IrohException::class)
-    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
-    override suspend fun `homeRelay`(): kotlin.String? =
-        uniffiRustCallAsync(
-            callWithPointer { thisPtr ->
-                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_irohnode_home_relay(
-                    thisPtr,
-                )
-            },
-            {
-                    future,
-                    callback,
-                    continuation,
-                ->
-                UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_rust_buffer(future, callback, continuation)
-            },
-            { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_rust_buffer(future, continuation) },
-            { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_rust_buffer(future) },
-            // lift function
-            { FfiConverterOptionalString.lift(it) },
-            // Error FFI converter
-            IrohException.ErrorHandler,
-        )
-
-    /**
-     * Returns `Some(addr)` if an RPC endpoint is running, `None` otherwise.
-     */
-    override fun `myRpcAddr`(): kotlin.String? =
-        FfiConverterOptionalString.lift(
-            callWithPointer {
-                uniffiRustCall { _status ->
-                    UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_irohnode_my_rpc_addr(
-                        it,
-                        _status,
-                    )
-                }
-            },
-        )
-
-    /**
-     * Return the [`NodeAddr`] for this node.
-     */
-    @Throws(IrohException::class)
-    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
-    override suspend fun `nodeAddr`(): NodeAddr =
-        uniffiRustCallAsync(
-            callWithPointer { thisPtr ->
-                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_irohnode_node_addr(
-                    thisPtr,
-                )
-            },
-            { future, callback, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_pointer(future, callback, continuation) },
-            { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_pointer(future, continuation) },
-            { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_pointer(future) },
-            // lift function
-            { FfiConverterTypeNodeAddr.lift(it) },
-            // Error FFI converter
-            IrohException.ErrorHandler,
-        )
-
-    /**
-     * The string representation of the PublicKey of this node.
-     */
-    @Throws(IrohException::class)
-    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
-    override suspend fun `nodeId`(): kotlin.String =
-        uniffiRustCallAsync(
-            callWithPointer { thisPtr ->
-                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_irohnode_node_id(
-                    thisPtr,
-                )
-            },
-            {
-                    future,
-                    callback,
-                    continuation,
-                ->
-                UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_rust_buffer(future, callback, continuation)
-            },
-            { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_rust_buffer(future, continuation) },
-            { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_rust_buffer(future) },
-            // lift function
-            { FfiConverterString.lift(it) },
-            // Error FFI converter
-            IrohException.ErrorHandler,
-        )
-
-    /**
-     * Shutdown this iroh node.
-     */
-    @Throws(IrohException::class)
-    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
-    override suspend fun `shutdown`(`force`: kotlin.Boolean) =
-        uniffiRustCallAsync(
-            callWithPointer { thisPtr ->
-                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_irohnode_shutdown(
-                    thisPtr,
-                    FfiConverterBoolean.lower(`force`),
-                )
-            },
-            { future, callback, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_void(future, callback, continuation) },
-            { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_void(future, continuation) },
-            { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_void(future) },
-            // lift function
-            { Unit },
-            // Error FFI converter
-            IrohException.ErrorHandler,
-        )
-
-    /**
-     * Get statistics of the running node.
-     */
-    @Throws(IrohException::class)
-    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
-    override suspend fun `stats`(): Map<kotlin.String, CounterStats> =
-        uniffiRustCallAsync(
-            callWithPointer { thisPtr ->
-                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_irohnode_stats(
-                    thisPtr,
-                )
-            },
-            {
-                    future,
-                    callback,
-                    continuation,
-                ->
-                UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_rust_buffer(future, callback, continuation)
-            },
-            { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_rust_buffer(future, continuation) },
-            { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_rust_buffer(future) },
-            // lift function
-            { FfiConverterMapStringTypeCounterStats.lift(it) },
-            // Error FFI converter
-            IrohException.ErrorHandler,
-        )
-
-    /**
-     * Get status information about a node
-     */
-    @Throws(IrohException::class)
-    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
-    override suspend fun `status`(): NodeStatus =
-        uniffiRustCallAsync(
-            callWithPointer { thisPtr ->
-                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_irohnode_status(
-                    thisPtr,
-                )
-            },
-            { future, callback, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_pointer(future, callback, continuation) },
-            { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_pointer(future, continuation) },
-            { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_pointer(future) },
-            // lift function
-            { FfiConverterTypeNodeStatus.lift(it) },
-            // Error FFI converter
-            IrohException.ErrorHandler,
-        )
-
-    /**
-     * Delete a tag
-     */
-    @Throws(IrohException::class)
-    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
-    override suspend fun `tagsDelete`(`name`: kotlin.ByteArray) =
-        uniffiRustCallAsync(
-            callWithPointer { thisPtr ->
-                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_irohnode_tags_delete(
-                    thisPtr,
-                    FfiConverterByteArray.lower(`name`),
-                )
-            },
-            { future, callback, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_void(future, callback, continuation) },
-            { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_void(future, continuation) },
-            { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_void(future) },
-            // lift function
-            { Unit },
-            // Error FFI converter
-            IrohException.ErrorHandler,
-        )
-
-    /**
-     * List all tags
-     *
-     * Note: this allocates for each `ListTagsResponse`, if you have many `Tags`s this may be a prohibitively large list.
-     * Please file an [issue](https://github.com/n0-computer/iroh-ffi/issues/new) if you run into this issue
-     */
-    @Throws(IrohException::class)
-    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
-    override suspend fun `tagsList`(): List<TagInfo> =
-        uniffiRustCallAsync(
-            callWithPointer { thisPtr ->
-                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_irohnode_tags_list(
-                    thisPtr,
-                )
-            },
-            {
-                    future,
-                    callback,
-                    continuation,
-                ->
-                UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_rust_buffer(future, callback, continuation)
-            },
-            { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_rust_buffer(future, continuation) },
-            { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_rust_buffer(future) },
-            // lift function
-            { FfiConverterSequenceTypeTagInfo.lift(it) },
-            // Error FFI converter
-            IrohException.ErrorHandler,
-        )
-
-    companion object {
-        /**
-         * Create a new iroh node.
-         *
-         * All data will be only persistet in memory.
-         */
-        @Throws(IrohException::class)
-        @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
-        suspend fun `memory`(): IrohNode =
-            uniffiRustCallAsync(
-                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_constructor_irohnode_memory(),
-                {
-                        future,
-                        callback,
-                        continuation,
-                    ->
-                    UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_pointer(future, callback, continuation)
-                },
-                { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_pointer(future, continuation) },
-                { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_pointer(future) },
-                // lift function
-                { FfiConverterTypeIrohNode.lift(it) },
-                // Error FFI converter
-                IrohException.ErrorHandler,
-            )
-
-        /**
-         * Create a new in memory iroh node with options.
-         */
-        @Throws(IrohException::class)
-        @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
-        suspend fun `memoryWithOptions`(`options`: NodeOptions): IrohNode =
-            uniffiRustCallAsync(
-                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_constructor_irohnode_memory_with_options(
-                    FfiConverterTypeNodeOptions.lower(`options`),
-                ),
-                {
-                        future,
-                        callback,
-                        continuation,
-                    ->
-                    UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_pointer(future, callback, continuation)
-                },
-                { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_pointer(future, continuation) },
-                { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_pointer(future) },
-                // lift function
-                { FfiConverterTypeIrohNode.lift(it) },
-                // Error FFI converter
-                IrohException.ErrorHandler,
-            )
-
-        /**
-         * Create a new iroh node.
-         *
-         * The `path` param should be a directory where we can store or load
-         * iroh data from a previous session.
-         */
-        @Throws(IrohException::class)
-        @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
-        suspend fun `persistent`(`path`: kotlin.String): IrohNode =
-            uniffiRustCallAsync(
-                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_constructor_irohnode_persistent(FfiConverterString.lower(`path`)),
-                {
-                        future,
-                        callback,
-                        continuation,
-                    ->
-                    UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_pointer(future, callback, continuation)
-                },
-                { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_pointer(future, continuation) },
-                { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_pointer(future) },
-                // lift function
-                { FfiConverterTypeIrohNode.lift(it) },
-                // Error FFI converter
-                IrohException.ErrorHandler,
-            )
-
-        /**
-         * Create a new iroh node with options.
-         */
-        @Throws(IrohException::class)
-        @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
-        suspend fun `persistentWithOptions`(
-            `path`: kotlin.String,
-            `options`: NodeOptions,
-        ): IrohNode =
-            uniffiRustCallAsync(
-                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_constructor_irohnode_persistent_with_options(
-                    FfiConverterString.lower(`path`),
-                    FfiConverterTypeNodeOptions.lower(`options`),
-                ),
-                {
-                        future,
-                        callback,
-                        continuation,
-                    ->
-                    UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_pointer(future, callback, continuation)
-                },
-                { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_pointer(future, continuation) },
-                { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_pointer(future) },
-                // lift function
-                { FfiConverterTypeIrohNode.lift(it) },
-                // Error FFI converter
-                IrohException.ErrorHandler,
-            )
-    }
-}
-
-public object FfiConverterTypeIrohNode : FfiConverter<IrohNode, Pointer> {
-    override fun lower(value: IrohNode): Pointer = value.uniffiClonePointer()
-
-    override fun lift(value: Pointer): IrohNode = IrohNode(value)
-
-    override fun read(buf: ByteBuffer): IrohNode {
-        // The Rust code always writes pointers as 8 bytes, and will
-        // fail to compile if they don't fit.
-        return lift(Pointer(buf.getLong()))
-    }
-
-    override fun allocationSize(value: IrohNode) = 8UL
-
-    override fun write(
-        value: IrohNode,
         buf: ByteBuffer,
     ) {
         // The Rust code always expects pointers written as 8 bytes,
@@ -13454,6 +14251,510 @@ public object FfiConverterTypeMessage : FfiConverter<Message, Pointer> {
 
     override fun write(
         value: Message,
+        buf: ByteBuffer,
+    ) {
+        // The Rust code always expects pointers written as 8 bytes,
+        // and will fail to compile if they don't fit.
+        buf.putLong(Pointer.nativeValue(lower(value)))
+    }
+}
+
+// This template implements a class for working with a Rust struct via a Pointer/Arc<T>
+// to the live Rust struct on the other side of the FFI.
+//
+// Each instance implements core operations for working with the Rust `Arc<T>` and the
+// Kotlin Pointer to work with the live Rust struct on the other side of the FFI.
+//
+// There's some subtlety here, because we have to be careful not to operate on a Rust
+// struct after it has been dropped, and because we must expose a public API for freeing
+// theq Kotlin wrapper object in lieu of reliable finalizers. The core requirements are:
+//
+//   * Each instance holds an opaque pointer to the underlying Rust struct.
+//     Method calls need to read this pointer from the object's state and pass it in to
+//     the Rust FFI.
+//
+//   * When an instance is no longer needed, its pointer should be passed to a
+//     special destructor function provided by the Rust FFI, which will drop the
+//     underlying Rust struct.
+//
+//   * Given an instance, calling code is expected to call the special
+//     `destroy` method in order to free it after use, either by calling it explicitly
+//     or by using a higher-level helper like the `use` method. Failing to do so risks
+//     leaking the underlying Rust struct.
+//
+//   * We can't assume that calling code will do the right thing, and must be prepared
+//     to handle Kotlin method calls executing concurrently with or even after a call to
+//     `destroy`, and to handle multiple (possibly concurrent!) calls to `destroy`.
+//
+//   * We must never allow Rust code to operate on the underlying Rust struct after
+//     the destructor has been called, and must never call the destructor more than once.
+//     Doing so may trigger memory unsafety.
+//
+//   * To mitigate many of the risks of leaking memory and use-after-free unsafety, a `Cleaner`
+//     is implemented to call the destructor when the Kotlin object becomes unreachable.
+//     This is done in a background thread. This is not a panacea, and client code should be aware that
+//      1. the thread may starve if some there are objects that have poorly performing
+//     `drop` methods or do significant work in their `drop` methods.
+//      2. the thread is shared across the whole library. This can be tuned by using `android_cleaner = true`,
+//         or `android = true` in the [`kotlin` section of the `uniffi.toml` file](https://mozilla.github.io/uniffi-rs/kotlin/configuration.html).
+//
+// If we try to implement this with mutual exclusion on access to the pointer, there is the
+// possibility of a race between a method call and a concurrent call to `destroy`:
+//
+//    * Thread A starts a method call, reads the value of the pointer, but is interrupted
+//      before it can pass the pointer over the FFI to Rust.
+//    * Thread B calls `destroy` and frees the underlying Rust struct.
+//    * Thread A resumes, passing the already-read pointer value to Rust and triggering
+//      a use-after-free.
+//
+// One possible solution would be to use a `ReadWriteLock`, with each method call taking
+// a read lock (and thus allowed to run concurrently) and the special `destroy` method
+// taking a write lock (and thus blocking on live method calls). However, we aim not to
+// generate methods with any hidden blocking semantics, and a `destroy` method that might
+// block if called incorrectly seems to meet that bar.
+//
+// So, we achieve our goals by giving each instance an associated `AtomicLong` counter to track
+// the number of in-flight method calls, and an `AtomicBoolean` flag to indicate whether `destroy`
+// has been called. These are updated according to the following rules:
+//
+//    * The initial value of the counter is 1, indicating a live object with no in-flight calls.
+//      The initial value for the flag is false.
+//
+//    * At the start of each method call, we atomically check the counter.
+//      If it is 0 then the underlying Rust struct has already been destroyed and the call is aborted.
+//      If it is nonzero them we atomically increment it by 1 and proceed with the method call.
+//
+//    * At the end of each method call, we atomically decrement and check the counter.
+//      If it has reached zero then we destroy the underlying Rust struct.
+//
+//    * When `destroy` is called, we atomically flip the flag from false to true.
+//      If the flag was already true we silently fail.
+//      Otherwise we atomically decrement and check the counter.
+//      If it has reached zero then we destroy the underlying Rust struct.
+//
+// Astute readers may observe that this all sounds very similar to the way that Rust's `Arc<T>` works,
+// and indeed it is, with the addition of a flag to guard against multiple calls to `destroy`.
+//
+// The overall effect is that the underlying Rust struct is destroyed only when `destroy` has been
+// called *and* all in-flight method calls have completed, avoiding violating any of the expectations
+// of the underlying Rust code.
+//
+// This makes a cleaner a better alternative to _not_ calling `destroy()` as
+// and when the object is finished with, but the abstraction is not perfect: if the Rust object's `drop`
+// method is slow, and/or there are many objects to cleanup, and it's on a low end Android device, then the cleaner
+// thread may be starved, and the app will leak memory.
+//
+// In this case, `destroy`ing manually may be a better solution.
+//
+// The cleaner can live side by side with the manual calling of `destroy`. In the order of responsiveness, uniffi objects
+// with Rust peers are reclaimed:
+//
+// 1. By calling the `destroy` method of the object, which calls `rustObject.free()`. If that doesn't happen:
+// 2. When the object becomes unreachable, AND the Cleaner thread gets to call `rustObject.free()`. If the thread is starved then:
+// 3. The memory is reclaimed when the process terminates.
+//
+// [1] https://stackoverflow.com/questions/24376768/can-java-finalize-an-object-when-it-is-still-in-scope/24380219
+//
+
+/**
+ * Iroh node client.
+ */
+public interface NodeInterface {
+    /**
+     * Add a known node address to the node.
+     */
+    suspend fun `addNodeAddr`(`addr`: NodeAddr)
+
+    /**
+     * Return connection information on the currently running node.
+     */
+    suspend fun `connectionInfo`(`nodeId`: PublicKey): ConnectionInfo?
+
+    /**
+     * Return `ConnectionInfo`s for each connection we have to another iroh node.
+     */
+    suspend fun `connections`(): List<ConnectionInfo>
+
+    /**
+     * Get the relay server we are connected to.
+     */
+    suspend fun `homeRelay`(): kotlin.String?
+
+    /**
+     * Returns `Some(addr)` if an RPC endpoint is running, `None` otherwise.
+     */
+    fun `myRpcAddr`(): kotlin.String?
+
+    /**
+     * Return the [`NodeAddr`] for this node.
+     */
+    suspend fun `nodeAddr`(): NodeAddr
+
+    /**
+     * The string representation of the PublicKey of this node.
+     */
+    suspend fun `nodeId`(): kotlin.String
+
+    /**
+     * Shutdown this iroh node.
+     */
+    suspend fun `shutdown`(`force`: kotlin.Boolean)
+
+    /**
+     * Get statistics of the running node.
+     */
+    suspend fun `stats`(): Map<kotlin.String, CounterStats>
+
+    /**
+     * Get status information about a node
+     */
+    suspend fun `status`(): NodeStatus
+
+    companion object
+}
+
+/**
+ * Iroh node client.
+ */
+open class Node :
+    Disposable,
+    AutoCloseable,
+    NodeInterface {
+    constructor(pointer: Pointer) {
+        this.pointer = pointer
+        this.cleanable = UniffiLib.CLEANER.register(this, UniffiCleanAction(pointer))
+    }
+
+    /**
+     * This constructor can be used to instantiate a fake object. Only used for tests. Any
+     * attempt to actually use an object constructed this way will fail as there is no
+     * connected Rust object.
+     */
+    @Suppress("UNUSED_PARAMETER")
+    constructor(noPointer: NoPointer) {
+        this.pointer = null
+        this.cleanable = UniffiLib.CLEANER.register(this, UniffiCleanAction(pointer))
+    }
+
+    protected val pointer: Pointer?
+    protected val cleanable: UniffiCleaner.Cleanable
+
+    private val wasDestroyed = AtomicBoolean(false)
+    private val callCounter = AtomicLong(1)
+
+    override fun destroy() {
+        // Only allow a single call to this method.
+        // TODO: maybe we should log a warning if called more than once?
+        if (this.wasDestroyed.compareAndSet(false, true)) {
+            // This decrement always matches the initial count of 1 given at creation time.
+            if (this.callCounter.decrementAndGet() == 0L) {
+                cleanable.clean()
+            }
+        }
+    }
+
+    @Synchronized
+    override fun close() {
+        this.destroy()
+    }
+
+    internal inline fun <R> callWithPointer(block: (ptr: Pointer) -> R): R {
+        // Check and increment the call counter, to keep the object alive.
+        // This needs a compare-and-set retry loop in case of concurrent updates.
+        do {
+            val c = this.callCounter.get()
+            if (c == 0L) {
+                throw IllegalStateException("${this.javaClass.simpleName} object has already been destroyed")
+            }
+            if (c == Long.MAX_VALUE) {
+                throw IllegalStateException("${this.javaClass.simpleName} call counter would overflow")
+            }
+        } while (!this.callCounter.compareAndSet(c, c + 1L))
+        // Now we can safely do the method call without the pointer being freed concurrently.
+        try {
+            return block(this.uniffiClonePointer())
+        } finally {
+            // This decrement always matches the increment we performed above.
+            if (this.callCounter.decrementAndGet() == 0L) {
+                cleanable.clean()
+            }
+        }
+    }
+
+    // Use a static inner class instead of a closure so as not to accidentally
+    // capture `this` as part of the cleanable's action.
+    private class UniffiCleanAction(
+        private val pointer: Pointer?,
+    ) : Runnable {
+        override fun run() {
+            pointer?.let { ptr ->
+                uniffiRustCall { status ->
+                    UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_free_node(ptr, status)
+                }
+            }
+        }
+    }
+
+    fun uniffiClonePointer(): Pointer =
+        uniffiRustCall { status ->
+            UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_clone_node(pointer!!, status)
+        }
+
+    /**
+     * Add a known node address to the node.
+     */
+    @Throws(IrohException::class)
+    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
+    override suspend fun `addNodeAddr`(`addr`: NodeAddr) =
+        uniffiRustCallAsync(
+            callWithPointer { thisPtr ->
+                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_node_add_node_addr(
+                    thisPtr,
+                    FfiConverterTypeNodeAddr.lower(`addr`),
+                )
+            },
+            { future, callback, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_void(future, callback, continuation) },
+            { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_void(future, continuation) },
+            { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_void(future) },
+            // lift function
+            { Unit },
+            // Error FFI converter
+            IrohException.ErrorHandler,
+        )
+
+    /**
+     * Return connection information on the currently running node.
+     */
+    @Throws(IrohException::class)
+    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
+    override suspend fun `connectionInfo`(`nodeId`: PublicKey): ConnectionInfo? =
+        uniffiRustCallAsync(
+            callWithPointer { thisPtr ->
+                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_node_connection_info(
+                    thisPtr,
+                    FfiConverterTypePublicKey.lower(`nodeId`),
+                )
+            },
+            {
+                    future,
+                    callback,
+                    continuation,
+                ->
+                UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_rust_buffer(future, callback, continuation)
+            },
+            { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_rust_buffer(future, continuation) },
+            { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_rust_buffer(future) },
+            // lift function
+            { FfiConverterOptionalTypeConnectionInfo.lift(it) },
+            // Error FFI converter
+            IrohException.ErrorHandler,
+        )
+
+    /**
+     * Return `ConnectionInfo`s for each connection we have to another iroh node.
+     */
+    @Throws(IrohException::class)
+    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
+    override suspend fun `connections`(): List<ConnectionInfo> =
+        uniffiRustCallAsync(
+            callWithPointer { thisPtr ->
+                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_node_connections(
+                    thisPtr,
+                )
+            },
+            {
+                    future,
+                    callback,
+                    continuation,
+                ->
+                UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_rust_buffer(future, callback, continuation)
+            },
+            { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_rust_buffer(future, continuation) },
+            { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_rust_buffer(future) },
+            // lift function
+            { FfiConverterSequenceTypeConnectionInfo.lift(it) },
+            // Error FFI converter
+            IrohException.ErrorHandler,
+        )
+
+    /**
+     * Get the relay server we are connected to.
+     */
+    @Throws(IrohException::class)
+    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
+    override suspend fun `homeRelay`(): kotlin.String? =
+        uniffiRustCallAsync(
+            callWithPointer { thisPtr ->
+                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_node_home_relay(
+                    thisPtr,
+                )
+            },
+            {
+                    future,
+                    callback,
+                    continuation,
+                ->
+                UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_rust_buffer(future, callback, continuation)
+            },
+            { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_rust_buffer(future, continuation) },
+            { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_rust_buffer(future) },
+            // lift function
+            { FfiConverterOptionalString.lift(it) },
+            // Error FFI converter
+            IrohException.ErrorHandler,
+        )
+
+    /**
+     * Returns `Some(addr)` if an RPC endpoint is running, `None` otherwise.
+     */
+    override fun `myRpcAddr`(): kotlin.String? =
+        FfiConverterOptionalString.lift(
+            callWithPointer {
+                uniffiRustCall { _status ->
+                    UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_node_my_rpc_addr(
+                        it,
+                        _status,
+                    )
+                }
+            },
+        )
+
+    /**
+     * Return the [`NodeAddr`] for this node.
+     */
+    @Throws(IrohException::class)
+    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
+    override suspend fun `nodeAddr`(): NodeAddr =
+        uniffiRustCallAsync(
+            callWithPointer { thisPtr ->
+                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_node_node_addr(
+                    thisPtr,
+                )
+            },
+            { future, callback, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_pointer(future, callback, continuation) },
+            { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_pointer(future, continuation) },
+            { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_pointer(future) },
+            // lift function
+            { FfiConverterTypeNodeAddr.lift(it) },
+            // Error FFI converter
+            IrohException.ErrorHandler,
+        )
+
+    /**
+     * The string representation of the PublicKey of this node.
+     */
+    @Throws(IrohException::class)
+    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
+    override suspend fun `nodeId`(): kotlin.String =
+        uniffiRustCallAsync(
+            callWithPointer { thisPtr ->
+                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_node_node_id(
+                    thisPtr,
+                )
+            },
+            {
+                    future,
+                    callback,
+                    continuation,
+                ->
+                UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_rust_buffer(future, callback, continuation)
+            },
+            { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_rust_buffer(future, continuation) },
+            { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_rust_buffer(future) },
+            // lift function
+            { FfiConverterString.lift(it) },
+            // Error FFI converter
+            IrohException.ErrorHandler,
+        )
+
+    /**
+     * Shutdown this iroh node.
+     */
+    @Throws(IrohException::class)
+    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
+    override suspend fun `shutdown`(`force`: kotlin.Boolean) =
+        uniffiRustCallAsync(
+            callWithPointer { thisPtr ->
+                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_node_shutdown(
+                    thisPtr,
+                    FfiConverterBoolean.lower(`force`),
+                )
+            },
+            { future, callback, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_void(future, callback, continuation) },
+            { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_void(future, continuation) },
+            { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_void(future) },
+            // lift function
+            { Unit },
+            // Error FFI converter
+            IrohException.ErrorHandler,
+        )
+
+    /**
+     * Get statistics of the running node.
+     */
+    @Throws(IrohException::class)
+    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
+    override suspend fun `stats`(): Map<kotlin.String, CounterStats> =
+        uniffiRustCallAsync(
+            callWithPointer { thisPtr ->
+                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_node_stats(
+                    thisPtr,
+                )
+            },
+            {
+                    future,
+                    callback,
+                    continuation,
+                ->
+                UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_rust_buffer(future, callback, continuation)
+            },
+            { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_rust_buffer(future, continuation) },
+            { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_rust_buffer(future) },
+            // lift function
+            { FfiConverterMapStringTypeCounterStats.lift(it) },
+            // Error FFI converter
+            IrohException.ErrorHandler,
+        )
+
+    /**
+     * Get status information about a node
+     */
+    @Throws(IrohException::class)
+    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
+    override suspend fun `status`(): NodeStatus =
+        uniffiRustCallAsync(
+            callWithPointer { thisPtr ->
+                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_node_status(
+                    thisPtr,
+                )
+            },
+            { future, callback, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_pointer(future, callback, continuation) },
+            { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_pointer(future, continuation) },
+            { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_pointer(future) },
+            // lift function
+            { FfiConverterTypeNodeStatus.lift(it) },
+            // Error FFI converter
+            IrohException.ErrorHandler,
+        )
+
+    companion object
+}
+
+public object FfiConverterTypeNode : FfiConverter<Node, Pointer> {
+    override fun lower(value: Node): Pointer = value.uniffiClonePointer()
+
+    override fun lift(value: Pointer): Node = Node(value)
+
+    override fun read(buf: ByteBuffer): Node {
+        // The Rust code always writes pointers as 8 bytes, and will
+        // fail to compile if they don't fit.
+        return lift(Pointer(buf.getLong()))
+    }
+
+    override fun allocationSize(value: Node) = 8UL
+
+    override fun write(
+        value: Node,
         buf: ByteBuffer,
     ) {
         // The Rust code always expects pointers written as 8 bytes,
@@ -15893,6 +17194,288 @@ public object FfiConverterTypeSubscribeCallback : FfiConverter<SubscribeCallback
 
     override fun write(
         value: SubscribeCallback,
+        buf: ByteBuffer,
+    ) {
+        // The Rust code always expects pointers written as 8 bytes,
+        // and will fail to compile if they don't fit.
+        buf.putLong(Pointer.nativeValue(lower(value)))
+    }
+}
+
+// This template implements a class for working with a Rust struct via a Pointer/Arc<T>
+// to the live Rust struct on the other side of the FFI.
+//
+// Each instance implements core operations for working with the Rust `Arc<T>` and the
+// Kotlin Pointer to work with the live Rust struct on the other side of the FFI.
+//
+// There's some subtlety here, because we have to be careful not to operate on a Rust
+// struct after it has been dropped, and because we must expose a public API for freeing
+// theq Kotlin wrapper object in lieu of reliable finalizers. The core requirements are:
+//
+//   * Each instance holds an opaque pointer to the underlying Rust struct.
+//     Method calls need to read this pointer from the object's state and pass it in to
+//     the Rust FFI.
+//
+//   * When an instance is no longer needed, its pointer should be passed to a
+//     special destructor function provided by the Rust FFI, which will drop the
+//     underlying Rust struct.
+//
+//   * Given an instance, calling code is expected to call the special
+//     `destroy` method in order to free it after use, either by calling it explicitly
+//     or by using a higher-level helper like the `use` method. Failing to do so risks
+//     leaking the underlying Rust struct.
+//
+//   * We can't assume that calling code will do the right thing, and must be prepared
+//     to handle Kotlin method calls executing concurrently with or even after a call to
+//     `destroy`, and to handle multiple (possibly concurrent!) calls to `destroy`.
+//
+//   * We must never allow Rust code to operate on the underlying Rust struct after
+//     the destructor has been called, and must never call the destructor more than once.
+//     Doing so may trigger memory unsafety.
+//
+//   * To mitigate many of the risks of leaking memory and use-after-free unsafety, a `Cleaner`
+//     is implemented to call the destructor when the Kotlin object becomes unreachable.
+//     This is done in a background thread. This is not a panacea, and client code should be aware that
+//      1. the thread may starve if some there are objects that have poorly performing
+//     `drop` methods or do significant work in their `drop` methods.
+//      2. the thread is shared across the whole library. This can be tuned by using `android_cleaner = true`,
+//         or `android = true` in the [`kotlin` section of the `uniffi.toml` file](https://mozilla.github.io/uniffi-rs/kotlin/configuration.html).
+//
+// If we try to implement this with mutual exclusion on access to the pointer, there is the
+// possibility of a race between a method call and a concurrent call to `destroy`:
+//
+//    * Thread A starts a method call, reads the value of the pointer, but is interrupted
+//      before it can pass the pointer over the FFI to Rust.
+//    * Thread B calls `destroy` and frees the underlying Rust struct.
+//    * Thread A resumes, passing the already-read pointer value to Rust and triggering
+//      a use-after-free.
+//
+// One possible solution would be to use a `ReadWriteLock`, with each method call taking
+// a read lock (and thus allowed to run concurrently) and the special `destroy` method
+// taking a write lock (and thus blocking on live method calls). However, we aim not to
+// generate methods with any hidden blocking semantics, and a `destroy` method that might
+// block if called incorrectly seems to meet that bar.
+//
+// So, we achieve our goals by giving each instance an associated `AtomicLong` counter to track
+// the number of in-flight method calls, and an `AtomicBoolean` flag to indicate whether `destroy`
+// has been called. These are updated according to the following rules:
+//
+//    * The initial value of the counter is 1, indicating a live object with no in-flight calls.
+//      The initial value for the flag is false.
+//
+//    * At the start of each method call, we atomically check the counter.
+//      If it is 0 then the underlying Rust struct has already been destroyed and the call is aborted.
+//      If it is nonzero them we atomically increment it by 1 and proceed with the method call.
+//
+//    * At the end of each method call, we atomically decrement and check the counter.
+//      If it has reached zero then we destroy the underlying Rust struct.
+//
+//    * When `destroy` is called, we atomically flip the flag from false to true.
+//      If the flag was already true we silently fail.
+//      Otherwise we atomically decrement and check the counter.
+//      If it has reached zero then we destroy the underlying Rust struct.
+//
+// Astute readers may observe that this all sounds very similar to the way that Rust's `Arc<T>` works,
+// and indeed it is, with the addition of a flag to guard against multiple calls to `destroy`.
+//
+// The overall effect is that the underlying Rust struct is destroyed only when `destroy` has been
+// called *and* all in-flight method calls have completed, avoiding violating any of the expectations
+// of the underlying Rust code.
+//
+// This makes a cleaner a better alternative to _not_ calling `destroy()` as
+// and when the object is finished with, but the abstraction is not perfect: if the Rust object's `drop`
+// method is slow, and/or there are many objects to cleanup, and it's on a low end Android device, then the cleaner
+// thread may be starved, and the app will leak memory.
+//
+// In this case, `destroy`ing manually may be a better solution.
+//
+// The cleaner can live side by side with the manual calling of `destroy`. In the order of responsiveness, uniffi objects
+// with Rust peers are reclaimed:
+//
+// 1. By calling the `destroy` method of the object, which calls `rustObject.free()`. If that doesn't happen:
+// 2. When the object becomes unreachable, AND the Cleaner thread gets to call `rustObject.free()`. If the thread is starved then:
+// 3. The memory is reclaimed when the process terminates.
+//
+// [1] https://stackoverflow.com/questions/24376768/can-java-finalize-an-object-when-it-is-still-in-scope/24380219
+//
+
+/**
+ * Iroh tags client.
+ */
+public interface TagsInterface {
+    /**
+     * Delete a tag
+     */
+    suspend fun `delete`(`name`: kotlin.ByteArray)
+
+    /**
+     * List all tags
+     *
+     * Note: this allocates for each `ListTagsResponse`, if you have many `Tags`s this may be a prohibitively large list.
+     * Please file an [issue](https://github.com/n0-computer/iroh-ffi/issues/new) if you run into this issue
+     */
+    suspend fun `list`(): List<TagInfo>
+
+    companion object
+}
+
+/**
+ * Iroh tags client.
+ */
+open class Tags :
+    Disposable,
+    AutoCloseable,
+    TagsInterface {
+    constructor(pointer: Pointer) {
+        this.pointer = pointer
+        this.cleanable = UniffiLib.CLEANER.register(this, UniffiCleanAction(pointer))
+    }
+
+    /**
+     * This constructor can be used to instantiate a fake object. Only used for tests. Any
+     * attempt to actually use an object constructed this way will fail as there is no
+     * connected Rust object.
+     */
+    @Suppress("UNUSED_PARAMETER")
+    constructor(noPointer: NoPointer) {
+        this.pointer = null
+        this.cleanable = UniffiLib.CLEANER.register(this, UniffiCleanAction(pointer))
+    }
+
+    protected val pointer: Pointer?
+    protected val cleanable: UniffiCleaner.Cleanable
+
+    private val wasDestroyed = AtomicBoolean(false)
+    private val callCounter = AtomicLong(1)
+
+    override fun destroy() {
+        // Only allow a single call to this method.
+        // TODO: maybe we should log a warning if called more than once?
+        if (this.wasDestroyed.compareAndSet(false, true)) {
+            // This decrement always matches the initial count of 1 given at creation time.
+            if (this.callCounter.decrementAndGet() == 0L) {
+                cleanable.clean()
+            }
+        }
+    }
+
+    @Synchronized
+    override fun close() {
+        this.destroy()
+    }
+
+    internal inline fun <R> callWithPointer(block: (ptr: Pointer) -> R): R {
+        // Check and increment the call counter, to keep the object alive.
+        // This needs a compare-and-set retry loop in case of concurrent updates.
+        do {
+            val c = this.callCounter.get()
+            if (c == 0L) {
+                throw IllegalStateException("${this.javaClass.simpleName} object has already been destroyed")
+            }
+            if (c == Long.MAX_VALUE) {
+                throw IllegalStateException("${this.javaClass.simpleName} call counter would overflow")
+            }
+        } while (!this.callCounter.compareAndSet(c, c + 1L))
+        // Now we can safely do the method call without the pointer being freed concurrently.
+        try {
+            return block(this.uniffiClonePointer())
+        } finally {
+            // This decrement always matches the increment we performed above.
+            if (this.callCounter.decrementAndGet() == 0L) {
+                cleanable.clean()
+            }
+        }
+    }
+
+    // Use a static inner class instead of a closure so as not to accidentally
+    // capture `this` as part of the cleanable's action.
+    private class UniffiCleanAction(
+        private val pointer: Pointer?,
+    ) : Runnable {
+        override fun run() {
+            pointer?.let { ptr ->
+                uniffiRustCall { status ->
+                    UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_free_tags(ptr, status)
+                }
+            }
+        }
+    }
+
+    fun uniffiClonePointer(): Pointer =
+        uniffiRustCall { status ->
+            UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_clone_tags(pointer!!, status)
+        }
+
+    /**
+     * Delete a tag
+     */
+    @Throws(IrohException::class)
+    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
+    override suspend fun `delete`(`name`: kotlin.ByteArray) =
+        uniffiRustCallAsync(
+            callWithPointer { thisPtr ->
+                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_tags_delete(
+                    thisPtr,
+                    FfiConverterByteArray.lower(`name`),
+                )
+            },
+            { future, callback, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_void(future, callback, continuation) },
+            { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_void(future, continuation) },
+            { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_void(future) },
+            // lift function
+            { Unit },
+            // Error FFI converter
+            IrohException.ErrorHandler,
+        )
+
+    /**
+     * List all tags
+     *
+     * Note: this allocates for each `ListTagsResponse`, if you have many `Tags`s this may be a prohibitively large list.
+     * Please file an [issue](https://github.com/n0-computer/iroh-ffi/issues/new) if you run into this issue
+     */
+    @Throws(IrohException::class)
+    @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
+    override suspend fun `list`(): List<TagInfo> =
+        uniffiRustCallAsync(
+            callWithPointer { thisPtr ->
+                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_tags_list(
+                    thisPtr,
+                )
+            },
+            {
+                    future,
+                    callback,
+                    continuation,
+                ->
+                UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_rust_buffer(future, callback, continuation)
+            },
+            { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_rust_buffer(future, continuation) },
+            { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_rust_buffer(future) },
+            // lift function
+            { FfiConverterSequenceTypeTagInfo.lift(it) },
+            // Error FFI converter
+            IrohException.ErrorHandler,
+        )
+
+    companion object
+}
+
+public object FfiConverterTypeTags : FfiConverter<Tags, Pointer> {
+    override fun lower(value: Tags): Pointer = value.uniffiClonePointer()
+
+    override fun lift(value: Pointer): Tags = Tags(value)
+
+    override fun read(buf: ByteBuffer): Tags {
+        // The Rust code always writes pointers as 8 bytes, and will
+        // fail to compile if they don't fit.
+        return lift(Pointer(buf.getLong()))
+    }
+
+    override fun allocationSize(value: Tags) = 8UL
+
+    override fun write(
+        value: Tags,
         buf: ByteBuffer,
     ) {
         // The Rust code always expects pointers written as 8 bytes,

--- a/kotlin/node_test.kts
+++ b/kotlin/node_test.kts
@@ -25,15 +25,15 @@ runBlocking {
     // Create node_0
     val irohDir0 = kotlin.io.path.createTempDirectory("node-test-0")
     println(irohDir0.toString())
-    val node0 = IrohNode.persistent(irohDir0.toString())
+    val node0 = Iroh.persistent(irohDir0.toString())
 
     // Create node_1
     val irohDir1 = kotlin.io.path.createTempDirectory("node-test-1")
     println(irohDir1.toString())
-    val node1 = IrohNode.persistent(irohDir1.toString())
+    val node1 = Iroh.persistent(irohDir1.toString())
 
     // Create doc on node_0
-    val doc0 = node0.docCreate()
+    val doc0 = node0.docs().create()
 
     // Subscribe to sync events
     val cb0 = Subscriber()
@@ -42,7 +42,7 @@ runBlocking {
     // Join the same doc from node_1
     val ticket = doc0.share(ShareMode.WRITE, AddrInfoOptions.RELAY_AND_ADDRESSES)
     val cb1 = Subscriber()
-    val doc1 = node1.docJoinAndSubscribe(ticket, cb1)
+    val doc1 = node1.docs().joinAndSubscribe(ticket, cb1)
 
     // wait for initial sync
     while (true) {
@@ -53,7 +53,7 @@ runBlocking {
     }
 
     // Create author on node_1
-    val author = node1.authorCreate()
+    val author = node1.authors().create()
     val blobSize = 100
     val bytes = generateRandomByteArray(blobSize)
 
@@ -67,7 +67,7 @@ runBlocking {
             println(hash)
 
             // Get content from hash
-            val v = node1.blobsReadToBytes(hash)
+            val v = node1.blobs().readToBytes(hash)
             assert(bytes contentEquals v)
 
             break

--- a/python/author_test.py
+++ b/python/author_test.py
@@ -1,5 +1,5 @@
 # tests that correspond to the `src/author.rs` rust api
-from iroh import IrohNode
+from iroh import Iroh
 import pytest
 import tempfile
 import iroh
@@ -12,32 +12,32 @@ async def test_author_api():
 
     #
     # create node
-    node = await IrohNode.memory()
+    node = await Iroh.memory()
     #
     # creating a node also creates an author
-    assert len(await node.author_list()) == 1
+    assert len(await node.authors().list()) == 1
     #
     # create
-    author_id = await node.author_create()
+    author_id = await node.authors().create()
     #
     # list all authors on the node
-    authors = await node.author_list()
+    authors = await node.authors().list()
     assert len(authors) == 2
     #
     # export the author
-    author = await node.author_export(author_id)
+    author = await node.authors().export(author_id)
     assert author_id.equal(author.id())
     #
     # remove that author from the node
-    await node.author_delete(author_id)
+    await node.authors().delete(author_id)
     #
     # check there are 1 authors on the node
-    authors = await node.author_list()
+    authors = await node.authors().list()
     assert len(authors) == 1
     #
     # import the author back into the node
-    await node.author_import(author)
+    await node.authors().import_author(author)
     #
     # check there is 1 author on the node
-    authors = await node.author_list()
+    authors = await node.authors().list()
     assert len(authors) == 2

--- a/python/author_test.py
+++ b/python/author_test.py
@@ -1,7 +1,6 @@
 # tests that correspond to the `src/author.rs` rust api
 from iroh import Iroh
 import pytest
-import tempfile
 import iroh
 import asyncio
 

--- a/python/blob_test.py
+++ b/python/blob_test.py
@@ -7,7 +7,7 @@ import time
 import iroh
 import asyncio
 
-from iroh import Hash, IrohNode, SetTagOption, BlobFormat, WrapOption, AddProgressType, NodeOptions
+from iroh import Hash, Iroh, SetTagOption, BlobFormat, WrapOption, AddProgressType, NodeOptions
 
 def test_hash():
     hash_str = "2kbxxbofqx5rau77wzafrj4yntjb4gn4olfpwxmv26js6dvhgjhq"
@@ -43,14 +43,14 @@ async def test_blob_add_get_bytes():
     #
     # create node
     dir = tempfile.TemporaryDirectory()
-    node = await IrohNode.persistent(dir.name)
+    node = await Iroh.persistent(dir.name)
     #
     # create bytes
     blob_size = 100
     bytes = bytearray(map(random.getrandbits,(8,)*blob_size))
     #
     # add blob
-    add_outcome = await node.blobs_add_bytes(bytes)
+    add_outcome = await node.blobs().add_bytes(bytes)
     #
     # check outcome info is as expected
     assert add_outcome.format == BlobFormat.RAW
@@ -58,11 +58,11 @@ async def test_blob_add_get_bytes():
     #
     # check we get the expected size from the hash
     hash = add_outcome.hash
-    got_size = await node.blobs_size(hash)
+    got_size = await node.blobs().size(hash)
     assert got_size == blob_size
     #
     # get bytes
-    got_bytes = await node.blobs_read_to_bytes(hash)
+    got_bytes = await node.blobs().read_to_bytes(hash)
     assert len(got_bytes) == blob_size
     assert got_bytes == bytes
 
@@ -74,7 +74,7 @@ async def test_blob_read_write_path():
     iroh.iroh_ffi.uniffi_set_event_loop(asyncio.get_running_loop())
 
     iroh_dir = tempfile.TemporaryDirectory()
-    node = await IrohNode.persistent(iroh_dir.name)
+    node = await Iroh.persistent(iroh_dir.name)
     #
     # create bytes
     blob_size = 100
@@ -108,25 +108,25 @@ async def test_blob_read_write_path():
                 raise Exception(abort_event.error)
 
     cb = AddCallback()
-    await node.blobs_add_from_path(path, False, tag, wrap, cb)
+    await node.blobs().add_from_path(path, False, tag, wrap, cb)
     #
     # check outcome info is as expected
     assert cb.format == BlobFormat.RAW
     assert cb.hash != None
     #
     # check we get the expected size from the hash
-    got_size = await node.blobs_size(cb.hash)
+    got_size = await node.blobs().size(cb.hash)
     assert got_size == blob_size
     #
     # get bytes
-    got_bytes = await node.blobs_read_to_bytes(cb.hash)
+    got_bytes = await node.blobs().read_to_bytes(cb.hash)
     print("read_to_bytes {}", got_bytes)
     assert len(got_bytes) == blob_size
     assert got_bytes == bytes
     #
     # write to file
     out_path = os.path.join(dir.name, "out")
-    await node.blobs_write_to_path(cb.hash, out_path)
+    await node.blobs().write_to_path(cb.hash, out_path)
     # open file
     got_file = open(out_path, "rb")
     got_bytes = got_file.read()
@@ -153,10 +153,10 @@ async def test_blob_collections():
 
     # make node
     iroh_dir = tempfile.TemporaryDirectory()
-    node = await IrohNode.persistent(iroh_dir.name)
+    node = await Iroh.persistent(iroh_dir.name)
 
     # ensure zero blobs
-    blobs = await node.blobs_list()
+    blobs = await node.blobs().list()
     assert len(blobs) == 0
 
     # create callback to get blobs and collection hash
@@ -183,13 +183,13 @@ async def test_blob_collections():
     tag = SetTagOption.auto()
     wrap = WrapOption.no_wrap()
     # add from path
-    await node.blobs_add_from_path(collection_dir.name, False, tag, wrap, cb)
+    await node.blobs().add_from_path(collection_dir.name, False, tag, wrap, cb)
 
     assert cb.collection_hash != None
     assert cb.format == BlobFormat.HASH_SEQ
 
     # list collections
-    collections = await node.blobs_list_collections()
+    collections = await node.blobs().list_collections()
     print("collection hash ", collections[0].hash)
     assert len(collections) == 1
     assert collections[0].hash.equal(cb.collection_hash)
@@ -201,9 +201,9 @@ async def test_blob_collections():
     # list blobs
     collection_hashes = cb.blob_hashes
     collection_hashes.append(cb.collection_hash)
-    got_hashes = await node.blobs_list()
+    got_hashes = await node.blobs().list()
     for hash in got_hashes:
-        blob = await node.blobs_read_to_bytes(hash)
+        blob = await node.blobs().read_to_bytes(hash)
         print("hash ", hash, " has size ", len(blob))
 
     hashes_exist(collection_hashes, got_hashes)
@@ -218,7 +218,7 @@ async def test_list_and_delete():
 
     iroh_dir = tempfile.TemporaryDirectory()
     opts = NodeOptions(gc_interval_millis=100)
-    node = await IrohNode.persistent_with_options(iroh_dir.name, opts)
+    node = await Iroh.persistent_with_options(iroh_dir.name, opts)
     #
     # create bytes
     blob_size = 100
@@ -233,22 +233,22 @@ async def test_list_and_delete():
     hashes = []
     tags = []
     for blob in blobs:
-        output = await node.blobs_add_bytes(blob)
+        output = await node.blobs().add_bytes(blob)
         hashes.append(output.hash)
         tags.append(output.tag)
 
-    got_hashes = await node.blobs_list()
+    got_hashes = await node.blobs().list()
     assert len(got_hashes) == num_blobs
     hashes_exist(hashes, got_hashes)
 
     remove_hash = hashes.pop(0)
     remove_tag = tags.pop(0)
     # delete the tag for the first blob
-    await node.tags_delete(remove_tag)
+    await node.tags().delete(remove_tag)
     # wait for GC to clear the blob
     time.sleep(0.25)
 
-    got_hashes = await node.blobs_list()
+    got_hashes = await node.blobs().list()
     assert len(got_hashes) == num_blobs - 1
     hashes_exist(hashes, got_hashes)
 
@@ -266,5 +266,5 @@ def hashes_exist(expect, got):
             raise Exception("could not find ", hash, "in list")
 
 # def test_download():
-    # need to wait to refactor IrohNode to take an rpc port, or we remove rpc
+    # need to wait to refactor Iroh to take an rpc port, or we remove rpc
     # ports from the iroh rpc in general

--- a/python/blob_test.py
+++ b/python/blob_test.py
@@ -112,7 +112,7 @@ async def test_blob_read_write_path():
     #
     # check outcome info is as expected
     assert cb.format == BlobFormat.RAW
-    assert cb.hash != None
+    assert cb.hash is not None
     #
     # check we get the expected size from the hash
     got_size = await node.blobs().size(cb.hash)
@@ -185,7 +185,7 @@ async def test_blob_collections():
     # add from path
     await node.blobs().add_from_path(collection_dir.name, False, tag, wrap, cb)
 
-    assert cb.collection_hash != None
+    assert cb.collection_hash is not None
     assert cb.format == BlobFormat.HASH_SEQ
 
     # list collections
@@ -223,7 +223,7 @@ async def test_list_and_delete():
     # create bytes
     blob_size = 100
     blobs = []
-    num_blobs = 3;
+    num_blobs = 3
 
     for x in range(num_blobs):
         print(x)

--- a/python/doc_test.py
+++ b/python/doc_test.py
@@ -1,5 +1,5 @@
 # tests that correspond to the `src/doc.rs` rust api
-from iroh import IrohNode, PublicKey, NodeAddr, AuthorId, Query, SortBy, SortDirection, QueryOptions, path_to_key, key_to_path
+from iroh import Iroh, PublicKey, NodeAddr, AuthorId, Query, SortBy, SortDirection, QueryOptions, path_to_key, key_to_path
 import pytest
 import tempfile
 import os
@@ -97,11 +97,11 @@ async def test_doc_entry_basics():
     #
     # create node
     dir = tempfile.TemporaryDirectory()
-    node = await IrohNode.persistent(dir.name)
+    node = await Iroh.persistent(dir.name)
     #
     # create doc and author
-    doc = await node.doc_create()
-    author = await node.author_create()
+    doc = await node.docs().create()
+    author = await node.authors().create()
     #
     # create entry
     val = b'hello world!'
@@ -139,11 +139,11 @@ async def test_doc_import_export():
     #
     # create node
     iroh_dir = tempfile.TemporaryDirectory()
-    node = await IrohNode.persistent(iroh_dir.name)
+    node = await Iroh.persistent(iroh_dir.name)
     #
     # create doc and author
-    doc = await node.doc_create()
-    author = await node.author_create()
+    doc = await node.docs().create()
+    author = await node.authors().create()
     #
     # import entry
     key = path_to_key(path, None, in_root)

--- a/python/doc_test.py
+++ b/python/doc_test.py
@@ -60,14 +60,14 @@ def test_query():
     opts.offset = 0
     single_latest_per_key = Query.single_latest_per_key(opts)
     assert 0 == single_latest_per_key.offset()
-    assert None == single_latest_per_key.limit()
+    assert single_latest_per_key.limit() is None
 
     # author
     opts.direction = SortDirection.ASC
     opts.offset = 100
     author = Query.author(AuthorId.from_string("mqtlzayyv4pb4xvnqnw5wxb2meivzq5ze6jihpa7fv5lfwdoya4q"), opts)
     assert 100 == author.offset()
-    assert None == author.limit()
+    assert author.limit() is None
 
     # key_exact
     opts.sort_by = SortBy.KEY_AUTHOR
@@ -85,7 +85,7 @@ def test_query():
     key_prefix = Query.key_prefix(
         b'prefix',
         opts
-    );
+    )
     assert 0 == key_prefix.offset()
     assert 100 == key_prefix.limit()
 

--- a/python/gossip_test.py
+++ b/python/gossip_test.py
@@ -1,10 +1,9 @@
 # tests that correspond to the `src/gossp.rs` rust api
-import tempfile
 import pytest
 import asyncio
 import iroh
 
-from iroh import Iroh, ShareMode, LiveEventType, MessageType, GossipMessageCallback
+from iroh import Iroh, MessageType, GossipMessageCallback
 
 class Callback(GossipMessageCallback):
     def __init__(self, name):
@@ -43,7 +42,7 @@ async def test_gossip_basic():
     await n1.node().add_node_addr(n0_addr)
 
     print("subscribe n1")
-    sink1 = await n1.gossip().subscribe(topic, [n0_id], cb1)
+    await n1.gossip().subscribe(topic, [n0_id], cb1)
 
     # Wait for n1 to show up for n0
     while (True):

--- a/python/gossip_test.py
+++ b/python/gossip_test.py
@@ -4,7 +4,7 @@ import pytest
 import asyncio
 import iroh
 
-from iroh import IrohNode, ShareMode, LiveEventType, MessageType, GossipMessageCallback
+from iroh import Iroh, ShareMode, LiveEventType, MessageType, GossipMessageCallback
 
 class Callback(GossipMessageCallback):
     def __init__(self, name):
@@ -21,29 +21,29 @@ async def test_gossip_basic():
     # setup event loop, to ensure async callbacks work
     iroh.iroh_ffi.uniffi_set_event_loop(asyncio.get_running_loop())
 
-    n0 = await IrohNode.memory()
-    n1 = await IrohNode.memory()
+    n0 = await Iroh.memory()
+    n1 = await Iroh.memory()
 
     # Create a topic
     topic = bytearray([1] * 32)
 
     # Setup gossip on node 0
     cb0 = Callback("n0")
-    n1_id = await n1.node_id()
-    n1_addr = await n1.node_addr()
-    await n0.add_node_addr(n1_addr)
+    n1_id = await n1.node().node_id()
+    n1_addr = await n1.node().node_addr()
+    await n0.node().add_node_addr(n1_addr)
 
     print("subscribe n0")
-    sink0 = await n0.gossip_subscribe(topic, [n1_id], cb0)
+    sink0 = await n0.gossip().subscribe(topic, [n1_id], cb0)
 
     # Setup gossip on node 1
     cb1 = Callback("n1")
-    n0_id = await n0.node_id()
-    n0_addr = await n0.node_addr()
-    await n1.add_node_addr(n0_addr)
+    n0_id = await n0.node().node_id()
+    n0_addr = await n0.node().node_addr()
+    await n1.node().add_node_addr(n0_addr)
 
     print("subscribe n1")
-    sink1 = await n1.gossip_subscribe(topic, [n0_id], cb1)
+    sink1 = await n1.gossip().subscribe(topic, [n0_id], cb1)
 
     # Wait for n1 to show up for n0
     while (True):

--- a/python/key_test.py
+++ b/python/key_test.py
@@ -1,6 +1,5 @@
 # tests that correspond to the `src/key.rs` rust api
 from iroh import PublicKey
-import sys
 
 def test_public_key():
     key_str = "ki6htfv2252cj2lhq3hxu4qfcfjtpjnukzonevigudzjpmmruxva"

--- a/python/lib_test.py
+++ b/python/lib_test.py
@@ -1,7 +1,5 @@
 # tests that correspond to the `src/lib.rs` rust api functions
 from iroh import path_to_key, key_to_path
-import pytest
-import tempfile
 
 def test_path_to_key_roundtrip():
     path = "/foo/bar"

--- a/python/main.py
+++ b/python/main.py
@@ -19,21 +19,21 @@ async def main():
         print()
 
         # create iroh node
-        node = await iroh.IrohNode.memory()
-        node_id = await node.node_id()
+        node = await iroh.Iroh.memory()
+        node_id = await node.node().node_id()
         print("Started Iroh node: {}".format(node_id))
 
         # create doc
-        doc = await node.doc_create()
+        doc = await node.docs().create()
         doc_id = doc.id()
         print("Created doc: {}".format(doc_id))
 
-        doc = await node.doc_create()
+        doc = await node.docs().create()
         doc_id = doc.id()
         print("Created doc: {}".format(doc_id))
 
         # list docs
-        docs = await node.doc_list()
+        docs = await node.docs().list()
         print("List all {} docs:".format(len(docs)))
         for doc in docs:
             print("\t{}".format(doc))
@@ -41,8 +41,8 @@ async def main():
         exit()
 
     # create iroh node
-    node = await iroh.IrohNode.memory()
-    node_id = await node.node_id()
+    node = await iroh.Iroh.memory()
+    node_id = await node.node().node_id()
     print("Started Iroh node: {}".format(node_id))
 
     # join doc


### PR DESCRIPTION
- divide structures, `fn blob_` is now `blobs().` etc
- workarounds for python reserved names `del` and `import`
- `IrohNode` is now `Iroh`

Closes #166 

### Example

```python
# Before
node = await IrohNode.persistent(dir.name)
add_outcome = await node.blobs_add_bytes(bytes)

# After
node = await Iroh.persistent(dir.name)
add_outcome = await node.blobs().add_bytes(bytes)
```


### Update bindings

- [x] Swift
- [x] Kotlin
- [x] Python