### PR TITLE
normalize ticket handling for all bindings

### DIFF
--- a/Iroh.xcframework/ios-arm64/Iroh.framework/Headers/iroh_ffiFFI.h
+++ b/Iroh.xcframework/ios-arm64/Iroh.framework/Headers/iroh_ffiFFI.h
@@ -545,6 +545,11 @@ void*_Nonnull uniffi_iroh_ffi_fn_method_blobticket_node_addr(void*_Nonnull ptr, 
 int8_t uniffi_iroh_ffi_fn_method_blobticket_recursive(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBTICKET_UNIFFI_TRAIT_DISPLAY
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBTICKET_UNIFFI_TRAIT_DISPLAY
+RustBuffer uniffi_iroh_ffi_fn_method_blobticket_uniffi_trait_display(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_BLOBS
 #define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_BLOBS
 void*_Nonnull uniffi_iroh_ffi_fn_clone_blobs(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
@@ -951,6 +956,26 @@ RustBuffer uniffi_iroh_ffi_fn_method_docimportprogress_as_progress(void*_Nonnull
 RustBuffer uniffi_iroh_ffi_fn_method_docimportprogress_type(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_DOCTICKET
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_DOCTICKET
+void*_Nonnull uniffi_iroh_ffi_fn_clone_docticket(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_FREE_DOCTICKET
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_FREE_DOCTICKET
+void uniffi_iroh_ffi_fn_free_docticket(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CONSTRUCTOR_DOCTICKET_NEW
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CONSTRUCTOR_DOCTICKET_NEW
+void*_Nonnull uniffi_iroh_ffi_fn_constructor_docticket_new(RustBuffer str, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_DOCTICKET_UNIFFI_TRAIT_DISPLAY
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_DOCTICKET_UNIFFI_TRAIT_DISPLAY
+RustBuffer uniffi_iroh_ffi_fn_method_docticket_uniffi_trait_display(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_DOCS
 #define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_DOCS
 void*_Nonnull uniffi_iroh_ffi_fn_clone_docs(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
@@ -973,12 +998,12 @@ uint64_t uniffi_iroh_ffi_fn_method_docs_drop_doc(void*_Nonnull ptr, RustBuffer d
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_DOCS_JOIN
 #define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_DOCS_JOIN
-uint64_t uniffi_iroh_ffi_fn_method_docs_join(void*_Nonnull ptr, RustBuffer ticket
+uint64_t uniffi_iroh_ffi_fn_method_docs_join(void*_Nonnull ptr, void*_Nonnull ticket
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_DOCS_JOIN_AND_SUBSCRIBE
 #define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_DOCS_JOIN_AND_SUBSCRIBE
-uint64_t uniffi_iroh_ffi_fn_method_docs_join_and_subscribe(void*_Nonnull ptr, RustBuffer ticket, void*_Nonnull cb
+uint64_t uniffi_iroh_ffi_fn_method_docs_join_and_subscribe(void*_Nonnull ptr, void*_Nonnull ticket, void*_Nonnull cb
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_DOCS_LIST
@@ -3056,6 +3081,12 @@ uint16_t uniffi_iroh_ffi_checksum_constructor_blobticket_new(void
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_CONSTRUCTOR_COLLECTION_NEW
 #define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_CONSTRUCTOR_COLLECTION_NEW
 uint16_t uniffi_iroh_ffi_checksum_constructor_collection_new(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_CONSTRUCTOR_DOCTICKET_NEW
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_CONSTRUCTOR_DOCTICKET_NEW
+uint16_t uniffi_iroh_ffi_checksum_constructor_docticket_new(void
     
 );
 #endif

--- a/Iroh.xcframework/ios-arm64_x86_64-simulator/Iroh.framework/Headers/iroh_ffiFFI.h
+++ b/Iroh.xcframework/ios-arm64_x86_64-simulator/Iroh.framework/Headers/iroh_ffiFFI.h
@@ -545,6 +545,11 @@ void*_Nonnull uniffi_iroh_ffi_fn_method_blobticket_node_addr(void*_Nonnull ptr, 
 int8_t uniffi_iroh_ffi_fn_method_blobticket_recursive(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBTICKET_UNIFFI_TRAIT_DISPLAY
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBTICKET_UNIFFI_TRAIT_DISPLAY
+RustBuffer uniffi_iroh_ffi_fn_method_blobticket_uniffi_trait_display(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_BLOBS
 #define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_BLOBS
 void*_Nonnull uniffi_iroh_ffi_fn_clone_blobs(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
@@ -951,6 +956,26 @@ RustBuffer uniffi_iroh_ffi_fn_method_docimportprogress_as_progress(void*_Nonnull
 RustBuffer uniffi_iroh_ffi_fn_method_docimportprogress_type(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_DOCTICKET
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_DOCTICKET
+void*_Nonnull uniffi_iroh_ffi_fn_clone_docticket(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_FREE_DOCTICKET
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_FREE_DOCTICKET
+void uniffi_iroh_ffi_fn_free_docticket(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CONSTRUCTOR_DOCTICKET_NEW
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CONSTRUCTOR_DOCTICKET_NEW
+void*_Nonnull uniffi_iroh_ffi_fn_constructor_docticket_new(RustBuffer str, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_DOCTICKET_UNIFFI_TRAIT_DISPLAY
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_DOCTICKET_UNIFFI_TRAIT_DISPLAY
+RustBuffer uniffi_iroh_ffi_fn_method_docticket_uniffi_trait_display(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_DOCS
 #define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_DOCS
 void*_Nonnull uniffi_iroh_ffi_fn_clone_docs(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
@@ -973,12 +998,12 @@ uint64_t uniffi_iroh_ffi_fn_method_docs_drop_doc(void*_Nonnull ptr, RustBuffer d
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_DOCS_JOIN
 #define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_DOCS_JOIN
-uint64_t uniffi_iroh_ffi_fn_method_docs_join(void*_Nonnull ptr, RustBuffer ticket
+uint64_t uniffi_iroh_ffi_fn_method_docs_join(void*_Nonnull ptr, void*_Nonnull ticket
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_DOCS_JOIN_AND_SUBSCRIBE
 #define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_DOCS_JOIN_AND_SUBSCRIBE
-uint64_t uniffi_iroh_ffi_fn_method_docs_join_and_subscribe(void*_Nonnull ptr, RustBuffer ticket, void*_Nonnull cb
+uint64_t uniffi_iroh_ffi_fn_method_docs_join_and_subscribe(void*_Nonnull ptr, void*_Nonnull ticket, void*_Nonnull cb
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_DOCS_LIST
@@ -3056,6 +3081,12 @@ uint16_t uniffi_iroh_ffi_checksum_constructor_blobticket_new(void
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_CONSTRUCTOR_COLLECTION_NEW
 #define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_CONSTRUCTOR_COLLECTION_NEW
 uint16_t uniffi_iroh_ffi_checksum_constructor_collection_new(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_CONSTRUCTOR_DOCTICKET_NEW
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_CONSTRUCTOR_DOCTICKET_NEW
+uint16_t uniffi_iroh_ffi_checksum_constructor_docticket_new(void
     
 );
 #endif

--- a/Iroh.xcframework/macos-arm64/Iroh.framework/Headers/iroh_ffiFFI.h
+++ b/Iroh.xcframework/macos-arm64/Iroh.framework/Headers/iroh_ffiFFI.h
@@ -545,6 +545,11 @@ void*_Nonnull uniffi_iroh_ffi_fn_method_blobticket_node_addr(void*_Nonnull ptr, 
 int8_t uniffi_iroh_ffi_fn_method_blobticket_recursive(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBTICKET_UNIFFI_TRAIT_DISPLAY
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_BLOBTICKET_UNIFFI_TRAIT_DISPLAY
+RustBuffer uniffi_iroh_ffi_fn_method_blobticket_uniffi_trait_display(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_BLOBS
 #define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_BLOBS
 void*_Nonnull uniffi_iroh_ffi_fn_clone_blobs(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
@@ -951,6 +956,26 @@ RustBuffer uniffi_iroh_ffi_fn_method_docimportprogress_as_progress(void*_Nonnull
 RustBuffer uniffi_iroh_ffi_fn_method_docimportprogress_type(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_DOCTICKET
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_DOCTICKET
+void*_Nonnull uniffi_iroh_ffi_fn_clone_docticket(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_FREE_DOCTICKET
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_FREE_DOCTICKET
+void uniffi_iroh_ffi_fn_free_docticket(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CONSTRUCTOR_DOCTICKET_NEW
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CONSTRUCTOR_DOCTICKET_NEW
+void*_Nonnull uniffi_iroh_ffi_fn_constructor_docticket_new(RustBuffer str, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_DOCTICKET_UNIFFI_TRAIT_DISPLAY
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_DOCTICKET_UNIFFI_TRAIT_DISPLAY
+RustBuffer uniffi_iroh_ffi_fn_method_docticket_uniffi_trait_display(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_DOCS
 #define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_CLONE_DOCS
 void*_Nonnull uniffi_iroh_ffi_fn_clone_docs(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
@@ -973,12 +998,12 @@ uint64_t uniffi_iroh_ffi_fn_method_docs_drop_doc(void*_Nonnull ptr, RustBuffer d
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_DOCS_JOIN
 #define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_DOCS_JOIN
-uint64_t uniffi_iroh_ffi_fn_method_docs_join(void*_Nonnull ptr, RustBuffer ticket
+uint64_t uniffi_iroh_ffi_fn_method_docs_join(void*_Nonnull ptr, void*_Nonnull ticket
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_DOCS_JOIN_AND_SUBSCRIBE
 #define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_DOCS_JOIN_AND_SUBSCRIBE
-uint64_t uniffi_iroh_ffi_fn_method_docs_join_and_subscribe(void*_Nonnull ptr, RustBuffer ticket, void*_Nonnull cb
+uint64_t uniffi_iroh_ffi_fn_method_docs_join_and_subscribe(void*_Nonnull ptr, void*_Nonnull ticket, void*_Nonnull cb
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_DOCS_LIST
@@ -3056,6 +3081,12 @@ uint16_t uniffi_iroh_ffi_checksum_constructor_blobticket_new(void
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_CONSTRUCTOR_COLLECTION_NEW
 #define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_CONSTRUCTOR_COLLECTION_NEW
 uint16_t uniffi_iroh_ffi_checksum_constructor_collection_new(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_CONSTRUCTOR_DOCTICKET_NEW
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_CONSTRUCTOR_DOCTICKET_NEW
+uint16_t uniffi_iroh_ffi_checksum_constructor_docticket_new(void
     
 );
 #endif

--- a/IrohLib/Sources/IrohLib/IrohLib.swift
+++ b/IrohLib/Sources/IrohLib/IrohLib.swift
@@ -8,10 +8,10 @@ import Foundation
 // might be in a separate module, or it might be compiled inline into
 // this module. This is a bit of light hackery to work with both.
 #if canImport(Iroh)
-import Iroh
+    import Iroh
 #endif
 
-fileprivate extension RustBuffer {
+private extension RustBuffer {
     // Allocate a new buffer, copying the contents of a `UInt8` array.
     init(bytes: [UInt8]) {
         let rbuf = bytes.withUnsafeBufferPointer { ptr in
@@ -21,7 +21,7 @@ fileprivate extension RustBuffer {
     }
 
     static func empty() -> RustBuffer {
-        RustBuffer(capacity: 0, len:0, data: nil)
+        RustBuffer(capacity: 0, len: 0, data: nil)
     }
 
     static func from(_ ptr: UnsafeBufferPointer<UInt8>) -> RustBuffer {
@@ -35,7 +35,7 @@ fileprivate extension RustBuffer {
     }
 }
 
-fileprivate extension ForeignBytes {
+private extension ForeignBytes {
     init(bufferPointer: UnsafeBufferPointer<UInt8>) {
         self.init(len: Int32(bufferPointer.count), data: bufferPointer.baseAddress)
     }
@@ -48,7 +48,7 @@ fileprivate extension ForeignBytes {
 // Helper classes/extensions that don't change.
 // Someday, this will be in a library of its own.
 
-fileprivate extension Data {
+private extension Data {
     init(rustBuffer: RustBuffer) {
         // TODO: This copies the buffer. Can we read directly from a
         // Rust buffer?
@@ -70,15 +70,15 @@ fileprivate extension Data {
 //
 // Instead, the read() method and these helper functions input a tuple of data
 
-fileprivate func createReader(data: Data) -> (data: Data, offset: Data.Index) {
+private func createReader(data: Data) -> (data: Data, offset: Data.Index) {
     (data: data, offset: 0)
 }
 
 // Reads an integer at the current offset, in big-endian order, and advances
 // the offset on success. Throws if reading the integer would move the
 // offset past the end of the buffer.
-fileprivate func readInt<T: FixedWidthInteger>(_ reader: inout (data: Data, offset: Data.Index)) throws -> T {
-    let range = reader.offset..<reader.offset + MemoryLayout<T>.size
+private func readInt<T: FixedWidthInteger>(_ reader: inout (data: Data, offset: Data.Index)) throws -> T {
+    let range = reader.offset ..< reader.offset + MemoryLayout<T>.size
     guard reader.data.count >= range.upperBound else {
         throw UniffiInternalError.bufferOverflow
     }
@@ -88,38 +88,38 @@ fileprivate func readInt<T: FixedWidthInteger>(_ reader: inout (data: Data, offs
         return value as! T
     }
     var value: T = 0
-    let _ = withUnsafeMutableBytes(of: &value, { reader.data.copyBytes(to: $0, from: range)})
+    let _ = withUnsafeMutableBytes(of: &value) { reader.data.copyBytes(to: $0, from: range) }
     reader.offset = range.upperBound
     return value.bigEndian
 }
 
 // Reads an arbitrary number of bytes, to be used to read
 // raw bytes, this is useful when lifting strings
-fileprivate func readBytes(_ reader: inout (data: Data, offset: Data.Index), count: Int) throws -> Array<UInt8> {
-    let range = reader.offset..<(reader.offset+count)
+private func readBytes(_ reader: inout (data: Data, offset: Data.Index), count: Int) throws -> [UInt8] {
+    let range = reader.offset ..< (reader.offset + count)
     guard reader.data.count >= range.upperBound else {
         throw UniffiInternalError.bufferOverflow
     }
     var value = [UInt8](repeating: 0, count: count)
-    value.withUnsafeMutableBufferPointer({ buffer in
+    value.withUnsafeMutableBufferPointer { buffer in
         reader.data.copyBytes(to: buffer, from: range)
-    })
+    }
     reader.offset = range.upperBound
     return value
 }
 
 // Reads a float at the current offset.
-fileprivate func readFloat(_ reader: inout (data: Data, offset: Data.Index)) throws -> Float {
-    return Float(bitPattern: try readInt(&reader))
+private func readFloat(_ reader: inout (data: Data, offset: Data.Index)) throws -> Float {
+    return try Float(bitPattern: readInt(&reader))
 }
 
 // Reads a float at the current offset.
-fileprivate func readDouble(_ reader: inout (data: Data, offset: Data.Index)) throws -> Double {
-    return Double(bitPattern: try readInt(&reader))
+private func readDouble(_ reader: inout (data: Data, offset: Data.Index)) throws -> Double {
+    return try Double(bitPattern: readInt(&reader))
 }
 
 // Indicates if the offset has reached the end of the buffer.
-fileprivate func hasRemaining(_ reader: (data: Data, offset: Data.Index)) -> Bool {
+private func hasRemaining(_ reader: (data: Data, offset: Data.Index)) -> Bool {
     return reader.offset < reader.data.count
 }
 
@@ -127,11 +127,11 @@ fileprivate func hasRemaining(_ reader: (data: Data, offset: Data.Index)) -> Boo
 // struct, but we use standalone functions instead in order to make external
 // types work.  See the above discussion on Readers for details.
 
-fileprivate func createWriter() -> [UInt8] {
+private func createWriter() -> [UInt8] {
     return []
 }
 
-fileprivate func writeBytes<S>(_ writer: inout [UInt8], _ byteArr: S) where S: Sequence, S.Element == UInt8 {
+private func writeBytes<S>(_ writer: inout [UInt8], _ byteArr: S) where S: Sequence, S.Element == UInt8 {
     writer.append(contentsOf: byteArr)
 }
 
@@ -139,22 +139,22 @@ fileprivate func writeBytes<S>(_ writer: inout [UInt8], _ byteArr: S) where S: S
 //
 // Warning: make sure what you are trying to write
 // is in the correct type!
-fileprivate func writeInt<T: FixedWidthInteger>(_ writer: inout [UInt8], _ value: T) {
+private func writeInt<T: FixedWidthInteger>(_ writer: inout [UInt8], _ value: T) {
     var value = value.bigEndian
     withUnsafeBytes(of: &value) { writer.append(contentsOf: $0) }
 }
 
-fileprivate func writeFloat(_ writer: inout [UInt8], _ value: Float) {
+private func writeFloat(_ writer: inout [UInt8], _ value: Float) {
     writeInt(&writer, value.bitPattern)
 }
 
-fileprivate func writeDouble(_ writer: inout [UInt8], _ value: Double) {
+private func writeDouble(_ writer: inout [UInt8], _ value: Double) {
     writeInt(&writer, value.bitPattern)
 }
 
 // Protocol for types that transfer other types across the FFI. This is
 // analogous to the Rust trait of the same name.
-fileprivate protocol FfiConverter {
+private protocol FfiConverter {
     associatedtype FfiType
     associatedtype SwiftType
 
@@ -165,7 +165,7 @@ fileprivate protocol FfiConverter {
 }
 
 // Types conforming to `Primitive` pass themselves directly over the FFI.
-fileprivate protocol FfiConverterPrimitive: FfiConverter where FfiType == SwiftType { }
+private protocol FfiConverterPrimitive: FfiConverter where FfiType == SwiftType {}
 
 extension FfiConverterPrimitive {
     public static func lift(_ value: FfiType) throws -> SwiftType {
@@ -179,7 +179,7 @@ extension FfiConverterPrimitive {
 
 // Types conforming to `FfiConverterRustBuffer` lift and lower into a `RustBuffer`.
 // Used for complex types where it's hard to write a custom lift/lower.
-fileprivate protocol FfiConverterRustBuffer: FfiConverter where FfiType == RustBuffer {}
+private protocol FfiConverterRustBuffer: FfiConverter where FfiType == RustBuffer {}
 
 extension FfiConverterRustBuffer {
     public static func lift(_ buf: RustBuffer) throws -> SwiftType {
@@ -193,14 +193,15 @@ extension FfiConverterRustBuffer {
     }
 
     public static func lower(_ value: SwiftType) -> RustBuffer {
-          var writer = createWriter()
-          write(value, into: &writer)
-          return RustBuffer(bytes: writer)
+        var writer = createWriter()
+        write(value, into: &writer)
+        return RustBuffer(bytes: writer)
     }
 }
+
 // An error type for FFI errors. These errors occur at the UniFFI level, not
 // the library level.
-fileprivate enum UniffiInternalError: LocalizedError {
+private enum UniffiInternalError: LocalizedError {
     case bufferOverflow
     case incompleteData
     case unexpectedOptionalTag
@@ -226,24 +227,24 @@ fileprivate enum UniffiInternalError: LocalizedError {
     }
 }
 
-fileprivate extension NSLock {
+private extension NSLock {
     func withLock<T>(f: () throws -> T) rethrows -> T {
-        self.lock()
+        lock()
         defer { self.unlock() }
         return try f()
     }
 }
 
-fileprivate let CALL_SUCCESS: Int8 = 0
-fileprivate let CALL_ERROR: Int8 = 1
-fileprivate let CALL_UNEXPECTED_ERROR: Int8 = 2
-fileprivate let CALL_CANCELLED: Int8 = 3
+private let CALL_SUCCESS: Int8 = 0
+private let CALL_ERROR: Int8 = 1
+private let CALL_UNEXPECTED_ERROR: Int8 = 2
+private let CALL_CANCELLED: Int8 = 3
 
-fileprivate extension RustCallStatus {
+private extension RustCallStatus {
     init() {
         self.init(
             code: CALL_SUCCESS,
-            errorBuf: RustBuffer.init(
+            errorBuf: RustBuffer(
                 capacity: 0,
                 len: 0,
                 data: nil
@@ -259,7 +260,8 @@ private func rustCall<T>(_ callback: (UnsafeMutablePointer<RustCallStatus>) -> T
 
 private func rustCallWithError<T, E: Swift.Error>(
     _ errorHandler: @escaping (RustBuffer) throws -> E,
-    _ callback: (UnsafeMutablePointer<RustCallStatus>) -> T) throws -> T {
+    _ callback: (UnsafeMutablePointer<RustCallStatus>) -> T
+) throws -> T {
     try makeRustCall(callback, errorHandler: errorHandler)
 }
 
@@ -268,7 +270,7 @@ private func makeRustCall<T, E: Swift.Error>(
     errorHandler: ((RustBuffer) throws -> E)?
 ) throws -> T {
     uniffiEnsureInitialized()
-    var callStatus = RustCallStatus.init()
+    var callStatus = RustCallStatus()
     let returnedVal = callback(&callStatus)
     try uniffiCheckCallStatus(callStatus: callStatus, errorHandler: errorHandler)
     return returnedVal
@@ -279,44 +281,44 @@ private func uniffiCheckCallStatus<E: Swift.Error>(
     errorHandler: ((RustBuffer) throws -> E)?
 ) throws {
     switch callStatus.code {
-        case CALL_SUCCESS:
-            return
+    case CALL_SUCCESS:
+        return
 
-        case CALL_ERROR:
-            if let errorHandler = errorHandler {
-                throw try errorHandler(callStatus.errorBuf)
-            } else {
-                callStatus.errorBuf.deallocate()
-                throw UniffiInternalError.unexpectedRustCallError
-            }
+    case CALL_ERROR:
+        if let errorHandler = errorHandler {
+            throw try errorHandler(callStatus.errorBuf)
+        } else {
+            callStatus.errorBuf.deallocate()
+            throw UniffiInternalError.unexpectedRustCallError
+        }
 
-        case CALL_UNEXPECTED_ERROR:
-            // When the rust code sees a panic, it tries to construct a RustBuffer
-            // with the message.  But if that code panics, then it just sends back
-            // an empty buffer.
-            if callStatus.errorBuf.len > 0 {
-                throw UniffiInternalError.rustPanic(try FfiConverterString.lift(callStatus.errorBuf))
-            } else {
-                callStatus.errorBuf.deallocate()
-                throw UniffiInternalError.rustPanic("Rust panic")
-            }
+    case CALL_UNEXPECTED_ERROR:
+        // When the rust code sees a panic, it tries to construct a RustBuffer
+        // with the message.  But if that code panics, then it just sends back
+        // an empty buffer.
+        if callStatus.errorBuf.len > 0 {
+            throw try UniffiInternalError.rustPanic(FfiConverterString.lift(callStatus.errorBuf))
+        } else {
+            callStatus.errorBuf.deallocate()
+            throw UniffiInternalError.rustPanic("Rust panic")
+        }
 
-        case CALL_CANCELLED:
-            fatalError("Cancellation not supported yet")
+    case CALL_CANCELLED:
+        fatalError("Cancellation not supported yet")
 
-        default:
-            throw UniffiInternalError.unexpectedRustCallStatusCode
+    default:
+        throw UniffiInternalError.unexpectedRustCallStatusCode
     }
 }
 
 private func uniffiTraitInterfaceCall<T>(
     callStatus: UnsafeMutablePointer<RustCallStatus>,
     makeCall: () throws -> T,
-    writeReturn: (T) -> ()
+    writeReturn: (T) -> Void
 ) {
     do {
         try writeReturn(makeCall())
-    } catch let error {
+    } catch {
         callStatus.pointee.code = CALL_UNEXPECTED_ERROR
         callStatus.pointee.errorBuf = FfiConverterString.lower(String(describing: error))
     }
@@ -325,7 +327,7 @@ private func uniffiTraitInterfaceCall<T>(
 private func uniffiTraitInterfaceCallWithError<T, E>(
     callStatus: UnsafeMutablePointer<RustCallStatus>,
     makeCall: () throws -> T,
-    writeReturn: (T) -> (),
+    writeReturn: (T) -> Void,
     lowerError: (E) -> RustBuffer
 ) {
     do {
@@ -338,7 +340,8 @@ private func uniffiTraitInterfaceCallWithError<T, E>(
         callStatus.pointee.errorBuf = FfiConverterString.lower(String(describing: error))
     }
 }
-fileprivate class UniffiHandleMap<T> {
+
+private class UniffiHandleMap<T> {
     private var map: [UInt64: T] = [:]
     private let lock = NSLock()
     private var currentHandle: UInt64 = 1
@@ -352,7 +355,7 @@ fileprivate class UniffiHandleMap<T> {
         }
     }
 
-     func get(handle: UInt64) throws -> T {
+    func get(handle: UInt64) throws -> T {
         try lock.withLock {
             guard let obj = map[handle] else {
                 throw UniffiInternalError.unexpectedStaleHandle
@@ -372,17 +375,13 @@ fileprivate class UniffiHandleMap<T> {
     }
 
     var count: Int {
-        get {
-            map.count
-        }
+        map.count
     }
 }
 
-
 // Public interface members begin here.
 
-
-fileprivate struct FfiConverterUInt32: FfiConverterPrimitive {
+private struct FfiConverterUInt32: FfiConverterPrimitive {
     typealias FfiType = UInt32
     typealias SwiftType = UInt32
 
@@ -395,7 +394,7 @@ fileprivate struct FfiConverterUInt32: FfiConverterPrimitive {
     }
 }
 
-fileprivate struct FfiConverterUInt64: FfiConverterPrimitive {
+private struct FfiConverterUInt64: FfiConverterPrimitive {
     typealias FfiType = UInt64
     typealias SwiftType = UInt64
 
@@ -408,7 +407,7 @@ fileprivate struct FfiConverterUInt64: FfiConverterPrimitive {
     }
 }
 
-fileprivate struct FfiConverterBool : FfiConverter {
+private struct FfiConverterBool: FfiConverter {
     typealias FfiType = Int8
     typealias SwiftType = Bool
 
@@ -429,7 +428,7 @@ fileprivate struct FfiConverterBool : FfiConverter {
     }
 }
 
-fileprivate struct FfiConverterString: FfiConverter {
+private struct FfiConverterString: FfiConverter {
     typealias SwiftType = String
     typealias FfiType = RustBuffer
 
@@ -457,7 +456,7 @@ fileprivate struct FfiConverterString: FfiConverter {
 
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> String {
         let len: Int32 = try readInt(&buf)
-        return String(bytes: try readBytes(&buf, count: Int(len)), encoding: String.Encoding.utf8)!
+        return try String(bytes: readBytes(&buf, count: Int(len)), encoding: String.Encoding.utf8)!
     }
 
     public static func write(_ value: String, into buf: inout [UInt8]) {
@@ -467,12 +466,12 @@ fileprivate struct FfiConverterString: FfiConverter {
     }
 }
 
-fileprivate struct FfiConverterData: FfiConverterRustBuffer {
+private struct FfiConverterData: FfiConverterRustBuffer {
     typealias SwiftType = Data
 
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> Data {
         let len: Int32 = try readInt(&buf)
-        return Data(try readBytes(&buf, count: Int(len)))
+        return try Data(readBytes(&buf, count: Int(len)))
     }
 
     public static func write(_ value: Data, into buf: inout [UInt8]) {
@@ -482,7 +481,7 @@ fileprivate struct FfiConverterData: FfiConverterRustBuffer {
     }
 }
 
-fileprivate struct FfiConverterTimestamp: FfiConverterRustBuffer {
+private struct FfiConverterTimestamp: FfiConverterRustBuffer {
     typealias SwiftType = Date
 
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> Date {
@@ -490,10 +489,10 @@ fileprivate struct FfiConverterTimestamp: FfiConverterRustBuffer {
         let nanoseconds: UInt32 = try readInt(&buf)
         if seconds >= 0 {
             let delta = Double(seconds) + (Double(nanoseconds) / 1.0e9)
-            return Date.init(timeIntervalSince1970: delta)
+            return Date(timeIntervalSince1970: delta)
         } else {
             let delta = Double(seconds) - (Double(nanoseconds) / 1.0e9)
-            return Date.init(timeIntervalSince1970: delta)
+            return Date(timeIntervalSince1970: delta)
         }
     }
 
@@ -517,7 +516,7 @@ fileprivate struct FfiConverterTimestamp: FfiConverterRustBuffer {
     }
 }
 
-fileprivate struct FfiConverterDuration: FfiConverterRustBuffer {
+private struct FfiConverterDuration: FfiConverterRustBuffer {
     typealias SwiftType = TimeInterval
 
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> TimeInterval {
@@ -542,18 +541,13 @@ fileprivate struct FfiConverterDuration: FfiConverterRustBuffer {
     }
 }
 
-
-
-
 /**
  * The `progress` method will be called for each `AddProgress` event that is
  * emitted during a `node.blobs_add_from_path`. Use the `AddProgress.type()`
  * method to check the `AddProgressType`
  */
-public protocol AddCallback : AnyObject {
-    
-    func progress(progress: AddProgress) async throws 
-    
+public protocol AddCallback: AnyObject {
+    func progress(progress: AddProgress) async throws
 }
 
 /**
@@ -562,7 +556,8 @@ public protocol AddCallback : AnyObject {
  * method to check the `AddProgressType`
  */
 open class AddCallbackImpl:
-    AddCallback {
+    AddCallback
+{
     fileprivate let pointer: UnsafeMutableRawPointer!
 
     /// Used to instantiate a [FFIObject] without an actual pointer, for fakes in tests, mostly.
@@ -573,7 +568,7 @@ open class AddCallbackImpl:
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-    required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
+    public required init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
 
@@ -582,13 +577,14 @@ open class AddCallbackImpl:
     ///
     /// - Warning:
     ///     Any object instantiated with this constructor cannot be passed to an actual Rust-backed object. Since there isn't a backing [Pointer] the FFI lower functions will crash.
-    public init(noPointer: NoPointer) {
-        self.pointer = nil
+    public init(noPointer _: NoPointer) {
+        pointer = nil
     }
 
     public func uniffiClonePointer() -> UnsafeMutableRawPointer {
         return try! rustCall { uniffi_iroh_ffi_fn_clone_addcallback(self.pointer, $0) }
     }
+
     // No primary constructor declared for this class.
 
     deinit {
@@ -599,28 +595,24 @@ open class AddCallbackImpl:
         try! rustCall { uniffi_iroh_ffi_fn_free_addcallback(pointer, $0) }
     }
 
-    
-
-    
-open func progress(progress: AddProgress)async throws  {
-    return
-        try  await uniffiRustCallAsync(
-            rustFutureFunc: {
-                uniffi_iroh_ffi_fn_method_addcallback_progress(
-                    self.uniffiClonePointer(),
-                    FfiConverterTypeAddProgress.lower(progress)
-                )
-            },
-            pollFunc: ffi_iroh_ffi_rust_future_poll_void,
-            completeFunc: ffi_iroh_ffi_rust_future_complete_void,
-            freeFunc: ffi_iroh_ffi_rust_future_free_void,
-            liftFunc: { $0 },
-            errorHandler: FfiConverterTypeCallbackError.lift
-        )
+    open func progress(progress: AddProgress) async throws {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_addcallback_progress(
+                        self.uniffiClonePointer(),
+                        FfiConverterTypeAddProgress.lower(progress)
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_void,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_void,
+                freeFunc: ffi_iroh_ffi_rust_future_free_void,
+                liftFunc: { $0 },
+                errorHandler: FfiConverterTypeCallbackError.lift
+            )
+    }
 }
-    
 
-}
 // Magic number for the Rust proxy to call using the same mechanism as every other method,
 // to free the callback once it's dropped by Rust.
 private let IDX_CALLBACK_FREE: Int32 = 0
@@ -630,11 +622,10 @@ private let UNIFFI_CALLBACK_ERROR: Int32 = 1
 private let UNIFFI_CALLBACK_UNEXPECTED_ERROR: Int32 = 2
 
 // Put the implementation in a struct so we don't pollute the top-level namespace
-fileprivate struct UniffiCallbackInterfaceAddCallback {
-
+private enum UniffiCallbackInterfaceAddCallback {
     // Create the VTable using a series of closures.
     // Swift automatically converts these into C callback functions.
-    static var vtable: UniffiVTableCallbackInterfaceAddCallback = UniffiVTableCallbackInterfaceAddCallback(
+    static var vtable: UniffiVTableCallbackInterfaceAddCallback = .init(
         progress: { (
             uniffiHandle: UInt64,
             progress: UnsafeMutableRawPointer,
@@ -643,16 +634,16 @@ fileprivate struct UniffiCallbackInterfaceAddCallback {
             uniffiOutReturn: UnsafeMutablePointer<UniffiForeignFuture>
         ) in
             let makeCall = {
-                () async throws -> () in
+                () async throws in
                 guard let uniffiObj = try? FfiConverterTypeAddCallback.handleMap.get(handle: uniffiHandle) else {
                     throw UniffiInternalError.unexpectedStaleHandle
                 }
                 return try await uniffiObj.progress(
-                     progress: try FfiConverterTypeAddProgress.lift(progress)
+                    progress: FfiConverterTypeAddProgress.lift(progress)
                 )
             }
 
-            let uniffiHandleSuccess = { (returnValue: ()) in
+            let uniffiHandleSuccess = { (_: ()) in
                 uniffiFutureCallback(
                     uniffiCallbackData,
                     UniffiForeignFutureStructVoid(
@@ -660,7 +651,7 @@ fileprivate struct UniffiCallbackInterfaceAddCallback {
                     )
                 )
             }
-            let uniffiHandleError = { (statusCode, errorBuf) in
+            let uniffiHandleError = { statusCode, errorBuf in
                 uniffiFutureCallback(
                     uniffiCallbackData,
                     UniffiForeignFutureStructVoid(
@@ -676,7 +667,7 @@ fileprivate struct UniffiCallbackInterfaceAddCallback {
             )
             uniffiOutReturn.pointee = uniffiForeignFuture
         },
-        uniffiFree: { (uniffiHandle: UInt64) -> () in
+        uniffiFree: { (uniffiHandle: UInt64) in
             let result = try? FfiConverterTypeAddCallback.handleMap.remove(handle: uniffiHandle)
             if result == nil {
                 print("Uniffi callback interface AddCallback: handle missing in uniffiFree")
@@ -711,7 +702,7 @@ public struct FfiConverterTypeAddCallback: FfiConverter {
         // The Rust code won't compile if a pointer won't fit in a UInt64.
         // We have to go via `UInt` because that's the thing that's the size of a pointer.
         let ptr = UnsafeMutableRawPointer(bitPattern: UInt(truncatingIfNeeded: v))
-        if (ptr == nil) {
+        if ptr == nil {
             throw UniffiInternalError.unexpectedNullPointer
         }
         return try lift(ptr!)
@@ -724,9 +715,6 @@ public struct FfiConverterTypeAddCallback: FfiConverter {
     }
 }
 
-
-
-
 public func FfiConverterTypeAddCallback_lift(_ pointer: UnsafeMutableRawPointer) throws -> AddCallback {
     return try FfiConverterTypeAddCallback.lift(pointer)
 }
@@ -735,51 +723,47 @@ public func FfiConverterTypeAddCallback_lower(_ value: AddCallback) -> UnsafeMut
     return FfiConverterTypeAddCallback.lower(value)
 }
 
-
-
-
 /**
  * Progress updates for the add operation.
  */
-public protocol AddProgressProtocol : AnyObject {
-    
+public protocol AddProgressProtocol: AnyObject {
     /**
      * Return the `AddProgressAbort`
      */
-    func asAbort()  -> AddProgressAbort
-    
+    func asAbort() -> AddProgressAbort
+
     /**
      * Return the `AddAllDone`
      */
-    func asAllDone()  -> AddProgressAllDone
-    
+    func asAllDone() -> AddProgressAllDone
+
     /**
      * Return the `AddProgressDone` event
      */
-    func asDone()  -> AddProgressDone
-    
+    func asDone() -> AddProgressDone
+
     /**
      * Return the `AddProgressFound` event
      */
-    func asFound()  -> AddProgressFound
-    
+    func asFound() -> AddProgressFound
+
     /**
      * Return the `AddProgressProgress` event
      */
-    func asProgress()  -> AddProgressProgress
-    
+    func asProgress() -> AddProgressProgress
+
     /**
      * Get the type of event
      */
-    func type()  -> AddProgressType
-    
+    func type() -> AddProgressType
 }
 
 /**
  * Progress updates for the add operation.
  */
 open class AddProgress:
-    AddProgressProtocol {
+    AddProgressProtocol
+{
     fileprivate let pointer: UnsafeMutableRawPointer!
 
     /// Used to instantiate a [FFIObject] without an actual pointer, for fakes in tests, mostly.
@@ -790,7 +774,7 @@ open class AddProgress:
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-    required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
+    public required init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
 
@@ -799,13 +783,14 @@ open class AddProgress:
     ///
     /// - Warning:
     ///     Any object instantiated with this constructor cannot be passed to an actual Rust-backed object. Since there isn't a backing [Pointer] the FFI lower functions will crash.
-    public init(noPointer: NoPointer) {
-        self.pointer = nil
+    public init(noPointer _: NoPointer) {
+        pointer = nil
     }
 
     public func uniffiClonePointer() -> UnsafeMutableRawPointer {
         return try! rustCall { uniffi_iroh_ffi_fn_clone_addprogress(self.pointer, $0) }
     }
+
     // No primary constructor declared for this class.
 
     deinit {
@@ -816,74 +801,62 @@ open class AddProgress:
         try! rustCall { uniffi_iroh_ffi_fn_free_addprogress(pointer, $0) }
     }
 
-    
-
-    
     /**
      * Return the `AddProgressAbort`
      */
-open func asAbort() -> AddProgressAbort {
-    return try!  FfiConverterTypeAddProgressAbort.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_addprogress_as_abort(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
+    open func asAbort() -> AddProgressAbort {
+        return try! FfiConverterTypeAddProgressAbort.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_addprogress_as_abort(self.uniffiClonePointer(), $0)
+        })
+    }
+
     /**
      * Return the `AddAllDone`
      */
-open func asAllDone() -> AddProgressAllDone {
-    return try!  FfiConverterTypeAddProgressAllDone.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_addprogress_as_all_done(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
+    open func asAllDone() -> AddProgressAllDone {
+        return try! FfiConverterTypeAddProgressAllDone.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_addprogress_as_all_done(self.uniffiClonePointer(), $0)
+        })
+    }
+
     /**
      * Return the `AddProgressDone` event
      */
-open func asDone() -> AddProgressDone {
-    return try!  FfiConverterTypeAddProgressDone.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_addprogress_as_done(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
+    open func asDone() -> AddProgressDone {
+        return try! FfiConverterTypeAddProgressDone.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_addprogress_as_done(self.uniffiClonePointer(), $0)
+        })
+    }
+
     /**
      * Return the `AddProgressFound` event
      */
-open func asFound() -> AddProgressFound {
-    return try!  FfiConverterTypeAddProgressFound.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_addprogress_as_found(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
+    open func asFound() -> AddProgressFound {
+        return try! FfiConverterTypeAddProgressFound.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_addprogress_as_found(self.uniffiClonePointer(), $0)
+        })
+    }
+
     /**
      * Return the `AddProgressProgress` event
      */
-open func asProgress() -> AddProgressProgress {
-    return try!  FfiConverterTypeAddProgressProgress.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_addprogress_as_progress(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
+    open func asProgress() -> AddProgressProgress {
+        return try! FfiConverterTypeAddProgressProgress.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_addprogress_as_progress(self.uniffiClonePointer(), $0)
+        })
+    }
+
     /**
      * Get the type of event
      */
-open func type() -> AddProgressType {
-    return try!  FfiConverterTypeAddProgressType.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_addprogress_type(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
-
+    open func type() -> AddProgressType {
+        return try! FfiConverterTypeAddProgressType.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_addprogress_type(self.uniffiClonePointer(), $0)
+        })
+    }
 }
 
 public struct FfiConverterTypeAddProgress: FfiConverter {
-
     typealias FfiType = UnsafeMutableRawPointer
     typealias SwiftType = AddProgress
 
@@ -900,7 +873,7 @@ public struct FfiConverterTypeAddProgress: FfiConverter {
         // The Rust code won't compile if a pointer won't fit in a UInt64.
         // We have to go via `UInt` because that's the thing that's the size of a pointer.
         let ptr = UnsafeMutableRawPointer(bitPattern: UInt(truncatingIfNeeded: v))
-        if (ptr == nil) {
+        if ptr == nil {
             throw UniffiInternalError.unexpectedNullPointer
         }
         return try lift(ptr!)
@@ -913,9 +886,6 @@ public struct FfiConverterTypeAddProgress: FfiConverter {
     }
 }
 
-
-
-
 public func FfiConverterTypeAddProgress_lift(_ pointer: UnsafeMutableRawPointer) throws -> AddProgress {
     return try FfiConverterTypeAddProgress.lift(pointer)
 }
@@ -924,21 +894,16 @@ public func FfiConverterTypeAddProgress_lower(_ value: AddProgress) -> UnsafeMut
     return FfiConverterTypeAddProgress.lower(value)
 }
 
-
-
-
 /**
  * Author key to insert entries in a document
  *
  * Internally, an author is a `SigningKey` which is used to sign entries.
  */
-public protocol AuthorProtocol : AnyObject {
-    
+public protocol AuthorProtocol: AnyObject {
     /**
      * Get the [`AuthorId`] of this Author
      */
-    func id()  -> AuthorId
-    
+    func id() -> AuthorId
 }
 
 /**
@@ -948,7 +913,8 @@ public protocol AuthorProtocol : AnyObject {
  */
 open class Author:
     CustomStringConvertible,
-    AuthorProtocol {
+    AuthorProtocol
+{
     fileprivate let pointer: UnsafeMutableRawPointer!
 
     /// Used to instantiate a [FFIObject] without an actual pointer, for fakes in tests, mostly.
@@ -959,7 +925,7 @@ open class Author:
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-    required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
+    public required init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
 
@@ -968,13 +934,14 @@ open class Author:
     ///
     /// - Warning:
     ///     Any object instantiated with this constructor cannot be passed to an actual Rust-backed object. Since there isn't a backing [Pointer] the FFI lower functions will crash.
-    public init(noPointer: NoPointer) {
-        self.pointer = nil
+    public init(noPointer _: NoPointer) {
+        pointer = nil
     }
 
     public func uniffiClonePointer() -> UnsafeMutableRawPointer {
         return try! rustCall { uniffi_iroh_ffi_fn_clone_author(self.pointer, $0) }
     }
+
     // No primary constructor declared for this class.
 
     deinit {
@@ -985,43 +952,36 @@ open class Author:
         try! rustCall { uniffi_iroh_ffi_fn_free_author(pointer, $0) }
     }
 
-    
     /**
      * Get an [`Author`] from a String
      */
-public static func fromString(str: String)throws  -> Author {
-    return try  FfiConverterTypeAuthor.lift(try rustCallWithError(FfiConverterTypeIrohError__as_error.lift) {
-    uniffi_iroh_ffi_fn_constructor_author_from_string(
-        FfiConverterString.lower(str),$0
-    )
-})
-}
-    
+    public static func fromString(str: String) throws -> Author {
+        return try FfiConverterTypeAuthor.lift(rustCallWithError(FfiConverterTypeIrohError__as_error.lift) {
+            uniffi_iroh_ffi_fn_constructor_author_from_string(
+                FfiConverterString.lower(str), $0
+            )
+        })
+    }
 
-    
     /**
      * Get the [`AuthorId`] of this Author
      */
-open func id() -> AuthorId {
-    return try!  FfiConverterTypeAuthorId.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_author_id(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
-    open var description: String {
-        return try!  FfiConverterString.lift(
-            try! rustCall() {
-    uniffi_iroh_ffi_fn_method_author_uniffi_trait_display(self.uniffiClonePointer(),$0
-    )
-}
-        )
+    open func id() -> AuthorId {
+        return try! FfiConverterTypeAuthorId.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_author_id(self.uniffiClonePointer(), $0)
+        })
     }
 
+    open var description: String {
+        return try! FfiConverterString.lift(
+            try! rustCall {
+                uniffi_iroh_ffi_fn_method_author_uniffi_trait_display(self.uniffiClonePointer(), $0)
+            }
+        )
+    }
 }
 
 public struct FfiConverterTypeAuthor: FfiConverter {
-
     typealias FfiType = UnsafeMutableRawPointer
     typealias SwiftType = Author
 
@@ -1038,7 +998,7 @@ public struct FfiConverterTypeAuthor: FfiConverter {
         // The Rust code won't compile if a pointer won't fit in a UInt64.
         // We have to go via `UInt` because that's the thing that's the size of a pointer.
         let ptr = UnsafeMutableRawPointer(bitPattern: UInt(truncatingIfNeeded: v))
-        if (ptr == nil) {
+        if ptr == nil {
             throw UniffiInternalError.unexpectedNullPointer
         }
         return try lift(ptr!)
@@ -1051,9 +1011,6 @@ public struct FfiConverterTypeAuthor: FfiConverter {
     }
 }
 
-
-
-
 public func FfiConverterTypeAuthor_lift(_ pointer: UnsafeMutableRawPointer) throws -> Author {
     return try FfiConverterTypeAuthor.lift(pointer)
 }
@@ -1062,19 +1019,14 @@ public func FfiConverterTypeAuthor_lower(_ value: Author) -> UnsafeMutableRawPoi
     return FfiConverterTypeAuthor.lower(value)
 }
 
-
-
-
 /**
  * Identifier for an [`Author`]
  */
-public protocol AuthorIdProtocol : AnyObject {
-    
+public protocol AuthorIdProtocol: AnyObject {
     /**
      * Returns true when both AuthorId's have the same value
      */
-    func equal(other: AuthorId)  -> Bool
-    
+    func equal(other: AuthorId) -> Bool
 }
 
 /**
@@ -1082,7 +1034,8 @@ public protocol AuthorIdProtocol : AnyObject {
  */
 open class AuthorId:
     CustomStringConvertible,
-    AuthorIdProtocol {
+    AuthorIdProtocol
+{
     fileprivate let pointer: UnsafeMutableRawPointer!
 
     /// Used to instantiate a [FFIObject] without an actual pointer, for fakes in tests, mostly.
@@ -1093,7 +1046,7 @@ open class AuthorId:
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-    required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
+    public required init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
 
@@ -1102,13 +1055,14 @@ open class AuthorId:
     ///
     /// - Warning:
     ///     Any object instantiated with this constructor cannot be passed to an actual Rust-backed object. Since there isn't a backing [Pointer] the FFI lower functions will crash.
-    public init(noPointer: NoPointer) {
-        self.pointer = nil
+    public init(noPointer _: NoPointer) {
+        pointer = nil
     }
 
     public func uniffiClonePointer() -> UnsafeMutableRawPointer {
         return try! rustCall { uniffi_iroh_ffi_fn_clone_authorid(self.pointer, $0) }
     }
+
     // No primary constructor declared for this class.
 
     deinit {
@@ -1119,44 +1073,37 @@ open class AuthorId:
         try! rustCall { uniffi_iroh_ffi_fn_free_authorid(pointer, $0) }
     }
 
-    
     /**
      * Get an [`AuthorId`] from a String.
      */
-public static func fromString(str: String)throws  -> AuthorId {
-    return try  FfiConverterTypeAuthorId.lift(try rustCallWithError(FfiConverterTypeIrohError__as_error.lift) {
-    uniffi_iroh_ffi_fn_constructor_authorid_from_string(
-        FfiConverterString.lower(str),$0
-    )
-})
-}
-    
+    public static func fromString(str: String) throws -> AuthorId {
+        return try FfiConverterTypeAuthorId.lift(rustCallWithError(FfiConverterTypeIrohError__as_error.lift) {
+            uniffi_iroh_ffi_fn_constructor_authorid_from_string(
+                FfiConverterString.lower(str), $0
+            )
+        })
+    }
 
-    
     /**
      * Returns true when both AuthorId's have the same value
      */
-open func equal(other: AuthorId) -> Bool {
-    return try!  FfiConverterBool.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_authorid_equal(self.uniffiClonePointer(),
-        FfiConverterTypeAuthorId.lower(other),$0
-    )
-})
-}
-    
-    open var description: String {
-        return try!  FfiConverterString.lift(
-            try! rustCall() {
-    uniffi_iroh_ffi_fn_method_authorid_uniffi_trait_display(self.uniffiClonePointer(),$0
-    )
-}
-        )
+    open func equal(other: AuthorId) -> Bool {
+        return try! FfiConverterBool.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_authorid_equal(self.uniffiClonePointer(),
+                                                     FfiConverterTypeAuthorId.lower(other), $0)
+        })
     }
 
+    open var description: String {
+        return try! FfiConverterString.lift(
+            try! rustCall {
+                uniffi_iroh_ffi_fn_method_authorid_uniffi_trait_display(self.uniffiClonePointer(), $0)
+            }
+        )
+    }
 }
 
 public struct FfiConverterTypeAuthorId: FfiConverter {
-
     typealias FfiType = UnsafeMutableRawPointer
     typealias SwiftType = AuthorId
 
@@ -1173,7 +1120,7 @@ public struct FfiConverterTypeAuthorId: FfiConverter {
         // The Rust code won't compile if a pointer won't fit in a UInt64.
         // We have to go via `UInt` because that's the thing that's the size of a pointer.
         let ptr = UnsafeMutableRawPointer(bitPattern: UInt(truncatingIfNeeded: v))
-        if (ptr == nil) {
+        if ptr == nil {
             throw UniffiInternalError.unexpectedNullPointer
         }
         return try lift(ptr!)
@@ -1186,9 +1133,6 @@ public struct FfiConverterTypeAuthorId: FfiConverter {
     }
 }
 
-
-
-
 public func FfiConverterTypeAuthorId_lift(_ pointer: UnsafeMutableRawPointer) throws -> AuthorId {
     return try FfiConverterTypeAuthorId.lift(pointer)
 }
@@ -1197,14 +1141,10 @@ public func FfiConverterTypeAuthorId_lower(_ value: AuthorId) -> UnsafeMutableRa
     return FfiConverterTypeAuthorId.lower(value)
 }
 
-
-
-
 /**
  * Iroh authors client.
  */
-public protocol AuthorsProtocol : AnyObject {
-    
+public protocol AuthorsProtocol: AnyObject {
     /**
      * Create a new document author.
      *
@@ -1213,8 +1153,8 @@ public protocol AuthorsProtocol : AnyObject {
      *
      * If you need only a single author, use [`Self::default`].
      */
-    func create() async throws  -> AuthorId
-    
+    func create() async throws -> AuthorId
+
     /**
      * Returns the default document author of this node.
      *
@@ -1223,49 +1163,49 @@ public protocol AuthorsProtocol : AnyObject {
      *
      * The default author can be set with [`Self::set_default`].
      */
-    func `default`() async throws  -> AuthorId
-    
+    func `default`() async throws -> AuthorId
+
     /**
      * Deletes the given author by id.
      *
      * Warning: This permanently removes this author.
      */
-    func delete(author: AuthorId) async throws 
-    
+    func delete(author: AuthorId) async throws
+
     /**
      * Export the given author.
      *
      * Warning: This contains sensitive data.
      */
-    func export(author: AuthorId) async throws  -> Author
-    
+    func export(author: AuthorId) async throws -> Author
+
     /**
      * Import the given author.
      *
      * Warning: This contains sensitive data.
      */
-    func `import`(author: Author) async throws  -> AuthorId
-    
+    func `import`(author: Author) async throws -> AuthorId
+
     /**
      * Import the given author.
      *
      * Warning: This contains sensitive data.
      * `import` is reserved in python.
      */
-    func importAuthor(author: Author) async throws  -> AuthorId
-    
+    func importAuthor(author: Author) async throws -> AuthorId
+
     /**
      * List all the AuthorIds that exist on this node.
      */
-    func list() async throws  -> [AuthorId]
-    
+    func list() async throws -> [AuthorId]
 }
 
 /**
  * Iroh authors client.
  */
 open class Authors:
-    AuthorsProtocol {
+    AuthorsProtocol
+{
     fileprivate let pointer: UnsafeMutableRawPointer!
 
     /// Used to instantiate a [FFIObject] without an actual pointer, for fakes in tests, mostly.
@@ -1276,7 +1216,7 @@ open class Authors:
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-    required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
+    public required init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
 
@@ -1285,13 +1225,14 @@ open class Authors:
     ///
     /// - Warning:
     ///     Any object instantiated with this constructor cannot be passed to an actual Rust-backed object. Since there isn't a backing [Pointer] the FFI lower functions will crash.
-    public init(noPointer: NoPointer) {
-        self.pointer = nil
+    public init(noPointer _: NoPointer) {
+        pointer = nil
     }
 
     public func uniffiClonePointer() -> UnsafeMutableRawPointer {
         return try! rustCall { uniffi_iroh_ffi_fn_clone_authors(self.pointer, $0) }
     }
+
     // No primary constructor declared for this class.
 
     deinit {
@@ -1302,9 +1243,6 @@ open class Authors:
         try! rustCall { uniffi_iroh_ffi_fn_free_authors(pointer, $0) }
     }
 
-    
-
-    
     /**
      * Create a new document author.
      *
@@ -1313,23 +1251,22 @@ open class Authors:
      *
      * If you need only a single author, use [`Self::default`].
      */
-open func create()async throws  -> AuthorId {
-    return
-        try  await uniffiRustCallAsync(
-            rustFutureFunc: {
-                uniffi_iroh_ffi_fn_method_authors_create(
-                    self.uniffiClonePointer()
-                    
-                )
-            },
-            pollFunc: ffi_iroh_ffi_rust_future_poll_pointer,
-            completeFunc: ffi_iroh_ffi_rust_future_complete_pointer,
-            freeFunc: ffi_iroh_ffi_rust_future_free_pointer,
-            liftFunc: FfiConverterTypeAuthorId.lift,
-            errorHandler: FfiConverterTypeIrohError__as_error.lift
-        )
-}
-    
+    open func create() async throws -> AuthorId {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_authors_create(
+                        self.uniffiClonePointer()
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_pointer,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_pointer,
+                freeFunc: ffi_iroh_ffi_rust_future_free_pointer,
+                liftFunc: FfiConverterTypeAuthorId.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
     /**
      * Returns the default document author of this node.
      *
@@ -1338,137 +1275,132 @@ open func create()async throws  -> AuthorId {
      *
      * The default author can be set with [`Self::set_default`].
      */
-open func `default`()async throws  -> AuthorId {
-    return
-        try  await uniffiRustCallAsync(
-            rustFutureFunc: {
-                uniffi_iroh_ffi_fn_method_authors_default(
-                    self.uniffiClonePointer()
-                    
-                )
-            },
-            pollFunc: ffi_iroh_ffi_rust_future_poll_pointer,
-            completeFunc: ffi_iroh_ffi_rust_future_complete_pointer,
-            freeFunc: ffi_iroh_ffi_rust_future_free_pointer,
-            liftFunc: FfiConverterTypeAuthorId.lift,
-            errorHandler: FfiConverterTypeIrohError__as_error.lift
-        )
-}
-    
+    open func `default`() async throws -> AuthorId {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_authors_default(
+                        self.uniffiClonePointer()
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_pointer,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_pointer,
+                freeFunc: ffi_iroh_ffi_rust_future_free_pointer,
+                liftFunc: FfiConverterTypeAuthorId.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
     /**
      * Deletes the given author by id.
      *
      * Warning: This permanently removes this author.
      */
-open func delete(author: AuthorId)async throws  {
-    return
-        try  await uniffiRustCallAsync(
-            rustFutureFunc: {
-                uniffi_iroh_ffi_fn_method_authors_delete(
-                    self.uniffiClonePointer(),
-                    FfiConverterTypeAuthorId.lower(author)
-                )
-            },
-            pollFunc: ffi_iroh_ffi_rust_future_poll_void,
-            completeFunc: ffi_iroh_ffi_rust_future_complete_void,
-            freeFunc: ffi_iroh_ffi_rust_future_free_void,
-            liftFunc: { $0 },
-            errorHandler: FfiConverterTypeIrohError__as_error.lift
-        )
-}
-    
+    open func delete(author: AuthorId) async throws {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_authors_delete(
+                        self.uniffiClonePointer(),
+                        FfiConverterTypeAuthorId.lower(author)
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_void,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_void,
+                freeFunc: ffi_iroh_ffi_rust_future_free_void,
+                liftFunc: { $0 },
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
     /**
      * Export the given author.
      *
      * Warning: This contains sensitive data.
      */
-open func export(author: AuthorId)async throws  -> Author {
-    return
-        try  await uniffiRustCallAsync(
-            rustFutureFunc: {
-                uniffi_iroh_ffi_fn_method_authors_export(
-                    self.uniffiClonePointer(),
-                    FfiConverterTypeAuthorId.lower(author)
-                )
-            },
-            pollFunc: ffi_iroh_ffi_rust_future_poll_pointer,
-            completeFunc: ffi_iroh_ffi_rust_future_complete_pointer,
-            freeFunc: ffi_iroh_ffi_rust_future_free_pointer,
-            liftFunc: FfiConverterTypeAuthor.lift,
-            errorHandler: FfiConverterTypeIrohError__as_error.lift
-        )
-}
-    
+    open func export(author: AuthorId) async throws -> Author {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_authors_export(
+                        self.uniffiClonePointer(),
+                        FfiConverterTypeAuthorId.lower(author)
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_pointer,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_pointer,
+                freeFunc: ffi_iroh_ffi_rust_future_free_pointer,
+                liftFunc: FfiConverterTypeAuthor.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
     /**
      * Import the given author.
      *
      * Warning: This contains sensitive data.
      */
-open func `import`(author: Author)async throws  -> AuthorId {
-    return
-        try  await uniffiRustCallAsync(
-            rustFutureFunc: {
-                uniffi_iroh_ffi_fn_method_authors_import(
-                    self.uniffiClonePointer(),
-                    FfiConverterTypeAuthor.lower(author)
-                )
-            },
-            pollFunc: ffi_iroh_ffi_rust_future_poll_pointer,
-            completeFunc: ffi_iroh_ffi_rust_future_complete_pointer,
-            freeFunc: ffi_iroh_ffi_rust_future_free_pointer,
-            liftFunc: FfiConverterTypeAuthorId.lift,
-            errorHandler: FfiConverterTypeIrohError__as_error.lift
-        )
-}
-    
+    open func `import`(author: Author) async throws -> AuthorId {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_authors_import(
+                        self.uniffiClonePointer(),
+                        FfiConverterTypeAuthor.lower(author)
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_pointer,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_pointer,
+                freeFunc: ffi_iroh_ffi_rust_future_free_pointer,
+                liftFunc: FfiConverterTypeAuthorId.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
     /**
      * Import the given author.
      *
      * Warning: This contains sensitive data.
      * `import` is reserved in python.
      */
-open func importAuthor(author: Author)async throws  -> AuthorId {
-    return
-        try  await uniffiRustCallAsync(
-            rustFutureFunc: {
-                uniffi_iroh_ffi_fn_method_authors_import_author(
-                    self.uniffiClonePointer(),
-                    FfiConverterTypeAuthor.lower(author)
-                )
-            },
-            pollFunc: ffi_iroh_ffi_rust_future_poll_pointer,
-            completeFunc: ffi_iroh_ffi_rust_future_complete_pointer,
-            freeFunc: ffi_iroh_ffi_rust_future_free_pointer,
-            liftFunc: FfiConverterTypeAuthorId.lift,
-            errorHandler: FfiConverterTypeIrohError__as_error.lift
-        )
-}
-    
+    open func importAuthor(author: Author) async throws -> AuthorId {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_authors_import_author(
+                        self.uniffiClonePointer(),
+                        FfiConverterTypeAuthor.lower(author)
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_pointer,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_pointer,
+                freeFunc: ffi_iroh_ffi_rust_future_free_pointer,
+                liftFunc: FfiConverterTypeAuthorId.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
     /**
      * List all the AuthorIds that exist on this node.
      */
-open func list()async throws  -> [AuthorId] {
-    return
-        try  await uniffiRustCallAsync(
-            rustFutureFunc: {
-                uniffi_iroh_ffi_fn_method_authors_list(
-                    self.uniffiClonePointer()
-                    
-                )
-            },
-            pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
-            completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
-            freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
-            liftFunc: FfiConverterSequenceTypeAuthorId.lift,
-            errorHandler: FfiConverterTypeIrohError__as_error.lift
-        )
-}
-    
-
+    open func list() async throws -> [AuthorId] {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_authors_list(
+                        self.uniffiClonePointer()
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
+                freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
+                liftFunc: FfiConverterSequenceTypeAuthorId.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
 }
 
 public struct FfiConverterTypeAuthors: FfiConverter {
-
     typealias FfiType = UnsafeMutableRawPointer
     typealias SwiftType = Authors
 
@@ -1485,7 +1417,7 @@ public struct FfiConverterTypeAuthors: FfiConverter {
         // The Rust code won't compile if a pointer won't fit in a UInt64.
         // We have to go via `UInt` because that's the thing that's the size of a pointer.
         let ptr = UnsafeMutableRawPointer(bitPattern: UInt(truncatingIfNeeded: v))
-        if (ptr == nil) {
+        if ptr == nil {
             throw UniffiInternalError.unexpectedNullPointer
         }
         return try lift(ptr!)
@@ -1498,9 +1430,6 @@ public struct FfiConverterTypeAuthors: FfiConverter {
     }
 }
 
-
-
-
 public func FfiConverterTypeAuthors_lift(_ pointer: UnsafeMutableRawPointer) throws -> Authors {
     return try FfiConverterTypeAuthors.lift(pointer)
 }
@@ -1509,21 +1438,17 @@ public func FfiConverterTypeAuthors_lower(_ value: Authors) -> UnsafeMutableRawP
     return FfiConverterTypeAuthors.lower(value)
 }
 
-
-
-
 /**
  * Options to download  data specified by the hash.
  */
-public protocol BlobDownloadOptionsProtocol : AnyObject {
-    
-}
+public protocol BlobDownloadOptionsProtocol: AnyObject {}
 
 /**
  * Options to download  data specified by the hash.
  */
 open class BlobDownloadOptions:
-    BlobDownloadOptionsProtocol {
+    BlobDownloadOptionsProtocol
+{
     fileprivate let pointer: UnsafeMutableRawPointer!
 
     /// Used to instantiate a [FFIObject] without an actual pointer, for fakes in tests, mostly.
@@ -1534,7 +1459,7 @@ open class BlobDownloadOptions:
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-    required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
+    public required init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
 
@@ -1543,27 +1468,28 @@ open class BlobDownloadOptions:
     ///
     /// - Warning:
     ///     Any object instantiated with this constructor cannot be passed to an actual Rust-backed object. Since there isn't a backing [Pointer] the FFI lower functions will crash.
-    public init(noPointer: NoPointer) {
-        self.pointer = nil
+    public init(noPointer _: NoPointer) {
+        pointer = nil
     }
 
     public func uniffiClonePointer() -> UnsafeMutableRawPointer {
         return try! rustCall { uniffi_iroh_ffi_fn_clone_blobdownloadoptions(self.pointer, $0) }
     }
+
     /**
      * Create a BlobDownloadRequest
      */
-public convenience init(format: BlobFormat, node: NodeAddr, tag: SetTagOption)throws  {
-    let pointer =
-        try rustCallWithError(FfiConverterTypeIrohError__as_error.lift) {
-    uniffi_iroh_ffi_fn_constructor_blobdownloadoptions_new(
-        FfiConverterTypeBlobFormat.lower(format),
-        FfiConverterTypeNodeAddr.lower(node),
-        FfiConverterTypeSetTagOption.lower(tag),$0
-    )
-}
-    self.init(unsafeFromRawPointer: pointer)
-}
+    public convenience init(format: BlobFormat, node: NodeAddr, tag: SetTagOption) throws {
+        let pointer =
+            try rustCallWithError(FfiConverterTypeIrohError__as_error.lift) {
+                uniffi_iroh_ffi_fn_constructor_blobdownloadoptions_new(
+                    FfiConverterTypeBlobFormat.lower(format),
+                    FfiConverterTypeNodeAddr.lower(node),
+                    FfiConverterTypeSetTagOption.lower(tag), $0
+                )
+            }
+        self.init(unsafeFromRawPointer: pointer)
+    }
 
     deinit {
         guard let pointer = pointer else {
@@ -1572,15 +1498,9 @@ public convenience init(format: BlobFormat, node: NodeAddr, tag: SetTagOption)th
 
         try! rustCall { uniffi_iroh_ffi_fn_free_blobdownloadoptions(pointer, $0) }
     }
-
-    
-
-    
-
 }
 
 public struct FfiConverterTypeBlobDownloadOptions: FfiConverter {
-
     typealias FfiType = UnsafeMutableRawPointer
     typealias SwiftType = BlobDownloadOptions
 
@@ -1597,7 +1517,7 @@ public struct FfiConverterTypeBlobDownloadOptions: FfiConverter {
         // The Rust code won't compile if a pointer won't fit in a UInt64.
         // We have to go via `UInt` because that's the thing that's the size of a pointer.
         let ptr = UnsafeMutableRawPointer(bitPattern: UInt(truncatingIfNeeded: v))
-        if (ptr == nil) {
+        if ptr == nil {
             throw UniffiInternalError.unexpectedNullPointer
         }
         return try lift(ptr!)
@@ -1610,9 +1530,6 @@ public struct FfiConverterTypeBlobDownloadOptions: FfiConverter {
     }
 }
 
-
-
-
 public func FfiConverterTypeBlobDownloadOptions_lift(_ pointer: UnsafeMutableRawPointer) throws -> BlobDownloadOptions {
     return try FfiConverterTypeBlobDownloadOptions.lift(pointer)
 }
@@ -1621,41 +1538,36 @@ public func FfiConverterTypeBlobDownloadOptions_lower(_ value: BlobDownloadOptio
     return FfiConverterTypeBlobDownloadOptions.lower(value)
 }
 
-
-
-
 /**
  * A token containing everything to get a file from the provider.
  *
  * It is a single item which can be easily serialized and deserialized.
  */
-public protocol BlobTicketProtocol : AnyObject {
-    
+public protocol BlobTicketProtocol: AnyObject {
     /**
      * Convert this ticket into input parameters for a call to blobs_download
      */
-    func asDownloadOptions()  -> BlobDownloadOptions
-    
+    func asDownloadOptions() -> BlobDownloadOptions
+
     /**
      * The [`BlobFormat`] for this ticket.
      */
-    func format()  -> BlobFormat
-    
+    func format() -> BlobFormat
+
     /**
      * The hash of the item this ticket can retrieve.
      */
-    func hash()  -> Hash
-    
+    func hash() -> Hash
+
     /**
      * The [`NodeAddr`] of the provider for this ticket.
      */
-    func nodeAddr()  -> NodeAddr
-    
+    func nodeAddr() -> NodeAddr
+
     /**
      * True if the ticket is for a collection and should retrieve all blobs in it.
      */
-    func recursive()  -> Bool
-    
+    func recursive() -> Bool
 }
 
 /**
@@ -1664,7 +1576,9 @@ public protocol BlobTicketProtocol : AnyObject {
  * It is a single item which can be easily serialized and deserialized.
  */
 open class BlobTicket:
-    BlobTicketProtocol {
+    CustomStringConvertible,
+    BlobTicketProtocol
+{
     fileprivate let pointer: UnsafeMutableRawPointer!
 
     /// Used to instantiate a [FFIObject] without an actual pointer, for fakes in tests, mostly.
@@ -1675,7 +1589,7 @@ open class BlobTicket:
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-    required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
+    public required init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
 
@@ -1684,22 +1598,23 @@ open class BlobTicket:
     ///
     /// - Warning:
     ///     Any object instantiated with this constructor cannot be passed to an actual Rust-backed object. Since there isn't a backing [Pointer] the FFI lower functions will crash.
-    public init(noPointer: NoPointer) {
-        self.pointer = nil
+    public init(noPointer _: NoPointer) {
+        pointer = nil
     }
 
     public func uniffiClonePointer() -> UnsafeMutableRawPointer {
         return try! rustCall { uniffi_iroh_ffi_fn_clone_blobticket(self.pointer, $0) }
     }
-public convenience init(str: String)throws  {
-    let pointer =
-        try rustCallWithError(FfiConverterTypeIrohError__as_error.lift) {
-    uniffi_iroh_ffi_fn_constructor_blobticket_new(
-        FfiConverterString.lower(str),$0
-    )
-}
-    self.init(unsafeFromRawPointer: pointer)
-}
+
+    public convenience init(str: String) throws {
+        let pointer =
+            try rustCallWithError(FfiConverterTypeIrohError__as_error.lift) {
+                uniffi_iroh_ffi_fn_constructor_blobticket_new(
+                    FfiConverterString.lower(str), $0
+                )
+            }
+        self.init(unsafeFromRawPointer: pointer)
+    }
 
     deinit {
         guard let pointer = pointer else {
@@ -1709,64 +1624,61 @@ public convenience init(str: String)throws  {
         try! rustCall { uniffi_iroh_ffi_fn_free_blobticket(pointer, $0) }
     }
 
-    
-
-    
     /**
      * Convert this ticket into input parameters for a call to blobs_download
      */
-open func asDownloadOptions() -> BlobDownloadOptions {
-    return try!  FfiConverterTypeBlobDownloadOptions.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_blobticket_as_download_options(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
+    open func asDownloadOptions() -> BlobDownloadOptions {
+        return try! FfiConverterTypeBlobDownloadOptions.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_blobticket_as_download_options(self.uniffiClonePointer(), $0)
+        })
+    }
+
     /**
      * The [`BlobFormat`] for this ticket.
      */
-open func format() -> BlobFormat {
-    return try!  FfiConverterTypeBlobFormat.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_blobticket_format(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
+    open func format() -> BlobFormat {
+        return try! FfiConverterTypeBlobFormat.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_blobticket_format(self.uniffiClonePointer(), $0)
+        })
+    }
+
     /**
      * The hash of the item this ticket can retrieve.
      */
-open func hash() -> Hash {
-    return try!  FfiConverterTypeHash.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_blobticket_hash(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
+    open func hash() -> Hash {
+        return try! FfiConverterTypeHash.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_blobticket_hash(self.uniffiClonePointer(), $0)
+        })
+    }
+
     /**
      * The [`NodeAddr`] of the provider for this ticket.
      */
-open func nodeAddr() -> NodeAddr {
-    return try!  FfiConverterTypeNodeAddr.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_blobticket_node_addr(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
+    open func nodeAddr() -> NodeAddr {
+        return try! FfiConverterTypeNodeAddr.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_blobticket_node_addr(self.uniffiClonePointer(), $0)
+        })
+    }
+
     /**
      * True if the ticket is for a collection and should retrieve all blobs in it.
      */
-open func recursive() -> Bool {
-    return try!  FfiConverterBool.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_blobticket_recursive(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
+    open func recursive() -> Bool {
+        return try! FfiConverterBool.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_blobticket_recursive(self.uniffiClonePointer(), $0)
+        })
+    }
 
+    open var description: String {
+        return try! FfiConverterString.lift(
+            try! rustCall {
+                uniffi_iroh_ffi_fn_method_blobticket_uniffi_trait_display(self.uniffiClonePointer(), $0)
+            }
+        )
+    }
 }
 
 public struct FfiConverterTypeBlobTicket: FfiConverter {
-
     typealias FfiType = UnsafeMutableRawPointer
     typealias SwiftType = BlobTicket
 
@@ -1783,7 +1695,7 @@ public struct FfiConverterTypeBlobTicket: FfiConverter {
         // The Rust code won't compile if a pointer won't fit in a UInt64.
         // We have to go via `UInt` because that's the thing that's the size of a pointer.
         let ptr = UnsafeMutableRawPointer(bitPattern: UInt(truncatingIfNeeded: v))
-        if (ptr == nil) {
+        if ptr == nil {
             throw UniffiInternalError.unexpectedNullPointer
         }
         return try lift(ptr!)
@@ -1796,9 +1708,6 @@ public struct FfiConverterTypeBlobTicket: FfiConverter {
     }
 }
 
-
-
-
 public func FfiConverterTypeBlobTicket_lift(_ pointer: UnsafeMutableRawPointer) throws -> BlobTicket {
     return try FfiConverterTypeBlobTicket.lift(pointer)
 }
@@ -1807,24 +1716,20 @@ public func FfiConverterTypeBlobTicket_lower(_ value: BlobTicket) -> UnsafeMutab
     return FfiConverterTypeBlobTicket.lower(value)
 }
 
-
-
-
 /**
  * Iroh blobs client.
  */
-public protocol BlobsProtocol : AnyObject {
-    
+public protocol BlobsProtocol: AnyObject {
     /**
      * Write a blob by passing bytes.
      */
-    func addBytes(bytes: Data) async throws  -> BlobAddOutcome
-    
+    func addBytes(bytes: Data) async throws -> BlobAddOutcome
+
     /**
      * Write a blob by passing bytes, setting an explicit tag name.
      */
-    func addBytesNamed(bytes: Data, name: String) async throws  -> BlobAddOutcome
-    
+    func addBytesNamed(bytes: Data, name: String) async throws -> BlobAddOutcome
+
     /**
      * Import a blob from a filesystem path.
      *
@@ -1833,26 +1738,26 @@ public protocol BlobsProtocol : AnyObject {
      * If `in_place` is true, Iroh will assume that the data will not change and will share it in
      * place without copying to the Iroh data directory.
      */
-    func addFromPath(path: String, inPlace: Bool, tag: SetTagOption, wrap: WrapOption, cb: AddCallback) async throws 
-    
+    func addFromPath(path: String, inPlace: Bool, tag: SetTagOption, wrap: WrapOption, cb: AddCallback) async throws
+
     /**
      * Create a collection from already existing blobs.
      *
      * To automatically clear the tags for the passed in blobs you can set
      * `tags_to_delete` on those tags, and they will be deleted once the collection is created.
      */
-    func createCollection(collection: Collection, tag: SetTagOption, tagsToDelete: [String]) async throws  -> HashAndTag
-    
+    func createCollection(collection: Collection, tag: SetTagOption, tagsToDelete: [String]) async throws -> HashAndTag
+
     /**
      * Delete a blob.
      */
-    func deleteBlob(hash: Hash) async throws 
-    
+    func deleteBlob(hash: Hash) async throws
+
     /**
      * Download a blob from another node and add it to the local database.
      */
-    func download(hash: Hash, opts: BlobDownloadOptions, cb: DownloadCallback) async throws 
-    
+    func download(hash: Hash, opts: BlobDownloadOptions, cb: DownloadCallback) async throws
+
     /**
      * Export a blob from the internal blob store to a path on the node's filesystem.
      *
@@ -1864,37 +1769,37 @@ public protocol BlobsProtocol : AnyObject {
      * The `mode` argument defines if the blob should be copied to the target location or moved out of
      * the internal store into the target location. See [`ExportMode`] for details.
      */
-    func export(hash: Hash, destination: String, format: BlobExportFormat, mode: BlobExportMode) async throws 
-    
+    func export(hash: Hash, destination: String, format: BlobExportFormat, mode: BlobExportMode) async throws
+
     /**
      * Read the content of a collection
      */
-    func getCollection(hash: Hash) async throws  -> Collection
-    
+    func getCollection(hash: Hash) async throws -> Collection
+
     /**
      * List all complete blobs.
      *
      * Note: this allocates for each `BlobListResponse`, if you have many `BlobListReponse`s this may be a prohibitively large list.
      * Please file an [issue](https://github.com/n0-computer/iroh-ffi/issues/new) if you run into this issue
      */
-    func list() async throws  -> [Hash]
-    
+    func list() async throws -> [Hash]
+
     /**
      * List all collections.
      *
      * Note: this allocates for each `BlobListCollectionsResponse`, if you have many `BlobListCollectionsResponse`s this may be a prohibitively large list.
      * Please file an [issue](https://github.com/n0-computer/iroh-ffi/issues/new) if you run into this issue
      */
-    func listCollections() async throws  -> [CollectionInfo]
-    
+    func listCollections() async throws -> [CollectionInfo]
+
     /**
      * List all incomplete (partial) blobs.
      *
      * Note: this allocates for each `BlobListIncompleteResponse`, if you have many `BlobListIncompleteResponse`s this may be a prohibitively large list.
      * Please file an [issue](https://github.com/n0-computer/iroh-ffi/issues/new) if you run into this issue
      */
-    func listIncomplete() async throws  -> [IncompleteBlobInfo]
-    
+    func listIncomplete() async throws -> [IncompleteBlobInfo]
+
     /**
      * Read all bytes of single blob at `offset` for length `len`.
      *
@@ -1902,8 +1807,8 @@ public protocol BlobsProtocol : AnyObject {
      * reading is small. If not sure, use [`Self::blobs_size`] and check the size with
      * before calling [`Self::blobs_read_at_to_bytes`].
      */
-    func readAtToBytes(hash: Hash, offset: UInt64, len: UInt64?) async throws  -> Data
-    
+    func readAtToBytes(hash: Hash, offset: UInt64, len: UInt64?) async throws -> Data
+
     /**
      * Read all bytes of single blob.
      *
@@ -1911,33 +1816,33 @@ public protocol BlobsProtocol : AnyObject {
      * reading is small. If not sure, use [`Self::blobs_size`] and check the size with
      * before calling [`Self::blobs_read_to_bytes`].
      */
-    func readToBytes(hash: Hash) async throws  -> Data
-    
+    func readToBytes(hash: Hash) async throws -> Data
+
     /**
      * Create a ticket for sharing a blob from this node.
      */
-    func share(hash: Hash, blobFormat: BlobFormat, ticketOptions: AddrInfoOptions) async throws  -> String
-    
+    func share(hash: Hash, blobFormat: BlobFormat, ticketOptions: AddrInfoOptions) async throws -> BlobTicket
+
     /**
      * Get the size information on a single blob.
      *
      * Method only exists in FFI
      */
-    func size(hash: Hash) async throws  -> UInt64
-    
+    func size(hash: Hash) async throws -> UInt64
+
     /**
      * Export the blob contents to a file path
      * The `path` field is expected to be the absolute path.
      */
-    func writeToPath(hash: Hash, path: String) async throws 
-    
+    func writeToPath(hash: Hash, path: String) async throws
 }
 
 /**
  * Iroh blobs client.
  */
 open class Blobs:
-    BlobsProtocol {
+    BlobsProtocol
+{
     fileprivate let pointer: UnsafeMutableRawPointer!
 
     /// Used to instantiate a [FFIObject] without an actual pointer, for fakes in tests, mostly.
@@ -1948,7 +1853,7 @@ open class Blobs:
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-    required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
+    public required init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
 
@@ -1957,13 +1862,14 @@ open class Blobs:
     ///
     /// - Warning:
     ///     Any object instantiated with this constructor cannot be passed to an actual Rust-backed object. Since there isn't a backing [Pointer] the FFI lower functions will crash.
-    public init(noPointer: NoPointer) {
-        self.pointer = nil
+    public init(noPointer _: NoPointer) {
+        pointer = nil
     }
 
     public func uniffiClonePointer() -> UnsafeMutableRawPointer {
         return try! rustCall { uniffi_iroh_ffi_fn_clone_blobs(self.pointer, $0) }
     }
+
     // No primary constructor declared for this class.
 
     deinit {
@@ -1974,49 +1880,46 @@ open class Blobs:
         try! rustCall { uniffi_iroh_ffi_fn_free_blobs(pointer, $0) }
     }
 
-    
-
-    
     /**
      * Write a blob by passing bytes.
      */
-open func addBytes(bytes: Data)async throws  -> BlobAddOutcome {
-    return
-        try  await uniffiRustCallAsync(
-            rustFutureFunc: {
-                uniffi_iroh_ffi_fn_method_blobs_add_bytes(
-                    self.uniffiClonePointer(),
-                    FfiConverterData.lower(bytes)
-                )
-            },
-            pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
-            completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
-            freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
-            liftFunc: FfiConverterTypeBlobAddOutcome.lift,
-            errorHandler: FfiConverterTypeIrohError__as_error.lift
-        )
-}
-    
+    open func addBytes(bytes: Data) async throws -> BlobAddOutcome {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_blobs_add_bytes(
+                        self.uniffiClonePointer(),
+                        FfiConverterData.lower(bytes)
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
+                freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
+                liftFunc: FfiConverterTypeBlobAddOutcome.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
     /**
      * Write a blob by passing bytes, setting an explicit tag name.
      */
-open func addBytesNamed(bytes: Data, name: String)async throws  -> BlobAddOutcome {
-    return
-        try  await uniffiRustCallAsync(
-            rustFutureFunc: {
-                uniffi_iroh_ffi_fn_method_blobs_add_bytes_named(
-                    self.uniffiClonePointer(),
-                    FfiConverterData.lower(bytes),FfiConverterString.lower(name)
-                )
-            },
-            pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
-            completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
-            freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
-            liftFunc: FfiConverterTypeBlobAddOutcome.lift,
-            errorHandler: FfiConverterTypeIrohError__as_error.lift
-        )
-}
-    
+    open func addBytesNamed(bytes: Data, name: String) async throws -> BlobAddOutcome {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_blobs_add_bytes_named(
+                        self.uniffiClonePointer(),
+                        FfiConverterData.lower(bytes), FfiConverterString.lower(name)
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
+                freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
+                liftFunc: FfiConverterTypeBlobAddOutcome.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
     /**
      * Import a blob from a filesystem path.
      *
@@ -2025,86 +1928,86 @@ open func addBytesNamed(bytes: Data, name: String)async throws  -> BlobAddOutcom
      * If `in_place` is true, Iroh will assume that the data will not change and will share it in
      * place without copying to the Iroh data directory.
      */
-open func addFromPath(path: String, inPlace: Bool, tag: SetTagOption, wrap: WrapOption, cb: AddCallback)async throws  {
-    return
-        try  await uniffiRustCallAsync(
-            rustFutureFunc: {
-                uniffi_iroh_ffi_fn_method_blobs_add_from_path(
-                    self.uniffiClonePointer(),
-                    FfiConverterString.lower(path),FfiConverterBool.lower(inPlace),FfiConverterTypeSetTagOption.lower(tag),FfiConverterTypeWrapOption.lower(wrap),FfiConverterTypeAddCallback.lower(cb)
-                )
-            },
-            pollFunc: ffi_iroh_ffi_rust_future_poll_void,
-            completeFunc: ffi_iroh_ffi_rust_future_complete_void,
-            freeFunc: ffi_iroh_ffi_rust_future_free_void,
-            liftFunc: { $0 },
-            errorHandler: FfiConverterTypeIrohError__as_error.lift
-        )
-}
-    
+    open func addFromPath(path: String, inPlace: Bool, tag: SetTagOption, wrap: WrapOption, cb: AddCallback) async throws {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_blobs_add_from_path(
+                        self.uniffiClonePointer(),
+                        FfiConverterString.lower(path), FfiConverterBool.lower(inPlace), FfiConverterTypeSetTagOption.lower(tag), FfiConverterTypeWrapOption.lower(wrap), FfiConverterTypeAddCallback.lower(cb)
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_void,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_void,
+                freeFunc: ffi_iroh_ffi_rust_future_free_void,
+                liftFunc: { $0 },
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
     /**
      * Create a collection from already existing blobs.
      *
      * To automatically clear the tags for the passed in blobs you can set
      * `tags_to_delete` on those tags, and they will be deleted once the collection is created.
      */
-open func createCollection(collection: Collection, tag: SetTagOption, tagsToDelete: [String])async throws  -> HashAndTag {
-    return
-        try  await uniffiRustCallAsync(
-            rustFutureFunc: {
-                uniffi_iroh_ffi_fn_method_blobs_create_collection(
-                    self.uniffiClonePointer(),
-                    FfiConverterTypeCollection.lower(collection),FfiConverterTypeSetTagOption.lower(tag),FfiConverterSequenceString.lower(tagsToDelete)
-                )
-            },
-            pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
-            completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
-            freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
-            liftFunc: FfiConverterTypeHashAndTag.lift,
-            errorHandler: FfiConverterTypeIrohError__as_error.lift
-        )
-}
-    
+    open func createCollection(collection: Collection, tag: SetTagOption, tagsToDelete: [String]) async throws -> HashAndTag {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_blobs_create_collection(
+                        self.uniffiClonePointer(),
+                        FfiConverterTypeCollection.lower(collection), FfiConverterTypeSetTagOption.lower(tag), FfiConverterSequenceString.lower(tagsToDelete)
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
+                freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
+                liftFunc: FfiConverterTypeHashAndTag.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
     /**
      * Delete a blob.
      */
-open func deleteBlob(hash: Hash)async throws  {
-    return
-        try  await uniffiRustCallAsync(
-            rustFutureFunc: {
-                uniffi_iroh_ffi_fn_method_blobs_delete_blob(
-                    self.uniffiClonePointer(),
-                    FfiConverterTypeHash.lower(hash)
-                )
-            },
-            pollFunc: ffi_iroh_ffi_rust_future_poll_void,
-            completeFunc: ffi_iroh_ffi_rust_future_complete_void,
-            freeFunc: ffi_iroh_ffi_rust_future_free_void,
-            liftFunc: { $0 },
-            errorHandler: FfiConverterTypeIrohError__as_error.lift
-        )
-}
-    
+    open func deleteBlob(hash: Hash) async throws {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_blobs_delete_blob(
+                        self.uniffiClonePointer(),
+                        FfiConverterTypeHash.lower(hash)
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_void,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_void,
+                freeFunc: ffi_iroh_ffi_rust_future_free_void,
+                liftFunc: { $0 },
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
     /**
      * Download a blob from another node and add it to the local database.
      */
-open func download(hash: Hash, opts: BlobDownloadOptions, cb: DownloadCallback)async throws  {
-    return
-        try  await uniffiRustCallAsync(
-            rustFutureFunc: {
-                uniffi_iroh_ffi_fn_method_blobs_download(
-                    self.uniffiClonePointer(),
-                    FfiConverterTypeHash.lower(hash),FfiConverterTypeBlobDownloadOptions.lower(opts),FfiConverterTypeDownloadCallback.lower(cb)
-                )
-            },
-            pollFunc: ffi_iroh_ffi_rust_future_poll_void,
-            completeFunc: ffi_iroh_ffi_rust_future_complete_void,
-            freeFunc: ffi_iroh_ffi_rust_future_free_void,
-            liftFunc: { $0 },
-            errorHandler: FfiConverterTypeIrohError__as_error.lift
-        )
-}
-    
+    open func download(hash: Hash, opts: BlobDownloadOptions, cb: DownloadCallback) async throws {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_blobs_download(
+                        self.uniffiClonePointer(),
+                        FfiConverterTypeHash.lower(hash), FfiConverterTypeBlobDownloadOptions.lower(opts), FfiConverterTypeDownloadCallback.lower(cb)
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_void,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_void,
+                freeFunc: ffi_iroh_ffi_rust_future_free_void,
+                liftFunc: { $0 },
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
     /**
      * Export a blob from the internal blob store to a path on the node's filesystem.
      *
@@ -2116,112 +2019,109 @@ open func download(hash: Hash, opts: BlobDownloadOptions, cb: DownloadCallback)a
      * The `mode` argument defines if the blob should be copied to the target location or moved out of
      * the internal store into the target location. See [`ExportMode`] for details.
      */
-open func export(hash: Hash, destination: String, format: BlobExportFormat, mode: BlobExportMode)async throws  {
-    return
-        try  await uniffiRustCallAsync(
-            rustFutureFunc: {
-                uniffi_iroh_ffi_fn_method_blobs_export(
-                    self.uniffiClonePointer(),
-                    FfiConverterTypeHash.lower(hash),FfiConverterString.lower(destination),FfiConverterTypeBlobExportFormat.lower(format),FfiConverterTypeBlobExportMode.lower(mode)
-                )
-            },
-            pollFunc: ffi_iroh_ffi_rust_future_poll_void,
-            completeFunc: ffi_iroh_ffi_rust_future_complete_void,
-            freeFunc: ffi_iroh_ffi_rust_future_free_void,
-            liftFunc: { $0 },
-            errorHandler: FfiConverterTypeIrohError__as_error.lift
-        )
-}
-    
+    open func export(hash: Hash, destination: String, format: BlobExportFormat, mode: BlobExportMode) async throws {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_blobs_export(
+                        self.uniffiClonePointer(),
+                        FfiConverterTypeHash.lower(hash), FfiConverterString.lower(destination), FfiConverterTypeBlobExportFormat.lower(format), FfiConverterTypeBlobExportMode.lower(mode)
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_void,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_void,
+                freeFunc: ffi_iroh_ffi_rust_future_free_void,
+                liftFunc: { $0 },
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
     /**
      * Read the content of a collection
      */
-open func getCollection(hash: Hash)async throws  -> Collection {
-    return
-        try  await uniffiRustCallAsync(
-            rustFutureFunc: {
-                uniffi_iroh_ffi_fn_method_blobs_get_collection(
-                    self.uniffiClonePointer(),
-                    FfiConverterTypeHash.lower(hash)
-                )
-            },
-            pollFunc: ffi_iroh_ffi_rust_future_poll_pointer,
-            completeFunc: ffi_iroh_ffi_rust_future_complete_pointer,
-            freeFunc: ffi_iroh_ffi_rust_future_free_pointer,
-            liftFunc: FfiConverterTypeCollection.lift,
-            errorHandler: FfiConverterTypeIrohError__as_error.lift
-        )
-}
-    
+    open func getCollection(hash: Hash) async throws -> Collection {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_blobs_get_collection(
+                        self.uniffiClonePointer(),
+                        FfiConverterTypeHash.lower(hash)
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_pointer,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_pointer,
+                freeFunc: ffi_iroh_ffi_rust_future_free_pointer,
+                liftFunc: FfiConverterTypeCollection.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
     /**
      * List all complete blobs.
      *
      * Note: this allocates for each `BlobListResponse`, if you have many `BlobListReponse`s this may be a prohibitively large list.
      * Please file an [issue](https://github.com/n0-computer/iroh-ffi/issues/new) if you run into this issue
      */
-open func list()async throws  -> [Hash] {
-    return
-        try  await uniffiRustCallAsync(
-            rustFutureFunc: {
-                uniffi_iroh_ffi_fn_method_blobs_list(
-                    self.uniffiClonePointer()
-                    
-                )
-            },
-            pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
-            completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
-            freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
-            liftFunc: FfiConverterSequenceTypeHash.lift,
-            errorHandler: FfiConverterTypeIrohError__as_error.lift
-        )
-}
-    
+    open func list() async throws -> [Hash] {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_blobs_list(
+                        self.uniffiClonePointer()
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
+                freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
+                liftFunc: FfiConverterSequenceTypeHash.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
     /**
      * List all collections.
      *
      * Note: this allocates for each `BlobListCollectionsResponse`, if you have many `BlobListCollectionsResponse`s this may be a prohibitively large list.
      * Please file an [issue](https://github.com/n0-computer/iroh-ffi/issues/new) if you run into this issue
      */
-open func listCollections()async throws  -> [CollectionInfo] {
-    return
-        try  await uniffiRustCallAsync(
-            rustFutureFunc: {
-                uniffi_iroh_ffi_fn_method_blobs_list_collections(
-                    self.uniffiClonePointer()
-                    
-                )
-            },
-            pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
-            completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
-            freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
-            liftFunc: FfiConverterSequenceTypeCollectionInfo.lift,
-            errorHandler: FfiConverterTypeIrohError__as_error.lift
-        )
-}
-    
+    open func listCollections() async throws -> [CollectionInfo] {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_blobs_list_collections(
+                        self.uniffiClonePointer()
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
+                freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
+                liftFunc: FfiConverterSequenceTypeCollectionInfo.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
     /**
      * List all incomplete (partial) blobs.
      *
      * Note: this allocates for each `BlobListIncompleteResponse`, if you have many `BlobListIncompleteResponse`s this may be a prohibitively large list.
      * Please file an [issue](https://github.com/n0-computer/iroh-ffi/issues/new) if you run into this issue
      */
-open func listIncomplete()async throws  -> [IncompleteBlobInfo] {
-    return
-        try  await uniffiRustCallAsync(
-            rustFutureFunc: {
-                uniffi_iroh_ffi_fn_method_blobs_list_incomplete(
-                    self.uniffiClonePointer()
-                    
-                )
-            },
-            pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
-            completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
-            freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
-            liftFunc: FfiConverterSequenceTypeIncompleteBlobInfo.lift,
-            errorHandler: FfiConverterTypeIrohError__as_error.lift
-        )
-}
-    
+    open func listIncomplete() async throws -> [IncompleteBlobInfo] {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_blobs_list_incomplete(
+                        self.uniffiClonePointer()
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
+                freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
+                liftFunc: FfiConverterSequenceTypeIncompleteBlobInfo.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
     /**
      * Read all bytes of single blob at `offset` for length `len`.
      *
@@ -2229,23 +2129,23 @@ open func listIncomplete()async throws  -> [IncompleteBlobInfo] {
      * reading is small. If not sure, use [`Self::blobs_size`] and check the size with
      * before calling [`Self::blobs_read_at_to_bytes`].
      */
-open func readAtToBytes(hash: Hash, offset: UInt64, len: UInt64?)async throws  -> Data {
-    return
-        try  await uniffiRustCallAsync(
-            rustFutureFunc: {
-                uniffi_iroh_ffi_fn_method_blobs_read_at_to_bytes(
-                    self.uniffiClonePointer(),
-                    FfiConverterTypeHash.lower(hash),FfiConverterUInt64.lower(offset),FfiConverterOptionUInt64.lower(len)
-                )
-            },
-            pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
-            completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
-            freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
-            liftFunc: FfiConverterData.lift,
-            errorHandler: FfiConverterTypeIrohError__as_error.lift
-        )
-}
-    
+    open func readAtToBytes(hash: Hash, offset: UInt64, len: UInt64?) async throws -> Data {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_blobs_read_at_to_bytes(
+                        self.uniffiClonePointer(),
+                        FfiConverterTypeHash.lower(hash), FfiConverterUInt64.lower(offset), FfiConverterOptionUInt64.lower(len)
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
+                freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
+                liftFunc: FfiConverterData.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
     /**
      * Read all bytes of single blob.
      *
@@ -2253,91 +2153,88 @@ open func readAtToBytes(hash: Hash, offset: UInt64, len: UInt64?)async throws  -
      * reading is small. If not sure, use [`Self::blobs_size`] and check the size with
      * before calling [`Self::blobs_read_to_bytes`].
      */
-open func readToBytes(hash: Hash)async throws  -> Data {
-    return
-        try  await uniffiRustCallAsync(
-            rustFutureFunc: {
-                uniffi_iroh_ffi_fn_method_blobs_read_to_bytes(
-                    self.uniffiClonePointer(),
-                    FfiConverterTypeHash.lower(hash)
-                )
-            },
-            pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
-            completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
-            freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
-            liftFunc: FfiConverterData.lift,
-            errorHandler: FfiConverterTypeIrohError__as_error.lift
-        )
-}
-    
+    open func readToBytes(hash: Hash) async throws -> Data {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_blobs_read_to_bytes(
+                        self.uniffiClonePointer(),
+                        FfiConverterTypeHash.lower(hash)
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
+                freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
+                liftFunc: FfiConverterData.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
     /**
      * Create a ticket for sharing a blob from this node.
      */
-open func share(hash: Hash, blobFormat: BlobFormat, ticketOptions: AddrInfoOptions)async throws  -> String {
-    return
-        try  await uniffiRustCallAsync(
-            rustFutureFunc: {
-                uniffi_iroh_ffi_fn_method_blobs_share(
-                    self.uniffiClonePointer(),
-                    FfiConverterTypeHash.lower(hash),FfiConverterTypeBlobFormat.lower(blobFormat),FfiConverterTypeAddrInfoOptions.lower(ticketOptions)
-                )
-            },
-            pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
-            completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
-            freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
-            liftFunc: FfiConverterString.lift,
-            errorHandler: FfiConverterTypeIrohError__as_error.lift
-        )
-}
-    
+    open func share(hash: Hash, blobFormat: BlobFormat, ticketOptions: AddrInfoOptions) async throws -> BlobTicket {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_blobs_share(
+                        self.uniffiClonePointer(),
+                        FfiConverterTypeHash.lower(hash), FfiConverterTypeBlobFormat.lower(blobFormat), FfiConverterTypeAddrInfoOptions.lower(ticketOptions)
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_pointer,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_pointer,
+                freeFunc: ffi_iroh_ffi_rust_future_free_pointer,
+                liftFunc: FfiConverterTypeBlobTicket.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
     /**
      * Get the size information on a single blob.
      *
      * Method only exists in FFI
      */
-open func size(hash: Hash)async throws  -> UInt64 {
-    return
-        try  await uniffiRustCallAsync(
-            rustFutureFunc: {
-                uniffi_iroh_ffi_fn_method_blobs_size(
-                    self.uniffiClonePointer(),
-                    FfiConverterTypeHash.lower(hash)
-                )
-            },
-            pollFunc: ffi_iroh_ffi_rust_future_poll_u64,
-            completeFunc: ffi_iroh_ffi_rust_future_complete_u64,
-            freeFunc: ffi_iroh_ffi_rust_future_free_u64,
-            liftFunc: FfiConverterUInt64.lift,
-            errorHandler: FfiConverterTypeIrohError__as_error.lift
-        )
-}
-    
+    open func size(hash: Hash) async throws -> UInt64 {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_blobs_size(
+                        self.uniffiClonePointer(),
+                        FfiConverterTypeHash.lower(hash)
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_u64,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_u64,
+                freeFunc: ffi_iroh_ffi_rust_future_free_u64,
+                liftFunc: FfiConverterUInt64.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
     /**
      * Export the blob contents to a file path
      * The `path` field is expected to be the absolute path.
      */
-open func writeToPath(hash: Hash, path: String)async throws  {
-    return
-        try  await uniffiRustCallAsync(
-            rustFutureFunc: {
-                uniffi_iroh_ffi_fn_method_blobs_write_to_path(
-                    self.uniffiClonePointer(),
-                    FfiConverterTypeHash.lower(hash),FfiConverterString.lower(path)
-                )
-            },
-            pollFunc: ffi_iroh_ffi_rust_future_poll_void,
-            completeFunc: ffi_iroh_ffi_rust_future_complete_void,
-            freeFunc: ffi_iroh_ffi_rust_future_free_void,
-            liftFunc: { $0 },
-            errorHandler: FfiConverterTypeIrohError__as_error.lift
-        )
-}
-    
-
+    open func writeToPath(hash: Hash, path: String) async throws {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_blobs_write_to_path(
+                        self.uniffiClonePointer(),
+                        FfiConverterTypeHash.lower(hash), FfiConverterString.lower(path)
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_void,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_void,
+                freeFunc: ffi_iroh_ffi_rust_future_free_void,
+                liftFunc: { $0 },
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
 }
 
 public struct FfiConverterTypeBlobs: FfiConverter {
-
     typealias FfiType = UnsafeMutableRawPointer
     typealias SwiftType = Blobs
 
@@ -2354,7 +2251,7 @@ public struct FfiConverterTypeBlobs: FfiConverter {
         // The Rust code won't compile if a pointer won't fit in a UInt64.
         // We have to go via `UInt` because that's the thing that's the size of a pointer.
         let ptr = UnsafeMutableRawPointer(bitPattern: UInt(truncatingIfNeeded: v))
-        if (ptr == nil) {
+        if ptr == nil {
             throw UniffiInternalError.unexpectedNullPointer
         }
         return try lift(ptr!)
@@ -2367,9 +2264,6 @@ public struct FfiConverterTypeBlobs: FfiConverter {
     }
 }
 
-
-
-
 public func FfiConverterTypeBlobs_lift(_ pointer: UnsafeMutableRawPointer) throws -> Blobs {
     return try FfiConverterTypeBlobs.lift(pointer)
 }
@@ -2378,51 +2272,47 @@ public func FfiConverterTypeBlobs_lower(_ value: Blobs) -> UnsafeMutableRawPoint
     return FfiConverterTypeBlobs.lower(value)
 }
 
-
-
-
 /**
  * A collection of blobs
  */
-public protocol CollectionProtocol : AnyObject {
-    
+public protocol CollectionProtocol: AnyObject {
     /**
      * Get the blobs associated with this collection
      */
-    func blobs() throws  -> [LinkAndName]
-    
+    func blobs() throws -> [LinkAndName]
+
     /**
      * Check if the collection is empty
      */
-    func isEmpty() throws  -> Bool
-    
+    func isEmpty() throws -> Bool
+
     /**
      * Returns the number of blobs in this collection
      */
-    func len() throws  -> UInt64
-    
+    func len() throws -> UInt64
+
     /**
      * Get the links to the blobs in this collection
      */
-    func links() throws  -> [Hash]
-    
+    func links() throws -> [Hash]
+
     /**
      * Get the names of the blobs in this collection
      */
-    func names() throws  -> [String]
-    
+    func names() throws -> [String]
+
     /**
      * Add the given blob to the collection
      */
-    func push(name: String, hash: Hash) throws 
-    
+    func push(name: String, hash: Hash) throws
 }
 
 /**
  * A collection of blobs
  */
 open class Collection:
-    CollectionProtocol {
+    CollectionProtocol
+{
     fileprivate let pointer: UnsafeMutableRawPointer!
 
     /// Used to instantiate a [FFIObject] without an actual pointer, for fakes in tests, mostly.
@@ -2433,7 +2323,7 @@ open class Collection:
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-    required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
+    public required init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
 
@@ -2442,24 +2332,25 @@ open class Collection:
     ///
     /// - Warning:
     ///     Any object instantiated with this constructor cannot be passed to an actual Rust-backed object. Since there isn't a backing [Pointer] the FFI lower functions will crash.
-    public init(noPointer: NoPointer) {
-        self.pointer = nil
+    public init(noPointer _: NoPointer) {
+        pointer = nil
     }
 
     public func uniffiClonePointer() -> UnsafeMutableRawPointer {
         return try! rustCall { uniffi_iroh_ffi_fn_clone_collection(self.pointer, $0) }
     }
+
     /**
      * Create a new empty collection
      */
-public convenience init() {
-    let pointer =
-        try! rustCall() {
-    uniffi_iroh_ffi_fn_constructor_collection_new($0
-    )
-}
-    self.init(unsafeFromRawPointer: pointer)
-}
+    public convenience init() {
+        let pointer =
+            try! rustCall {
+                uniffi_iroh_ffi_fn_constructor_collection_new($0
+                )
+            }
+        self.init(unsafeFromRawPointer: pointer)
+    }
 
     deinit {
         guard let pointer = pointer else {
@@ -2469,75 +2360,63 @@ public convenience init() {
         try! rustCall { uniffi_iroh_ffi_fn_free_collection(pointer, $0) }
     }
 
-    
-
-    
     /**
      * Get the blobs associated with this collection
      */
-open func blobs()throws  -> [LinkAndName] {
-    return try  FfiConverterSequenceTypeLinkAndName.lift(try rustCallWithError(FfiConverterTypeIrohError__as_error.lift) {
-    uniffi_iroh_ffi_fn_method_collection_blobs(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
+    open func blobs() throws -> [LinkAndName] {
+        return try FfiConverterSequenceTypeLinkAndName.lift(rustCallWithError(FfiConverterTypeIrohError__as_error.lift) {
+            uniffi_iroh_ffi_fn_method_collection_blobs(self.uniffiClonePointer(), $0)
+        })
+    }
+
     /**
      * Check if the collection is empty
      */
-open func isEmpty()throws  -> Bool {
-    return try  FfiConverterBool.lift(try rustCallWithError(FfiConverterTypeIrohError__as_error.lift) {
-    uniffi_iroh_ffi_fn_method_collection_is_empty(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
+    open func isEmpty() throws -> Bool {
+        return try FfiConverterBool.lift(rustCallWithError(FfiConverterTypeIrohError__as_error.lift) {
+            uniffi_iroh_ffi_fn_method_collection_is_empty(self.uniffiClonePointer(), $0)
+        })
+    }
+
     /**
      * Returns the number of blobs in this collection
      */
-open func len()throws  -> UInt64 {
-    return try  FfiConverterUInt64.lift(try rustCallWithError(FfiConverterTypeIrohError__as_error.lift) {
-    uniffi_iroh_ffi_fn_method_collection_len(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
+    open func len() throws -> UInt64 {
+        return try FfiConverterUInt64.lift(rustCallWithError(FfiConverterTypeIrohError__as_error.lift) {
+            uniffi_iroh_ffi_fn_method_collection_len(self.uniffiClonePointer(), $0)
+        })
+    }
+
     /**
      * Get the links to the blobs in this collection
      */
-open func links()throws  -> [Hash] {
-    return try  FfiConverterSequenceTypeHash.lift(try rustCallWithError(FfiConverterTypeIrohError__as_error.lift) {
-    uniffi_iroh_ffi_fn_method_collection_links(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
+    open func links() throws -> [Hash] {
+        return try FfiConverterSequenceTypeHash.lift(rustCallWithError(FfiConverterTypeIrohError__as_error.lift) {
+            uniffi_iroh_ffi_fn_method_collection_links(self.uniffiClonePointer(), $0)
+        })
+    }
+
     /**
      * Get the names of the blobs in this collection
      */
-open func names()throws  -> [String] {
-    return try  FfiConverterSequenceString.lift(try rustCallWithError(FfiConverterTypeIrohError__as_error.lift) {
-    uniffi_iroh_ffi_fn_method_collection_names(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
+    open func names() throws -> [String] {
+        return try FfiConverterSequenceString.lift(rustCallWithError(FfiConverterTypeIrohError__as_error.lift) {
+            uniffi_iroh_ffi_fn_method_collection_names(self.uniffiClonePointer(), $0)
+        })
+    }
+
     /**
      * Add the given blob to the collection
      */
-open func push(name: String, hash: Hash)throws  {try rustCallWithError(FfiConverterTypeIrohError__as_error.lift) {
-    uniffi_iroh_ffi_fn_method_collection_push(self.uniffiClonePointer(),
-        FfiConverterString.lower(name),
-        FfiConverterTypeHash.lower(hash),$0
-    )
-}
-}
-    
-
+    open func push(name: String, hash: Hash) throws { try rustCallWithError(FfiConverterTypeIrohError__as_error.lift) {
+        uniffi_iroh_ffi_fn_method_collection_push(self.uniffiClonePointer(),
+                                                  FfiConverterString.lower(name),
+                                                  FfiConverterTypeHash.lower(hash), $0)
+    }
+    }
 }
 
 public struct FfiConverterTypeCollection: FfiConverter {
-
     typealias FfiType = UnsafeMutableRawPointer
     typealias SwiftType = Collection
 
@@ -2554,7 +2433,7 @@ public struct FfiConverterTypeCollection: FfiConverter {
         // The Rust code won't compile if a pointer won't fit in a UInt64.
         // We have to go via `UInt` because that's the thing that's the size of a pointer.
         let ptr = UnsafeMutableRawPointer(bitPattern: UInt(truncatingIfNeeded: v))
-        if (ptr == nil) {
+        if ptr == nil {
             throw UniffiInternalError.unexpectedNullPointer
         }
         return try lift(ptr!)
@@ -2567,9 +2446,6 @@ public struct FfiConverterTypeCollection: FfiConverter {
     }
 }
 
-
-
-
 public func FfiConverterTypeCollection_lift(_ pointer: UnsafeMutableRawPointer) throws -> Collection {
     return try FfiConverterTypeCollection.lift(pointer)
 }
@@ -2578,41 +2454,37 @@ public func FfiConverterTypeCollection_lower(_ value: Collection) -> UnsafeMutab
     return FfiConverterTypeCollection.lower(value)
 }
 
-
-
-
 /**
  * The type of connection we have to the node
  */
-public protocol ConnectionTypeProtocol : AnyObject {
-    
+public protocol ConnectionTypeProtocol: AnyObject {
     /**
      * Return the socket address if this is a direct connection
      */
-    func asDirect()  -> String
-    
+    func asDirect() -> String
+
     /**
      * Return the socket address and DERP url if this is a mixed connection
      */
-    func asMixed()  -> ConnectionTypeMixed
-    
+    func asMixed() -> ConnectionTypeMixed
+
     /**
      * Return the derp url if this is a relay connection
      */
-    func asRelay()  -> String
-    
+    func asRelay() -> String
+
     /**
      * Whether connection is direct, relay, mixed, or none
      */
-    func type()  -> ConnType
-    
+    func type() -> ConnType
 }
 
 /**
  * The type of connection we have to the node
  */
 open class ConnectionType:
-    ConnectionTypeProtocol {
+    ConnectionTypeProtocol
+{
     fileprivate let pointer: UnsafeMutableRawPointer!
 
     /// Used to instantiate a [FFIObject] without an actual pointer, for fakes in tests, mostly.
@@ -2623,7 +2495,7 @@ open class ConnectionType:
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-    required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
+    public required init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
 
@@ -2632,13 +2504,14 @@ open class ConnectionType:
     ///
     /// - Warning:
     ///     Any object instantiated with this constructor cannot be passed to an actual Rust-backed object. Since there isn't a backing [Pointer] the FFI lower functions will crash.
-    public init(noPointer: NoPointer) {
-        self.pointer = nil
+    public init(noPointer _: NoPointer) {
+        pointer = nil
     }
 
     public func uniffiClonePointer() -> UnsafeMutableRawPointer {
         return try! rustCall { uniffi_iroh_ffi_fn_clone_connectiontype(self.pointer, $0) }
     }
+
     // No primary constructor declared for this class.
 
     deinit {
@@ -2649,54 +2522,44 @@ open class ConnectionType:
         try! rustCall { uniffi_iroh_ffi_fn_free_connectiontype(pointer, $0) }
     }
 
-    
-
-    
     /**
      * Return the socket address if this is a direct connection
      */
-open func asDirect() -> String {
-    return try!  FfiConverterString.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_connectiontype_as_direct(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
+    open func asDirect() -> String {
+        return try! FfiConverterString.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_connectiontype_as_direct(self.uniffiClonePointer(), $0)
+        })
+    }
+
     /**
      * Return the socket address and DERP url if this is a mixed connection
      */
-open func asMixed() -> ConnectionTypeMixed {
-    return try!  FfiConverterTypeConnectionTypeMixed.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_connectiontype_as_mixed(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
+    open func asMixed() -> ConnectionTypeMixed {
+        return try! FfiConverterTypeConnectionTypeMixed.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_connectiontype_as_mixed(self.uniffiClonePointer(), $0)
+        })
+    }
+
     /**
      * Return the derp url if this is a relay connection
      */
-open func asRelay() -> String {
-    return try!  FfiConverterString.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_connectiontype_as_relay(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
+    open func asRelay() -> String {
+        return try! FfiConverterString.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_connectiontype_as_relay(self.uniffiClonePointer(), $0)
+        })
+    }
+
     /**
      * Whether connection is direct, relay, mixed, or none
      */
-open func type() -> ConnType {
-    return try!  FfiConverterTypeConnType.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_connectiontype_type(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
-
+    open func type() -> ConnType {
+        return try! FfiConverterTypeConnType.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_connectiontype_type(self.uniffiClonePointer(), $0)
+        })
+    }
 }
 
 public struct FfiConverterTypeConnectionType: FfiConverter {
-
     typealias FfiType = UnsafeMutableRawPointer
     typealias SwiftType = ConnectionType
 
@@ -2713,7 +2576,7 @@ public struct FfiConverterTypeConnectionType: FfiConverter {
         // The Rust code won't compile if a pointer won't fit in a UInt64.
         // We have to go via `UInt` because that's the thing that's the size of a pointer.
         let ptr = UnsafeMutableRawPointer(bitPattern: UInt(truncatingIfNeeded: v))
-        if (ptr == nil) {
+        if ptr == nil {
             throw UniffiInternalError.unexpectedNullPointer
         }
         return try lift(ptr!)
@@ -2726,9 +2589,6 @@ public struct FfiConverterTypeConnectionType: FfiConverter {
     }
 }
 
-
-
-
 public func FfiConverterTypeConnectionType_lift(_ pointer: UnsafeMutableRawPointer) throws -> ConnectionType {
     return try FfiConverterTypeConnectionType.lift(pointer)
 }
@@ -2737,41 +2597,37 @@ public func FfiConverterTypeConnectionType_lower(_ value: ConnectionType) -> Uns
     return FfiConverterTypeConnectionType.lower(value)
 }
 
-
-
-
 /**
  * Information about a direct address.
  */
-public protocol DirectAddrInfoProtocol : AnyObject {
-    
+public protocol DirectAddrInfoProtocol: AnyObject {
     /**
      * Get the reported address
      */
-    func addr()  -> String
-    
+    func addr() -> String
+
     /**
      * Get the last control message received by this node
      */
-    func lastControl()  -> LatencyAndControlMsg?
-    
+    func lastControl() -> LatencyAndControlMsg?
+
     /**
      * Get how long ago the last payload message was received for this node
      */
-    func lastPayload()  -> TimeInterval?
-    
+    func lastPayload() -> TimeInterval?
+
     /**
      * Get the reported latency, if it exists
      */
-    func latency()  -> TimeInterval?
-    
+    func latency() -> TimeInterval?
 }
 
 /**
  * Information about a direct address.
  */
 open class DirectAddrInfo:
-    DirectAddrInfoProtocol {
+    DirectAddrInfoProtocol
+{
     fileprivate let pointer: UnsafeMutableRawPointer!
 
     /// Used to instantiate a [FFIObject] without an actual pointer, for fakes in tests, mostly.
@@ -2782,7 +2638,7 @@ open class DirectAddrInfo:
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-    required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
+    public required init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
 
@@ -2791,13 +2647,14 @@ open class DirectAddrInfo:
     ///
     /// - Warning:
     ///     Any object instantiated with this constructor cannot be passed to an actual Rust-backed object. Since there isn't a backing [Pointer] the FFI lower functions will crash.
-    public init(noPointer: NoPointer) {
-        self.pointer = nil
+    public init(noPointer _: NoPointer) {
+        pointer = nil
     }
 
     public func uniffiClonePointer() -> UnsafeMutableRawPointer {
         return try! rustCall { uniffi_iroh_ffi_fn_clone_directaddrinfo(self.pointer, $0) }
     }
+
     // No primary constructor declared for this class.
 
     deinit {
@@ -2808,54 +2665,44 @@ open class DirectAddrInfo:
         try! rustCall { uniffi_iroh_ffi_fn_free_directaddrinfo(pointer, $0) }
     }
 
-    
-
-    
     /**
      * Get the reported address
      */
-open func addr() -> String {
-    return try!  FfiConverterString.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_directaddrinfo_addr(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
+    open func addr() -> String {
+        return try! FfiConverterString.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_directaddrinfo_addr(self.uniffiClonePointer(), $0)
+        })
+    }
+
     /**
      * Get the last control message received by this node
      */
-open func lastControl() -> LatencyAndControlMsg? {
-    return try!  FfiConverterOptionTypeLatencyAndControlMsg.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_directaddrinfo_last_control(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
+    open func lastControl() -> LatencyAndControlMsg? {
+        return try! FfiConverterOptionTypeLatencyAndControlMsg.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_directaddrinfo_last_control(self.uniffiClonePointer(), $0)
+        })
+    }
+
     /**
      * Get how long ago the last payload message was received for this node
      */
-open func lastPayload() -> TimeInterval? {
-    return try!  FfiConverterOptionDuration.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_directaddrinfo_last_payload(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
+    open func lastPayload() -> TimeInterval? {
+        return try! FfiConverterOptionDuration.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_directaddrinfo_last_payload(self.uniffiClonePointer(), $0)
+        })
+    }
+
     /**
      * Get the reported latency, if it exists
      */
-open func latency() -> TimeInterval? {
-    return try!  FfiConverterOptionDuration.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_directaddrinfo_latency(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
-
+    open func latency() -> TimeInterval? {
+        return try! FfiConverterOptionDuration.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_directaddrinfo_latency(self.uniffiClonePointer(), $0)
+        })
+    }
 }
 
 public struct FfiConverterTypeDirectAddrInfo: FfiConverter {
-
     typealias FfiType = UnsafeMutableRawPointer
     typealias SwiftType = DirectAddrInfo
 
@@ -2872,7 +2719,7 @@ public struct FfiConverterTypeDirectAddrInfo: FfiConverter {
         // The Rust code won't compile if a pointer won't fit in a UInt64.
         // We have to go via `UInt` because that's the thing that's the size of a pointer.
         let ptr = UnsafeMutableRawPointer(bitPattern: UInt(truncatingIfNeeded: v))
-        if (ptr == nil) {
+        if ptr == nil {
             throw UniffiInternalError.unexpectedNullPointer
         }
         return try lift(ptr!)
@@ -2885,9 +2732,6 @@ public struct FfiConverterTypeDirectAddrInfo: FfiConverter {
     }
 }
 
-
-
-
 public func FfiConverterTypeDirectAddrInfo_lift(_ pointer: UnsafeMutableRawPointer) throws -> DirectAddrInfo {
     return try FfiConverterTypeDirectAddrInfo.lift(pointer)
 }
@@ -2896,19 +2740,15 @@ public func FfiConverterTypeDirectAddrInfo_lower(_ value: DirectAddrInfo) -> Uns
     return FfiConverterTypeDirectAddrInfo.lower(value)
 }
 
-
-
-
 /**
  * A representation of a mutable, synchronizable key-value store.
  */
-public protocol DocProtocol : AnyObject {
-    
+public protocol DocProtocol: AnyObject {
     /**
      * Close the document.
      */
-    func closeMe() async throws 
-    
+    func closeMe() async throws
+
     /**
      * Delete entries that match the given `author` and key `prefix`.
      *
@@ -2917,98 +2757,98 @@ public protocol DocProtocol : AnyObject {
      *
      * Returns the number of entries deleted.
      */
-    func delete(authorId: AuthorId, prefix: Data) async throws  -> UInt64
-    
+    func delete(authorId: AuthorId, prefix: Data) async throws -> UInt64
+
     /**
      * Export an entry as a file to a given absolute path
      */
-    func exportFile(entry: Entry, path: String, cb: DocExportFileCallback?) async throws 
-    
+    func exportFile(entry: Entry, path: String, cb: DocExportFileCallback?) async throws
+
     /**
      * Get the download policy for this document
      */
-    func getDownloadPolicy() async throws  -> DownloadPolicy
-    
+    func getDownloadPolicy() async throws -> DownloadPolicy
+
     /**
      * Get an entry for a key and author.
      */
-    func getExact(author: AuthorId, key: Data, includeEmpty: Bool) async throws  -> Entry?
-    
+    func getExact(author: AuthorId, key: Data, includeEmpty: Bool) async throws -> Entry?
+
     /**
      * Get entries.
      *
      * Note: this allocates for each `Entry`, if you have many `Entry`s this may be a prohibitively large list.
      * Please file an [issue](https://github.com/n0-computer/iroh-ffi/issues/new) if you run into this issue
      */
-    func getMany(query: Query) async throws  -> [Entry]
-    
+    func getMany(query: Query) async throws -> [Entry]
+
     /**
      * Get the latest entry for a key and author.
      */
-    func getOne(query: Query) async throws  -> Entry?
-    
+    func getOne(query: Query) async throws -> Entry?
+
     /**
      * Get sync peers for this document
      */
-    func getSyncPeers() async throws  -> [Data]?
-    
+    func getSyncPeers() async throws -> [Data]?
+
     /**
      * Get the document id of this doc.
      */
-    func id()  -> String
-    
+    func id() -> String
+
     /**
      * Add an entry from an absolute file path
      */
-    func importFile(author: AuthorId, key: Data, path: String, inPlace: Bool, cb: DocImportFileCallback?) async throws 
-    
+    func importFile(author: AuthorId, key: Data, path: String, inPlace: Bool, cb: DocImportFileCallback?) async throws
+
     /**
      * Stop the live sync for this document.
      */
-    func leave() async throws 
-    
+    func leave() async throws
+
     /**
      * Set the content of a key to a byte array.
      */
-    func setBytes(authorId: AuthorId, key: Data, value: Data) async throws  -> Hash
-    
+    func setBytes(authorId: AuthorId, key: Data, value: Data) async throws -> Hash
+
     /**
      * Set the download policy for this document
      */
-    func setDownloadPolicy(policy: DownloadPolicy) async throws 
-    
+    func setDownloadPolicy(policy: DownloadPolicy) async throws
+
     /**
      * Set an entries on the doc via its key, hash, and size.
      */
-    func setHash(authorId: AuthorId, key: Data, hash: Hash, size: UInt64) async throws 
-    
+    func setHash(authorId: AuthorId, key: Data, hash: Hash, size: UInt64) async throws
+
     /**
      * Share this document with peers over a ticket.
      */
-    func share(mode: ShareMode, addrOptions: AddrInfoOptions) async throws  -> String
-    
+    func share(mode: ShareMode, addrOptions: AddrInfoOptions) async throws -> DocTicket
+
     /**
      * Start to sync this document with a list of peers.
      */
-    func startSync(peers: [NodeAddr]) async throws 
-    
+    func startSync(peers: [NodeAddr]) async throws
+
     /**
      * Get status info for this document
      */
-    func status() async throws  -> OpenState
-    
+    func status() async throws -> OpenState
+
     /**
      * Subscribe to events for this document.
      */
-    func subscribe(cb: SubscribeCallback) async throws 
-    
+    func subscribe(cb: SubscribeCallback) async throws
 }
 
 /**
  * A representation of a mutable, synchronizable key-value store.
  */
 open class Doc:
-    DocProtocol {
+    DocProtocol
+{
     fileprivate let pointer: UnsafeMutableRawPointer!
 
     /// Used to instantiate a [FFIObject] without an actual pointer, for fakes in tests, mostly.
@@ -3019,7 +2859,7 @@ open class Doc:
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-    required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
+    public required init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
 
@@ -3028,13 +2868,14 @@ open class Doc:
     ///
     /// - Warning:
     ///     Any object instantiated with this constructor cannot be passed to an actual Rust-backed object. Since there isn't a backing [Pointer] the FFI lower functions will crash.
-    public init(noPointer: NoPointer) {
-        self.pointer = nil
+    public init(noPointer _: NoPointer) {
+        pointer = nil
     }
 
     public func uniffiClonePointer() -> UnsafeMutableRawPointer {
         return try! rustCall { uniffi_iroh_ffi_fn_clone_doc(self.pointer, $0) }
     }
+
     // No primary constructor declared for this class.
 
     deinit {
@@ -3045,29 +2886,25 @@ open class Doc:
         try! rustCall { uniffi_iroh_ffi_fn_free_doc(pointer, $0) }
     }
 
-    
-
-    
     /**
      * Close the document.
      */
-open func closeMe()async throws  {
-    return
-        try  await uniffiRustCallAsync(
-            rustFutureFunc: {
-                uniffi_iroh_ffi_fn_method_doc_close_me(
-                    self.uniffiClonePointer()
-                    
-                )
-            },
-            pollFunc: ffi_iroh_ffi_rust_future_poll_void,
-            completeFunc: ffi_iroh_ffi_rust_future_complete_void,
-            freeFunc: ffi_iroh_ffi_rust_future_free_void,
-            liftFunc: { $0 },
-            errorHandler: FfiConverterTypeIrohError__as_error.lift
-        )
-}
-    
+    open func closeMe() async throws {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_doc_close_me(
+                        self.uniffiClonePointer()
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_void,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_void,
+                freeFunc: ffi_iroh_ffi_rust_future_free_void,
+                liftFunc: { $0 },
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
     /**
      * Delete entries that match the given `author` and key `prefix`.
      *
@@ -3076,341 +2913,333 @@ open func closeMe()async throws  {
      *
      * Returns the number of entries deleted.
      */
-open func delete(authorId: AuthorId, prefix: Data)async throws  -> UInt64 {
-    return
-        try  await uniffiRustCallAsync(
-            rustFutureFunc: {
-                uniffi_iroh_ffi_fn_method_doc_delete(
-                    self.uniffiClonePointer(),
-                    FfiConverterTypeAuthorId.lower(authorId),FfiConverterData.lower(prefix)
-                )
-            },
-            pollFunc: ffi_iroh_ffi_rust_future_poll_u64,
-            completeFunc: ffi_iroh_ffi_rust_future_complete_u64,
-            freeFunc: ffi_iroh_ffi_rust_future_free_u64,
-            liftFunc: FfiConverterUInt64.lift,
-            errorHandler: FfiConverterTypeIrohError__as_error.lift
-        )
-}
-    
+    open func delete(authorId: AuthorId, prefix: Data) async throws -> UInt64 {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_doc_delete(
+                        self.uniffiClonePointer(),
+                        FfiConverterTypeAuthorId.lower(authorId), FfiConverterData.lower(prefix)
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_u64,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_u64,
+                freeFunc: ffi_iroh_ffi_rust_future_free_u64,
+                liftFunc: FfiConverterUInt64.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
     /**
      * Export an entry as a file to a given absolute path
      */
-open func exportFile(entry: Entry, path: String, cb: DocExportFileCallback?)async throws  {
-    return
-        try  await uniffiRustCallAsync(
-            rustFutureFunc: {
-                uniffi_iroh_ffi_fn_method_doc_export_file(
-                    self.uniffiClonePointer(),
-                    FfiConverterTypeEntry.lower(entry),FfiConverterString.lower(path),FfiConverterOptionTypeDocExportFileCallback.lower(cb)
-                )
-            },
-            pollFunc: ffi_iroh_ffi_rust_future_poll_void,
-            completeFunc: ffi_iroh_ffi_rust_future_complete_void,
-            freeFunc: ffi_iroh_ffi_rust_future_free_void,
-            liftFunc: { $0 },
-            errorHandler: FfiConverterTypeIrohError__as_error.lift
-        )
-}
-    
+    open func exportFile(entry: Entry, path: String, cb: DocExportFileCallback?) async throws {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_doc_export_file(
+                        self.uniffiClonePointer(),
+                        FfiConverterTypeEntry.lower(entry), FfiConverterString.lower(path), FfiConverterOptionTypeDocExportFileCallback.lower(cb)
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_void,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_void,
+                freeFunc: ffi_iroh_ffi_rust_future_free_void,
+                liftFunc: { $0 },
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
     /**
      * Get the download policy for this document
      */
-open func getDownloadPolicy()async throws  -> DownloadPolicy {
-    return
-        try  await uniffiRustCallAsync(
-            rustFutureFunc: {
-                uniffi_iroh_ffi_fn_method_doc_get_download_policy(
-                    self.uniffiClonePointer()
-                    
-                )
-            },
-            pollFunc: ffi_iroh_ffi_rust_future_poll_pointer,
-            completeFunc: ffi_iroh_ffi_rust_future_complete_pointer,
-            freeFunc: ffi_iroh_ffi_rust_future_free_pointer,
-            liftFunc: FfiConverterTypeDownloadPolicy.lift,
-            errorHandler: FfiConverterTypeIrohError__as_error.lift
-        )
-}
-    
+    open func getDownloadPolicy() async throws -> DownloadPolicy {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_doc_get_download_policy(
+                        self.uniffiClonePointer()
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_pointer,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_pointer,
+                freeFunc: ffi_iroh_ffi_rust_future_free_pointer,
+                liftFunc: FfiConverterTypeDownloadPolicy.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
     /**
      * Get an entry for a key and author.
      */
-open func getExact(author: AuthorId, key: Data, includeEmpty: Bool)async throws  -> Entry? {
-    return
-        try  await uniffiRustCallAsync(
-            rustFutureFunc: {
-                uniffi_iroh_ffi_fn_method_doc_get_exact(
-                    self.uniffiClonePointer(),
-                    FfiConverterTypeAuthorId.lower(author),FfiConverterData.lower(key),FfiConverterBool.lower(includeEmpty)
-                )
-            },
-            pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
-            completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
-            freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
-            liftFunc: FfiConverterOptionTypeEntry.lift,
-            errorHandler: FfiConverterTypeIrohError__as_error.lift
-        )
-}
-    
+    open func getExact(author: AuthorId, key: Data, includeEmpty: Bool) async throws -> Entry? {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_doc_get_exact(
+                        self.uniffiClonePointer(),
+                        FfiConverterTypeAuthorId.lower(author), FfiConverterData.lower(key), FfiConverterBool.lower(includeEmpty)
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
+                freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
+                liftFunc: FfiConverterOptionTypeEntry.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
     /**
      * Get entries.
      *
      * Note: this allocates for each `Entry`, if you have many `Entry`s this may be a prohibitively large list.
      * Please file an [issue](https://github.com/n0-computer/iroh-ffi/issues/new) if you run into this issue
      */
-open func getMany(query: Query)async throws  -> [Entry] {
-    return
-        try  await uniffiRustCallAsync(
-            rustFutureFunc: {
-                uniffi_iroh_ffi_fn_method_doc_get_many(
-                    self.uniffiClonePointer(),
-                    FfiConverterTypeQuery.lower(query)
-                )
-            },
-            pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
-            completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
-            freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
-            liftFunc: FfiConverterSequenceTypeEntry.lift,
-            errorHandler: FfiConverterTypeIrohError__as_error.lift
-        )
-}
-    
+    open func getMany(query: Query) async throws -> [Entry] {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_doc_get_many(
+                        self.uniffiClonePointer(),
+                        FfiConverterTypeQuery.lower(query)
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
+                freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
+                liftFunc: FfiConverterSequenceTypeEntry.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
     /**
      * Get the latest entry for a key and author.
      */
-open func getOne(query: Query)async throws  -> Entry? {
-    return
-        try  await uniffiRustCallAsync(
-            rustFutureFunc: {
-                uniffi_iroh_ffi_fn_method_doc_get_one(
-                    self.uniffiClonePointer(),
-                    FfiConverterTypeQuery.lower(query)
-                )
-            },
-            pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
-            completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
-            freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
-            liftFunc: FfiConverterOptionTypeEntry.lift,
-            errorHandler: FfiConverterTypeIrohError__as_error.lift
-        )
-}
-    
+    open func getOne(query: Query) async throws -> Entry? {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_doc_get_one(
+                        self.uniffiClonePointer(),
+                        FfiConverterTypeQuery.lower(query)
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
+                freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
+                liftFunc: FfiConverterOptionTypeEntry.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
     /**
      * Get sync peers for this document
      */
-open func getSyncPeers()async throws  -> [Data]? {
-    return
-        try  await uniffiRustCallAsync(
-            rustFutureFunc: {
-                uniffi_iroh_ffi_fn_method_doc_get_sync_peers(
-                    self.uniffiClonePointer()
-                    
-                )
-            },
-            pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
-            completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
-            freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
-            liftFunc: FfiConverterOptionSequenceData.lift,
-            errorHandler: FfiConverterTypeIrohError__as_error.lift
-        )
-}
-    
+    open func getSyncPeers() async throws -> [Data]? {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_doc_get_sync_peers(
+                        self.uniffiClonePointer()
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
+                freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
+                liftFunc: FfiConverterOptionSequenceData.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
     /**
      * Get the document id of this doc.
      */
-open func id() -> String {
-    return try!  FfiConverterString.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_doc_id(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
+    open func id() -> String {
+        return try! FfiConverterString.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_doc_id(self.uniffiClonePointer(), $0)
+        })
+    }
+
     /**
      * Add an entry from an absolute file path
      */
-open func importFile(author: AuthorId, key: Data, path: String, inPlace: Bool, cb: DocImportFileCallback?)async throws  {
-    return
-        try  await uniffiRustCallAsync(
-            rustFutureFunc: {
-                uniffi_iroh_ffi_fn_method_doc_import_file(
-                    self.uniffiClonePointer(),
-                    FfiConverterTypeAuthorId.lower(author),FfiConverterData.lower(key),FfiConverterString.lower(path),FfiConverterBool.lower(inPlace),FfiConverterOptionTypeDocImportFileCallback.lower(cb)
-                )
-            },
-            pollFunc: ffi_iroh_ffi_rust_future_poll_void,
-            completeFunc: ffi_iroh_ffi_rust_future_complete_void,
-            freeFunc: ffi_iroh_ffi_rust_future_free_void,
-            liftFunc: { $0 },
-            errorHandler: FfiConverterTypeIrohError__as_error.lift
-        )
-}
-    
+    open func importFile(author: AuthorId, key: Data, path: String, inPlace: Bool, cb: DocImportFileCallback?) async throws {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_doc_import_file(
+                        self.uniffiClonePointer(),
+                        FfiConverterTypeAuthorId.lower(author), FfiConverterData.lower(key), FfiConverterString.lower(path), FfiConverterBool.lower(inPlace), FfiConverterOptionTypeDocImportFileCallback.lower(cb)
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_void,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_void,
+                freeFunc: ffi_iroh_ffi_rust_future_free_void,
+                liftFunc: { $0 },
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
     /**
      * Stop the live sync for this document.
      */
-open func leave()async throws  {
-    return
-        try  await uniffiRustCallAsync(
-            rustFutureFunc: {
-                uniffi_iroh_ffi_fn_method_doc_leave(
-                    self.uniffiClonePointer()
-                    
-                )
-            },
-            pollFunc: ffi_iroh_ffi_rust_future_poll_void,
-            completeFunc: ffi_iroh_ffi_rust_future_complete_void,
-            freeFunc: ffi_iroh_ffi_rust_future_free_void,
-            liftFunc: { $0 },
-            errorHandler: FfiConverterTypeIrohError__as_error.lift
-        )
-}
-    
+    open func leave() async throws {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_doc_leave(
+                        self.uniffiClonePointer()
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_void,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_void,
+                freeFunc: ffi_iroh_ffi_rust_future_free_void,
+                liftFunc: { $0 },
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
     /**
      * Set the content of a key to a byte array.
      */
-open func setBytes(authorId: AuthorId, key: Data, value: Data)async throws  -> Hash {
-    return
-        try  await uniffiRustCallAsync(
-            rustFutureFunc: {
-                uniffi_iroh_ffi_fn_method_doc_set_bytes(
-                    self.uniffiClonePointer(),
-                    FfiConverterTypeAuthorId.lower(authorId),FfiConverterData.lower(key),FfiConverterData.lower(value)
-                )
-            },
-            pollFunc: ffi_iroh_ffi_rust_future_poll_pointer,
-            completeFunc: ffi_iroh_ffi_rust_future_complete_pointer,
-            freeFunc: ffi_iroh_ffi_rust_future_free_pointer,
-            liftFunc: FfiConverterTypeHash.lift,
-            errorHandler: FfiConverterTypeIrohError__as_error.lift
-        )
-}
-    
+    open func setBytes(authorId: AuthorId, key: Data, value: Data) async throws -> Hash {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_doc_set_bytes(
+                        self.uniffiClonePointer(),
+                        FfiConverterTypeAuthorId.lower(authorId), FfiConverterData.lower(key), FfiConverterData.lower(value)
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_pointer,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_pointer,
+                freeFunc: ffi_iroh_ffi_rust_future_free_pointer,
+                liftFunc: FfiConverterTypeHash.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
     /**
      * Set the download policy for this document
      */
-open func setDownloadPolicy(policy: DownloadPolicy)async throws  {
-    return
-        try  await uniffiRustCallAsync(
-            rustFutureFunc: {
-                uniffi_iroh_ffi_fn_method_doc_set_download_policy(
-                    self.uniffiClonePointer(),
-                    FfiConverterTypeDownloadPolicy.lower(policy)
-                )
-            },
-            pollFunc: ffi_iroh_ffi_rust_future_poll_void,
-            completeFunc: ffi_iroh_ffi_rust_future_complete_void,
-            freeFunc: ffi_iroh_ffi_rust_future_free_void,
-            liftFunc: { $0 },
-            errorHandler: FfiConverterTypeIrohError__as_error.lift
-        )
-}
-    
+    open func setDownloadPolicy(policy: DownloadPolicy) async throws {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_doc_set_download_policy(
+                        self.uniffiClonePointer(),
+                        FfiConverterTypeDownloadPolicy.lower(policy)
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_void,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_void,
+                freeFunc: ffi_iroh_ffi_rust_future_free_void,
+                liftFunc: { $0 },
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
     /**
      * Set an entries on the doc via its key, hash, and size.
      */
-open func setHash(authorId: AuthorId, key: Data, hash: Hash, size: UInt64)async throws  {
-    return
-        try  await uniffiRustCallAsync(
-            rustFutureFunc: {
-                uniffi_iroh_ffi_fn_method_doc_set_hash(
-                    self.uniffiClonePointer(),
-                    FfiConverterTypeAuthorId.lower(authorId),FfiConverterData.lower(key),FfiConverterTypeHash.lower(hash),FfiConverterUInt64.lower(size)
-                )
-            },
-            pollFunc: ffi_iroh_ffi_rust_future_poll_void,
-            completeFunc: ffi_iroh_ffi_rust_future_complete_void,
-            freeFunc: ffi_iroh_ffi_rust_future_free_void,
-            liftFunc: { $0 },
-            errorHandler: FfiConverterTypeIrohError__as_error.lift
-        )
-}
-    
+    open func setHash(authorId: AuthorId, key: Data, hash: Hash, size: UInt64) async throws {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_doc_set_hash(
+                        self.uniffiClonePointer(),
+                        FfiConverterTypeAuthorId.lower(authorId), FfiConverterData.lower(key), FfiConverterTypeHash.lower(hash), FfiConverterUInt64.lower(size)
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_void,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_void,
+                freeFunc: ffi_iroh_ffi_rust_future_free_void,
+                liftFunc: { $0 },
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
     /**
      * Share this document with peers over a ticket.
      */
-open func share(mode: ShareMode, addrOptions: AddrInfoOptions)async throws  -> String {
-    return
-        try  await uniffiRustCallAsync(
-            rustFutureFunc: {
-                uniffi_iroh_ffi_fn_method_doc_share(
-                    self.uniffiClonePointer(),
-                    FfiConverterTypeShareMode.lower(mode),FfiConverterTypeAddrInfoOptions.lower(addrOptions)
-                )
-            },
-            pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
-            completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
-            freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
-            liftFunc: FfiConverterString.lift,
-            errorHandler: FfiConverterTypeIrohError__as_error.lift
-        )
-}
-    
+    open func share(mode: ShareMode, addrOptions: AddrInfoOptions) async throws -> DocTicket {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_doc_share(
+                        self.uniffiClonePointer(),
+                        FfiConverterTypeShareMode.lower(mode), FfiConverterTypeAddrInfoOptions.lower(addrOptions)
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_pointer,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_pointer,
+                freeFunc: ffi_iroh_ffi_rust_future_free_pointer,
+                liftFunc: FfiConverterTypeDocTicket.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
     /**
      * Start to sync this document with a list of peers.
      */
-open func startSync(peers: [NodeAddr])async throws  {
-    return
-        try  await uniffiRustCallAsync(
-            rustFutureFunc: {
-                uniffi_iroh_ffi_fn_method_doc_start_sync(
-                    self.uniffiClonePointer(),
-                    FfiConverterSequenceTypeNodeAddr.lower(peers)
-                )
-            },
-            pollFunc: ffi_iroh_ffi_rust_future_poll_void,
-            completeFunc: ffi_iroh_ffi_rust_future_complete_void,
-            freeFunc: ffi_iroh_ffi_rust_future_free_void,
-            liftFunc: { $0 },
-            errorHandler: FfiConverterTypeIrohError__as_error.lift
-        )
-}
-    
+    open func startSync(peers: [NodeAddr]) async throws {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_doc_start_sync(
+                        self.uniffiClonePointer(),
+                        FfiConverterSequenceTypeNodeAddr.lower(peers)
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_void,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_void,
+                freeFunc: ffi_iroh_ffi_rust_future_free_void,
+                liftFunc: { $0 },
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
     /**
      * Get status info for this document
      */
-open func status()async throws  -> OpenState {
-    return
-        try  await uniffiRustCallAsync(
-            rustFutureFunc: {
-                uniffi_iroh_ffi_fn_method_doc_status(
-                    self.uniffiClonePointer()
-                    
-                )
-            },
-            pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
-            completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
-            freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
-            liftFunc: FfiConverterTypeOpenState.lift,
-            errorHandler: FfiConverterTypeIrohError__as_error.lift
-        )
-}
-    
+    open func status() async throws -> OpenState {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_doc_status(
+                        self.uniffiClonePointer()
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
+                freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
+                liftFunc: FfiConverterTypeOpenState.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
     /**
      * Subscribe to events for this document.
      */
-open func subscribe(cb: SubscribeCallback)async throws  {
-    return
-        try  await uniffiRustCallAsync(
-            rustFutureFunc: {
-                uniffi_iroh_ffi_fn_method_doc_subscribe(
-                    self.uniffiClonePointer(),
-                    FfiConverterTypeSubscribeCallback.lower(cb)
-                )
-            },
-            pollFunc: ffi_iroh_ffi_rust_future_poll_void,
-            completeFunc: ffi_iroh_ffi_rust_future_complete_void,
-            freeFunc: ffi_iroh_ffi_rust_future_free_void,
-            liftFunc: { $0 },
-            errorHandler: FfiConverterTypeIrohError__as_error.lift
-        )
-}
-    
-
+    open func subscribe(cb: SubscribeCallback) async throws {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_doc_subscribe(
+                        self.uniffiClonePointer(),
+                        FfiConverterTypeSubscribeCallback.lower(cb)
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_void,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_void,
+                freeFunc: ffi_iroh_ffi_rust_future_free_void,
+                liftFunc: { $0 },
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
 }
 
 public struct FfiConverterTypeDoc: FfiConverter {
-
     typealias FfiType = UnsafeMutableRawPointer
     typealias SwiftType = Doc
 
@@ -3427,7 +3256,7 @@ public struct FfiConverterTypeDoc: FfiConverter {
         // The Rust code won't compile if a pointer won't fit in a UInt64.
         // We have to go via `UInt` because that's the thing that's the size of a pointer.
         let ptr = UnsafeMutableRawPointer(bitPattern: UInt(truncatingIfNeeded: v))
-        if (ptr == nil) {
+        if ptr == nil {
             throw UniffiInternalError.unexpectedNullPointer
         }
         return try lift(ptr!)
@@ -3440,9 +3269,6 @@ public struct FfiConverterTypeDoc: FfiConverter {
     }
 }
 
-
-
-
 public func FfiConverterTypeDoc_lift(_ pointer: UnsafeMutableRawPointer) throws -> Doc {
     return try FfiConverterTypeDoc.lift(pointer)
 }
@@ -3451,18 +3277,13 @@ public func FfiConverterTypeDoc_lower(_ value: Doc) -> UnsafeMutableRawPointer {
     return FfiConverterTypeDoc.lower(value)
 }
 
-
-
-
 /**
  * The `progress` method will be called for each `DocExportProgress` event that is
  * emitted during a `doc.export_file()` call. Use the `DocExportProgress.type()`
  * method to check the `DocExportProgressType`
  */
-public protocol DocExportFileCallback : AnyObject {
-    
-    func progress(progress: DocExportProgress) async throws 
-    
+public protocol DocExportFileCallback: AnyObject {
+    func progress(progress: DocExportProgress) async throws
 }
 
 /**
@@ -3471,7 +3292,8 @@ public protocol DocExportFileCallback : AnyObject {
  * method to check the `DocExportProgressType`
  */
 open class DocExportFileCallbackImpl:
-    DocExportFileCallback {
+    DocExportFileCallback
+{
     fileprivate let pointer: UnsafeMutableRawPointer!
 
     /// Used to instantiate a [FFIObject] without an actual pointer, for fakes in tests, mostly.
@@ -3482,7 +3304,7 @@ open class DocExportFileCallbackImpl:
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-    required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
+    public required init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
 
@@ -3491,13 +3313,14 @@ open class DocExportFileCallbackImpl:
     ///
     /// - Warning:
     ///     Any object instantiated with this constructor cannot be passed to an actual Rust-backed object. Since there isn't a backing [Pointer] the FFI lower functions will crash.
-    public init(noPointer: NoPointer) {
-        self.pointer = nil
+    public init(noPointer _: NoPointer) {
+        pointer = nil
     }
 
     public func uniffiClonePointer() -> UnsafeMutableRawPointer {
         return try! rustCall { uniffi_iroh_ffi_fn_clone_docexportfilecallback(self.pointer, $0) }
     }
+
     // No primary constructor declared for this class.
 
     deinit {
@@ -3508,36 +3331,29 @@ open class DocExportFileCallbackImpl:
         try! rustCall { uniffi_iroh_ffi_fn_free_docexportfilecallback(pointer, $0) }
     }
 
-    
-
-    
-open func progress(progress: DocExportProgress)async throws  {
-    return
-        try  await uniffiRustCallAsync(
-            rustFutureFunc: {
-                uniffi_iroh_ffi_fn_method_docexportfilecallback_progress(
-                    self.uniffiClonePointer(),
-                    FfiConverterTypeDocExportProgress.lower(progress)
-                )
-            },
-            pollFunc: ffi_iroh_ffi_rust_future_poll_void,
-            completeFunc: ffi_iroh_ffi_rust_future_complete_void,
-            freeFunc: ffi_iroh_ffi_rust_future_free_void,
-            liftFunc: { $0 },
-            errorHandler: FfiConverterTypeCallbackError.lift
-        )
+    open func progress(progress: DocExportProgress) async throws {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_docexportfilecallback_progress(
+                        self.uniffiClonePointer(),
+                        FfiConverterTypeDocExportProgress.lower(progress)
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_void,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_void,
+                freeFunc: ffi_iroh_ffi_rust_future_free_void,
+                liftFunc: { $0 },
+                errorHandler: FfiConverterTypeCallbackError.lift
+            )
+    }
 }
-    
-
-}
-
 
 // Put the implementation in a struct so we don't pollute the top-level namespace
-fileprivate struct UniffiCallbackInterfaceDocExportFileCallback {
-
+private enum UniffiCallbackInterfaceDocExportFileCallback {
     // Create the VTable using a series of closures.
     // Swift automatically converts these into C callback functions.
-    static var vtable: UniffiVTableCallbackInterfaceDocExportFileCallback = UniffiVTableCallbackInterfaceDocExportFileCallback(
+    static var vtable: UniffiVTableCallbackInterfaceDocExportFileCallback = .init(
         progress: { (
             uniffiHandle: UInt64,
             progress: UnsafeMutableRawPointer,
@@ -3546,16 +3362,16 @@ fileprivate struct UniffiCallbackInterfaceDocExportFileCallback {
             uniffiOutReturn: UnsafeMutablePointer<UniffiForeignFuture>
         ) in
             let makeCall = {
-                () async throws -> () in
+                () async throws in
                 guard let uniffiObj = try? FfiConverterTypeDocExportFileCallback.handleMap.get(handle: uniffiHandle) else {
                     throw UniffiInternalError.unexpectedStaleHandle
                 }
                 return try await uniffiObj.progress(
-                     progress: try FfiConverterTypeDocExportProgress.lift(progress)
+                    progress: FfiConverterTypeDocExportProgress.lift(progress)
                 )
             }
 
-            let uniffiHandleSuccess = { (returnValue: ()) in
+            let uniffiHandleSuccess = { (_: ()) in
                 uniffiFutureCallback(
                     uniffiCallbackData,
                     UniffiForeignFutureStructVoid(
@@ -3563,7 +3379,7 @@ fileprivate struct UniffiCallbackInterfaceDocExportFileCallback {
                     )
                 )
             }
-            let uniffiHandleError = { (statusCode, errorBuf) in
+            let uniffiHandleError = { statusCode, errorBuf in
                 uniffiFutureCallback(
                     uniffiCallbackData,
                     UniffiForeignFutureStructVoid(
@@ -3579,7 +3395,7 @@ fileprivate struct UniffiCallbackInterfaceDocExportFileCallback {
             )
             uniffiOutReturn.pointee = uniffiForeignFuture
         },
-        uniffiFree: { (uniffiHandle: UInt64) -> () in
+        uniffiFree: { (uniffiHandle: UInt64) in
             let result = try? FfiConverterTypeDocExportFileCallback.handleMap.remove(handle: uniffiHandle)
             if result == nil {
                 print("Uniffi callback interface DocExportFileCallback: handle missing in uniffiFree")
@@ -3614,7 +3430,7 @@ public struct FfiConverterTypeDocExportFileCallback: FfiConverter {
         // The Rust code won't compile if a pointer won't fit in a UInt64.
         // We have to go via `UInt` because that's the thing that's the size of a pointer.
         let ptr = UnsafeMutableRawPointer(bitPattern: UInt(truncatingIfNeeded: v))
-        if (ptr == nil) {
+        if ptr == nil {
             throw UniffiInternalError.unexpectedNullPointer
         }
         return try lift(ptr!)
@@ -3627,9 +3443,6 @@ public struct FfiConverterTypeDocExportFileCallback: FfiConverter {
     }
 }
 
-
-
-
 public func FfiConverterTypeDocExportFileCallback_lift(_ pointer: UnsafeMutableRawPointer) throws -> DocExportFileCallback {
     return try FfiConverterTypeDocExportFileCallback.lift(pointer)
 }
@@ -3638,41 +3451,37 @@ public func FfiConverterTypeDocExportFileCallback_lower(_ value: DocExportFileCa
     return FfiConverterTypeDocExportFileCallback.lower(value)
 }
 
-
-
-
 /**
  * Progress updates for the doc import file operation.
  */
-public protocol DocExportProgressProtocol : AnyObject {
-    
+public protocol DocExportProgressProtocol: AnyObject {
     /**
      * Return the `DocExportProgressAbort`
      */
-    func asAbort()  -> DocExportProgressAbort
-    
+    func asAbort() -> DocExportProgressAbort
+
     /**
      * Return the `DocExportProgressFound` event
      */
-    func asFound()  -> DocExportProgressFound
-    
+    func asFound() -> DocExportProgressFound
+
     /**
      * Return the `DocExportProgressProgress` event
      */
-    func asProgress()  -> DocExportProgressProgress
-    
+    func asProgress() -> DocExportProgressProgress
+
     /**
      * Get the type of event
      */
-    func type()  -> DocExportProgressType
-    
+    func type() -> DocExportProgressType
 }
 
 /**
  * Progress updates for the doc import file operation.
  */
 open class DocExportProgress:
-    DocExportProgressProtocol {
+    DocExportProgressProtocol
+{
     fileprivate let pointer: UnsafeMutableRawPointer!
 
     /// Used to instantiate a [FFIObject] without an actual pointer, for fakes in tests, mostly.
@@ -3683,7 +3492,7 @@ open class DocExportProgress:
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-    required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
+    public required init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
 
@@ -3692,13 +3501,14 @@ open class DocExportProgress:
     ///
     /// - Warning:
     ///     Any object instantiated with this constructor cannot be passed to an actual Rust-backed object. Since there isn't a backing [Pointer] the FFI lower functions will crash.
-    public init(noPointer: NoPointer) {
-        self.pointer = nil
+    public init(noPointer _: NoPointer) {
+        pointer = nil
     }
 
     public func uniffiClonePointer() -> UnsafeMutableRawPointer {
         return try! rustCall { uniffi_iroh_ffi_fn_clone_docexportprogress(self.pointer, $0) }
     }
+
     // No primary constructor declared for this class.
 
     deinit {
@@ -3709,54 +3519,44 @@ open class DocExportProgress:
         try! rustCall { uniffi_iroh_ffi_fn_free_docexportprogress(pointer, $0) }
     }
 
-    
-
-    
     /**
      * Return the `DocExportProgressAbort`
      */
-open func asAbort() -> DocExportProgressAbort {
-    return try!  FfiConverterTypeDocExportProgressAbort.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_docexportprogress_as_abort(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
+    open func asAbort() -> DocExportProgressAbort {
+        return try! FfiConverterTypeDocExportProgressAbort.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_docexportprogress_as_abort(self.uniffiClonePointer(), $0)
+        })
+    }
+
     /**
      * Return the `DocExportProgressFound` event
      */
-open func asFound() -> DocExportProgressFound {
-    return try!  FfiConverterTypeDocExportProgressFound.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_docexportprogress_as_found(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
+    open func asFound() -> DocExportProgressFound {
+        return try! FfiConverterTypeDocExportProgressFound.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_docexportprogress_as_found(self.uniffiClonePointer(), $0)
+        })
+    }
+
     /**
      * Return the `DocExportProgressProgress` event
      */
-open func asProgress() -> DocExportProgressProgress {
-    return try!  FfiConverterTypeDocExportProgressProgress.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_docexportprogress_as_progress(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
+    open func asProgress() -> DocExportProgressProgress {
+        return try! FfiConverterTypeDocExportProgressProgress.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_docexportprogress_as_progress(self.uniffiClonePointer(), $0)
+        })
+    }
+
     /**
      * Get the type of event
      */
-open func type() -> DocExportProgressType {
-    return try!  FfiConverterTypeDocExportProgressType.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_docexportprogress_type(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
-
+    open func type() -> DocExportProgressType {
+        return try! FfiConverterTypeDocExportProgressType.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_docexportprogress_type(self.uniffiClonePointer(), $0)
+        })
+    }
 }
 
 public struct FfiConverterTypeDocExportProgress: FfiConverter {
-
     typealias FfiType = UnsafeMutableRawPointer
     typealias SwiftType = DocExportProgress
 
@@ -3773,7 +3573,7 @@ public struct FfiConverterTypeDocExportProgress: FfiConverter {
         // The Rust code won't compile if a pointer won't fit in a UInt64.
         // We have to go via `UInt` because that's the thing that's the size of a pointer.
         let ptr = UnsafeMutableRawPointer(bitPattern: UInt(truncatingIfNeeded: v))
-        if (ptr == nil) {
+        if ptr == nil {
             throw UniffiInternalError.unexpectedNullPointer
         }
         return try lift(ptr!)
@@ -3786,9 +3586,6 @@ public struct FfiConverterTypeDocExportProgress: FfiConverter {
     }
 }
 
-
-
-
 public func FfiConverterTypeDocExportProgress_lift(_ pointer: UnsafeMutableRawPointer) throws -> DocExportProgress {
     return try FfiConverterTypeDocExportProgress.lift(pointer)
 }
@@ -3797,18 +3594,13 @@ public func FfiConverterTypeDocExportProgress_lower(_ value: DocExportProgress) 
     return FfiConverterTypeDocExportProgress.lower(value)
 }
 
-
-
-
 /**
  * The `progress` method will be called for each `DocImportProgress` event that is
  * emitted during a `doc.import_file()` call. Use the `DocImportProgress.type()`
  * method to check the `DocImportProgressType`
  */
-public protocol DocImportFileCallback : AnyObject {
-    
-    func progress(progress: DocImportProgress) async throws 
-    
+public protocol DocImportFileCallback: AnyObject {
+    func progress(progress: DocImportProgress) async throws
 }
 
 /**
@@ -3817,7 +3609,8 @@ public protocol DocImportFileCallback : AnyObject {
  * method to check the `DocImportProgressType`
  */
 open class DocImportFileCallbackImpl:
-    DocImportFileCallback {
+    DocImportFileCallback
+{
     fileprivate let pointer: UnsafeMutableRawPointer!
 
     /// Used to instantiate a [FFIObject] without an actual pointer, for fakes in tests, mostly.
@@ -3828,7 +3621,7 @@ open class DocImportFileCallbackImpl:
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-    required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
+    public required init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
 
@@ -3837,13 +3630,14 @@ open class DocImportFileCallbackImpl:
     ///
     /// - Warning:
     ///     Any object instantiated with this constructor cannot be passed to an actual Rust-backed object. Since there isn't a backing [Pointer] the FFI lower functions will crash.
-    public init(noPointer: NoPointer) {
-        self.pointer = nil
+    public init(noPointer _: NoPointer) {
+        pointer = nil
     }
 
     public func uniffiClonePointer() -> UnsafeMutableRawPointer {
         return try! rustCall { uniffi_iroh_ffi_fn_clone_docimportfilecallback(self.pointer, $0) }
     }
+
     // No primary constructor declared for this class.
 
     deinit {
@@ -3854,36 +3648,29 @@ open class DocImportFileCallbackImpl:
         try! rustCall { uniffi_iroh_ffi_fn_free_docimportfilecallback(pointer, $0) }
     }
 
-    
-
-    
-open func progress(progress: DocImportProgress)async throws  {
-    return
-        try  await uniffiRustCallAsync(
-            rustFutureFunc: {
-                uniffi_iroh_ffi_fn_method_docimportfilecallback_progress(
-                    self.uniffiClonePointer(),
-                    FfiConverterTypeDocImportProgress.lower(progress)
-                )
-            },
-            pollFunc: ffi_iroh_ffi_rust_future_poll_void,
-            completeFunc: ffi_iroh_ffi_rust_future_complete_void,
-            freeFunc: ffi_iroh_ffi_rust_future_free_void,
-            liftFunc: { $0 },
-            errorHandler: FfiConverterTypeCallbackError.lift
-        )
+    open func progress(progress: DocImportProgress) async throws {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_docimportfilecallback_progress(
+                        self.uniffiClonePointer(),
+                        FfiConverterTypeDocImportProgress.lower(progress)
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_void,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_void,
+                freeFunc: ffi_iroh_ffi_rust_future_free_void,
+                liftFunc: { $0 },
+                errorHandler: FfiConverterTypeCallbackError.lift
+            )
+    }
 }
-    
-
-}
-
 
 // Put the implementation in a struct so we don't pollute the top-level namespace
-fileprivate struct UniffiCallbackInterfaceDocImportFileCallback {
-
+private enum UniffiCallbackInterfaceDocImportFileCallback {
     // Create the VTable using a series of closures.
     // Swift automatically converts these into C callback functions.
-    static var vtable: UniffiVTableCallbackInterfaceDocImportFileCallback = UniffiVTableCallbackInterfaceDocImportFileCallback(
+    static var vtable: UniffiVTableCallbackInterfaceDocImportFileCallback = .init(
         progress: { (
             uniffiHandle: UInt64,
             progress: UnsafeMutableRawPointer,
@@ -3892,16 +3679,16 @@ fileprivate struct UniffiCallbackInterfaceDocImportFileCallback {
             uniffiOutReturn: UnsafeMutablePointer<UniffiForeignFuture>
         ) in
             let makeCall = {
-                () async throws -> () in
+                () async throws in
                 guard let uniffiObj = try? FfiConverterTypeDocImportFileCallback.handleMap.get(handle: uniffiHandle) else {
                     throw UniffiInternalError.unexpectedStaleHandle
                 }
                 return try await uniffiObj.progress(
-                     progress: try FfiConverterTypeDocImportProgress.lift(progress)
+                    progress: FfiConverterTypeDocImportProgress.lift(progress)
                 )
             }
 
-            let uniffiHandleSuccess = { (returnValue: ()) in
+            let uniffiHandleSuccess = { (_: ()) in
                 uniffiFutureCallback(
                     uniffiCallbackData,
                     UniffiForeignFutureStructVoid(
@@ -3909,7 +3696,7 @@ fileprivate struct UniffiCallbackInterfaceDocImportFileCallback {
                     )
                 )
             }
-            let uniffiHandleError = { (statusCode, errorBuf) in
+            let uniffiHandleError = { statusCode, errorBuf in
                 uniffiFutureCallback(
                     uniffiCallbackData,
                     UniffiForeignFutureStructVoid(
@@ -3925,7 +3712,7 @@ fileprivate struct UniffiCallbackInterfaceDocImportFileCallback {
             )
             uniffiOutReturn.pointee = uniffiForeignFuture
         },
-        uniffiFree: { (uniffiHandle: UInt64) -> () in
+        uniffiFree: { (uniffiHandle: UInt64) in
             let result = try? FfiConverterTypeDocImportFileCallback.handleMap.remove(handle: uniffiHandle)
             if result == nil {
                 print("Uniffi callback interface DocImportFileCallback: handle missing in uniffiFree")
@@ -3960,7 +3747,7 @@ public struct FfiConverterTypeDocImportFileCallback: FfiConverter {
         // The Rust code won't compile if a pointer won't fit in a UInt64.
         // We have to go via `UInt` because that's the thing that's the size of a pointer.
         let ptr = UnsafeMutableRawPointer(bitPattern: UInt(truncatingIfNeeded: v))
-        if (ptr == nil) {
+        if ptr == nil {
             throw UniffiInternalError.unexpectedNullPointer
         }
         return try lift(ptr!)
@@ -3973,9 +3760,6 @@ public struct FfiConverterTypeDocImportFileCallback: FfiConverter {
     }
 }
 
-
-
-
 public func FfiConverterTypeDocImportFileCallback_lift(_ pointer: UnsafeMutableRawPointer) throws -> DocImportFileCallback {
     return try FfiConverterTypeDocImportFileCallback.lift(pointer)
 }
@@ -3984,51 +3768,47 @@ public func FfiConverterTypeDocImportFileCallback_lower(_ value: DocImportFileCa
     return FfiConverterTypeDocImportFileCallback.lower(value)
 }
 
-
-
-
 /**
  * Progress updates for the doc import file operation.
  */
-public protocol DocImportProgressProtocol : AnyObject {
-    
+public protocol DocImportProgressProtocol: AnyObject {
     /**
      * Return the `DocImportProgressAbort`
      */
-    func asAbort()  -> DocImportProgressAbort
-    
+    func asAbort() -> DocImportProgressAbort
+
     /**
      * Return the `DocImportProgressAllDone`
      */
-    func asAllDone()  -> DocImportProgressAllDone
-    
+    func asAllDone() -> DocImportProgressAllDone
+
     /**
      * Return the `DocImportProgressFound` event
      */
-    func asFound()  -> DocImportProgressFound
-    
+    func asFound() -> DocImportProgressFound
+
     /**
      * Return the `DocImportProgressDone` event
      */
-    func asIngestDone()  -> DocImportProgressIngestDone
-    
+    func asIngestDone() -> DocImportProgressIngestDone
+
     /**
      * Return the `DocImportProgressProgress` event
      */
-    func asProgress()  -> DocImportProgressProgress
-    
+    func asProgress() -> DocImportProgressProgress
+
     /**
      * Get the type of event
      */
-    func type()  -> DocImportProgressType
-    
+    func type() -> DocImportProgressType
 }
 
 /**
  * Progress updates for the doc import file operation.
  */
 open class DocImportProgress:
-    DocImportProgressProtocol {
+    DocImportProgressProtocol
+{
     fileprivate let pointer: UnsafeMutableRawPointer!
 
     /// Used to instantiate a [FFIObject] without an actual pointer, for fakes in tests, mostly.
@@ -4039,7 +3819,7 @@ open class DocImportProgress:
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-    required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
+    public required init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
 
@@ -4048,13 +3828,14 @@ open class DocImportProgress:
     ///
     /// - Warning:
     ///     Any object instantiated with this constructor cannot be passed to an actual Rust-backed object. Since there isn't a backing [Pointer] the FFI lower functions will crash.
-    public init(noPointer: NoPointer) {
-        self.pointer = nil
+    public init(noPointer _: NoPointer) {
+        pointer = nil
     }
 
     public func uniffiClonePointer() -> UnsafeMutableRawPointer {
         return try! rustCall { uniffi_iroh_ffi_fn_clone_docimportprogress(self.pointer, $0) }
     }
+
     // No primary constructor declared for this class.
 
     deinit {
@@ -4065,74 +3846,62 @@ open class DocImportProgress:
         try! rustCall { uniffi_iroh_ffi_fn_free_docimportprogress(pointer, $0) }
     }
 
-    
-
-    
     /**
      * Return the `DocImportProgressAbort`
      */
-open func asAbort() -> DocImportProgressAbort {
-    return try!  FfiConverterTypeDocImportProgressAbort.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_docimportprogress_as_abort(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
+    open func asAbort() -> DocImportProgressAbort {
+        return try! FfiConverterTypeDocImportProgressAbort.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_docimportprogress_as_abort(self.uniffiClonePointer(), $0)
+        })
+    }
+
     /**
      * Return the `DocImportProgressAllDone`
      */
-open func asAllDone() -> DocImportProgressAllDone {
-    return try!  FfiConverterTypeDocImportProgressAllDone.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_docimportprogress_as_all_done(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
+    open func asAllDone() -> DocImportProgressAllDone {
+        return try! FfiConverterTypeDocImportProgressAllDone.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_docimportprogress_as_all_done(self.uniffiClonePointer(), $0)
+        })
+    }
+
     /**
      * Return the `DocImportProgressFound` event
      */
-open func asFound() -> DocImportProgressFound {
-    return try!  FfiConverterTypeDocImportProgressFound.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_docimportprogress_as_found(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
+    open func asFound() -> DocImportProgressFound {
+        return try! FfiConverterTypeDocImportProgressFound.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_docimportprogress_as_found(self.uniffiClonePointer(), $0)
+        })
+    }
+
     /**
      * Return the `DocImportProgressDone` event
      */
-open func asIngestDone() -> DocImportProgressIngestDone {
-    return try!  FfiConverterTypeDocImportProgressIngestDone.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_docimportprogress_as_ingest_done(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
+    open func asIngestDone() -> DocImportProgressIngestDone {
+        return try! FfiConverterTypeDocImportProgressIngestDone.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_docimportprogress_as_ingest_done(self.uniffiClonePointer(), $0)
+        })
+    }
+
     /**
      * Return the `DocImportProgressProgress` event
      */
-open func asProgress() -> DocImportProgressProgress {
-    return try!  FfiConverterTypeDocImportProgressProgress.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_docimportprogress_as_progress(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
+    open func asProgress() -> DocImportProgressProgress {
+        return try! FfiConverterTypeDocImportProgressProgress.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_docimportprogress_as_progress(self.uniffiClonePointer(), $0)
+        })
+    }
+
     /**
      * Get the type of event
      */
-open func type() -> DocImportProgressType {
-    return try!  FfiConverterTypeDocImportProgressType.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_docimportprogress_type(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
-
+    open func type() -> DocImportProgressType {
+        return try! FfiConverterTypeDocImportProgressType.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_docimportprogress_type(self.uniffiClonePointer(), $0)
+        })
+    }
 }
 
 public struct FfiConverterTypeDocImportProgress: FfiConverter {
-
     typealias FfiType = UnsafeMutableRawPointer
     typealias SwiftType = DocImportProgress
 
@@ -4149,7 +3918,7 @@ public struct FfiConverterTypeDocImportProgress: FfiConverter {
         // The Rust code won't compile if a pointer won't fit in a UInt64.
         // We have to go via `UInt` because that's the thing that's the size of a pointer.
         let ptr = UnsafeMutableRawPointer(bitPattern: UInt(truncatingIfNeeded: v))
-        if (ptr == nil) {
+        if ptr == nil {
             throw UniffiInternalError.unexpectedNullPointer
         }
         return try lift(ptr!)
@@ -4162,9 +3931,6 @@ public struct FfiConverterTypeDocImportProgress: FfiConverter {
     }
 }
 
-
-
-
 public func FfiConverterTypeDocImportProgress_lift(_ pointer: UnsafeMutableRawPointer) throws -> DocImportProgress {
     return try FfiConverterTypeDocImportProgress.lift(pointer)
 }
@@ -4173,57 +3939,18 @@ public func FfiConverterTypeDocImportProgress_lower(_ value: DocImportProgress) 
     return FfiConverterTypeDocImportProgress.lower(value)
 }
 
-
-
+/**
+ * Contains both a key (either secret or public) to a document, and a list of peers to join.
+ */
+public protocol DocTicketProtocol: AnyObject {}
 
 /**
- * Iroh docs client.
+ * Contains both a key (either secret or public) to a document, and a list of peers to join.
  */
-public protocol DocsProtocol : AnyObject {
-    
-    /**
-     * Create a new doc.
-     */
-    func create() async throws  -> Doc
-    
-    /**
-     * Delete a document from the local node.
-     *
-     * This is a destructive operation. Both the document secret key and all entries in the
-     * document will be permanently deleted from the node's storage. Content blobs will be deleted
-     * through garbage collection unless they are referenced from another document or tag.
-     */
-    func dropDoc(docId: String) async throws 
-    
-    /**
-     * Join and sync with an already existing document.
-     */
-    func join(ticket: String) async throws  -> Doc
-    
-    /**
-     * Join and sync with an already existing document and subscribe to events on that document.
-     */
-    func joinAndSubscribe(ticket: String, cb: SubscribeCallback) async throws  -> Doc
-    
-    /**
-     * List all the docs we have access to on this node.
-     */
-    func list() async throws  -> [NamespaceAndCapability]
-    
-    /**
-     * Get a [`Doc`].
-     *
-     * Returns None if the document cannot be found.
-     */
-    func `open`(id: String) async throws  -> Doc?
-    
-}
-
-/**
- * Iroh docs client.
- */
-open class Docs:
-    DocsProtocol {
+open class DocTicket:
+    CustomStringConvertible,
+    DocTicketProtocol
+{
     fileprivate let pointer: UnsafeMutableRawPointer!
 
     /// Used to instantiate a [FFIObject] without an actual pointer, for fakes in tests, mostly.
@@ -4234,7 +3961,7 @@ open class Docs:
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-    required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
+    public required init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
 
@@ -4243,13 +3970,153 @@ open class Docs:
     ///
     /// - Warning:
     ///     Any object instantiated with this constructor cannot be passed to an actual Rust-backed object. Since there isn't a backing [Pointer] the FFI lower functions will crash.
-    public init(noPointer: NoPointer) {
-        self.pointer = nil
+    public init(noPointer _: NoPointer) {
+        pointer = nil
+    }
+
+    public func uniffiClonePointer() -> UnsafeMutableRawPointer {
+        return try! rustCall { uniffi_iroh_ffi_fn_clone_docticket(self.pointer, $0) }
+    }
+
+    public convenience init(str: String) throws {
+        let pointer =
+            try rustCallWithError(FfiConverterTypeIrohError__as_error.lift) {
+                uniffi_iroh_ffi_fn_constructor_docticket_new(
+                    FfiConverterString.lower(str), $0
+                )
+            }
+        self.init(unsafeFromRawPointer: pointer)
+    }
+
+    deinit {
+        guard let pointer = pointer else {
+            return
+        }
+
+        try! rustCall { uniffi_iroh_ffi_fn_free_docticket(pointer, $0) }
+    }
+
+    open var description: String {
+        return try! FfiConverterString.lift(
+            try! rustCall {
+                uniffi_iroh_ffi_fn_method_docticket_uniffi_trait_display(self.uniffiClonePointer(), $0)
+            }
+        )
+    }
+}
+
+public struct FfiConverterTypeDocTicket: FfiConverter {
+    typealias FfiType = UnsafeMutableRawPointer
+    typealias SwiftType = DocTicket
+
+    public static func lift(_ pointer: UnsafeMutableRawPointer) throws -> DocTicket {
+        return DocTicket(unsafeFromRawPointer: pointer)
+    }
+
+    public static func lower(_ value: DocTicket) -> UnsafeMutableRawPointer {
+        return value.uniffiClonePointer()
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> DocTicket {
+        let v: UInt64 = try readInt(&buf)
+        // The Rust code won't compile if a pointer won't fit in a UInt64.
+        // We have to go via `UInt` because that's the thing that's the size of a pointer.
+        let ptr = UnsafeMutableRawPointer(bitPattern: UInt(truncatingIfNeeded: v))
+        if ptr == nil {
+            throw UniffiInternalError.unexpectedNullPointer
+        }
+        return try lift(ptr!)
+    }
+
+    public static func write(_ value: DocTicket, into buf: inout [UInt8]) {
+        // This fiddling is because `Int` is the thing that's the same size as a pointer.
+        // The Rust code won't compile if a pointer won't fit in a `UInt64`.
+        writeInt(&buf, UInt64(bitPattern: Int64(Int(bitPattern: lower(value)))))
+    }
+}
+
+public func FfiConverterTypeDocTicket_lift(_ pointer: UnsafeMutableRawPointer) throws -> DocTicket {
+    return try FfiConverterTypeDocTicket.lift(pointer)
+}
+
+public func FfiConverterTypeDocTicket_lower(_ value: DocTicket) -> UnsafeMutableRawPointer {
+    return FfiConverterTypeDocTicket.lower(value)
+}
+
+/**
+ * Iroh docs client.
+ */
+public protocol DocsProtocol: AnyObject {
+    /**
+     * Create a new doc.
+     */
+    func create() async throws -> Doc
+
+    /**
+     * Delete a document from the local node.
+     *
+     * This is a destructive operation. Both the document secret key and all entries in the
+     * document will be permanently deleted from the node's storage. Content blobs will be deleted
+     * through garbage collection unless they are referenced from another document or tag.
+     */
+    func dropDoc(docId: String) async throws
+
+    /**
+     * Join and sync with an already existing document.
+     */
+    func join(ticket: DocTicket) async throws -> Doc
+
+    /**
+     * Join and sync with an already existing document and subscribe to events on that document.
+     */
+    func joinAndSubscribe(ticket: DocTicket, cb: SubscribeCallback) async throws -> Doc
+
+    /**
+     * List all the docs we have access to on this node.
+     */
+    func list() async throws -> [NamespaceAndCapability]
+
+    /**
+     * Get a [`Doc`].
+     *
+     * Returns None if the document cannot be found.
+     */
+    func open(id: String) async throws -> Doc?
+}
+
+/**
+ * Iroh docs client.
+ */
+open class Docs:
+    DocsProtocol
+{
+    fileprivate let pointer: UnsafeMutableRawPointer!
+
+    /// Used to instantiate a [FFIObject] without an actual pointer, for fakes in tests, mostly.
+    public struct NoPointer {
+        public init() {}
+    }
+
+    // TODO: We'd like this to be `private` but for Swifty reasons,
+    // we can't implement `FfiConverter` without making this `required` and we can't
+    // make it `required` without making it `public`.
+    public required init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
+        self.pointer = pointer
+    }
+
+    /// This constructor can be used to instantiate a fake object.
+    /// - Parameter noPointer: Placeholder value so we can have a constructor separate from the default empty one that may be implemented for classes extending [FFIObject].
+    ///
+    /// - Warning:
+    ///     Any object instantiated with this constructor cannot be passed to an actual Rust-backed object. Since there isn't a backing [Pointer] the FFI lower functions will crash.
+    public init(noPointer _: NoPointer) {
+        pointer = nil
     }
 
     public func uniffiClonePointer() -> UnsafeMutableRawPointer {
         return try! rustCall { uniffi_iroh_ffi_fn_clone_docs(self.pointer, $0) }
     }
+
     // No primary constructor declared for this class.
 
     deinit {
@@ -4260,29 +4127,25 @@ open class Docs:
         try! rustCall { uniffi_iroh_ffi_fn_free_docs(pointer, $0) }
     }
 
-    
-
-    
     /**
      * Create a new doc.
      */
-open func create()async throws  -> Doc {
-    return
-        try  await uniffiRustCallAsync(
-            rustFutureFunc: {
-                uniffi_iroh_ffi_fn_method_docs_create(
-                    self.uniffiClonePointer()
-                    
-                )
-            },
-            pollFunc: ffi_iroh_ffi_rust_future_poll_pointer,
-            completeFunc: ffi_iroh_ffi_rust_future_complete_pointer,
-            freeFunc: ffi_iroh_ffi_rust_future_free_pointer,
-            liftFunc: FfiConverterTypeDoc.lift,
-            errorHandler: FfiConverterTypeIrohError__as_error.lift
-        )
-}
-    
+    open func create() async throws -> Doc {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_docs_create(
+                        self.uniffiClonePointer()
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_pointer,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_pointer,
+                freeFunc: ffi_iroh_ffi_rust_future_free_pointer,
+                liftFunc: FfiConverterTypeDoc.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
     /**
      * Delete a document from the local node.
      *
@@ -4290,110 +4153,106 @@ open func create()async throws  -> Doc {
      * document will be permanently deleted from the node's storage. Content blobs will be deleted
      * through garbage collection unless they are referenced from another document or tag.
      */
-open func dropDoc(docId: String)async throws  {
-    return
-        try  await uniffiRustCallAsync(
-            rustFutureFunc: {
-                uniffi_iroh_ffi_fn_method_docs_drop_doc(
-                    self.uniffiClonePointer(),
-                    FfiConverterString.lower(docId)
-                )
-            },
-            pollFunc: ffi_iroh_ffi_rust_future_poll_void,
-            completeFunc: ffi_iroh_ffi_rust_future_complete_void,
-            freeFunc: ffi_iroh_ffi_rust_future_free_void,
-            liftFunc: { $0 },
-            errorHandler: FfiConverterTypeIrohError__as_error.lift
-        )
-}
-    
+    open func dropDoc(docId: String) async throws {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_docs_drop_doc(
+                        self.uniffiClonePointer(),
+                        FfiConverterString.lower(docId)
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_void,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_void,
+                freeFunc: ffi_iroh_ffi_rust_future_free_void,
+                liftFunc: { $0 },
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
     /**
      * Join and sync with an already existing document.
      */
-open func join(ticket: String)async throws  -> Doc {
-    return
-        try  await uniffiRustCallAsync(
-            rustFutureFunc: {
-                uniffi_iroh_ffi_fn_method_docs_join(
-                    self.uniffiClonePointer(),
-                    FfiConverterString.lower(ticket)
-                )
-            },
-            pollFunc: ffi_iroh_ffi_rust_future_poll_pointer,
-            completeFunc: ffi_iroh_ffi_rust_future_complete_pointer,
-            freeFunc: ffi_iroh_ffi_rust_future_free_pointer,
-            liftFunc: FfiConverterTypeDoc.lift,
-            errorHandler: FfiConverterTypeIrohError__as_error.lift
-        )
-}
-    
+    open func join(ticket: DocTicket) async throws -> Doc {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_docs_join(
+                        self.uniffiClonePointer(),
+                        FfiConverterTypeDocTicket.lower(ticket)
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_pointer,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_pointer,
+                freeFunc: ffi_iroh_ffi_rust_future_free_pointer,
+                liftFunc: FfiConverterTypeDoc.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
     /**
      * Join and sync with an already existing document and subscribe to events on that document.
      */
-open func joinAndSubscribe(ticket: String, cb: SubscribeCallback)async throws  -> Doc {
-    return
-        try  await uniffiRustCallAsync(
-            rustFutureFunc: {
-                uniffi_iroh_ffi_fn_method_docs_join_and_subscribe(
-                    self.uniffiClonePointer(),
-                    FfiConverterString.lower(ticket),FfiConverterTypeSubscribeCallback.lower(cb)
-                )
-            },
-            pollFunc: ffi_iroh_ffi_rust_future_poll_pointer,
-            completeFunc: ffi_iroh_ffi_rust_future_complete_pointer,
-            freeFunc: ffi_iroh_ffi_rust_future_free_pointer,
-            liftFunc: FfiConverterTypeDoc.lift,
-            errorHandler: FfiConverterTypeIrohError__as_error.lift
-        )
-}
-    
+    open func joinAndSubscribe(ticket: DocTicket, cb: SubscribeCallback) async throws -> Doc {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_docs_join_and_subscribe(
+                        self.uniffiClonePointer(),
+                        FfiConverterTypeDocTicket.lower(ticket), FfiConverterTypeSubscribeCallback.lower(cb)
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_pointer,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_pointer,
+                freeFunc: ffi_iroh_ffi_rust_future_free_pointer,
+                liftFunc: FfiConverterTypeDoc.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
     /**
      * List all the docs we have access to on this node.
      */
-open func list()async throws  -> [NamespaceAndCapability] {
-    return
-        try  await uniffiRustCallAsync(
-            rustFutureFunc: {
-                uniffi_iroh_ffi_fn_method_docs_list(
-                    self.uniffiClonePointer()
-                    
-                )
-            },
-            pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
-            completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
-            freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
-            liftFunc: FfiConverterSequenceTypeNamespaceAndCapability.lift,
-            errorHandler: FfiConverterTypeIrohError__as_error.lift
-        )
-}
-    
+    open func list() async throws -> [NamespaceAndCapability] {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_docs_list(
+                        self.uniffiClonePointer()
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
+                freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
+                liftFunc: FfiConverterSequenceTypeNamespaceAndCapability.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
     /**
      * Get a [`Doc`].
      *
      * Returns None if the document cannot be found.
      */
-open func `open`(id: String)async throws  -> Doc? {
-    return
-        try  await uniffiRustCallAsync(
-            rustFutureFunc: {
-                uniffi_iroh_ffi_fn_method_docs_open(
-                    self.uniffiClonePointer(),
-                    FfiConverterString.lower(id)
-                )
-            },
-            pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
-            completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
-            freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
-            liftFunc: FfiConverterOptionTypeDoc.lift,
-            errorHandler: FfiConverterTypeIrohError__as_error.lift
-        )
-}
-    
-
+    open func open(id: String) async throws -> Doc? {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_docs_open(
+                        self.uniffiClonePointer(),
+                        FfiConverterString.lower(id)
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
+                freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
+                liftFunc: FfiConverterOptionTypeDoc.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
 }
 
 public struct FfiConverterTypeDocs: FfiConverter {
-
     typealias FfiType = UnsafeMutableRawPointer
     typealias SwiftType = Docs
 
@@ -4410,7 +4269,7 @@ public struct FfiConverterTypeDocs: FfiConverter {
         // The Rust code won't compile if a pointer won't fit in a UInt64.
         // We have to go via `UInt` because that's the thing that's the size of a pointer.
         let ptr = UnsafeMutableRawPointer(bitPattern: UInt(truncatingIfNeeded: v))
-        if (ptr == nil) {
+        if ptr == nil {
             throw UniffiInternalError.unexpectedNullPointer
         }
         return try lift(ptr!)
@@ -4423,9 +4282,6 @@ public struct FfiConverterTypeDocs: FfiConverter {
     }
 }
 
-
-
-
 public func FfiConverterTypeDocs_lift(_ pointer: UnsafeMutableRawPointer) throws -> Docs {
     return try FfiConverterTypeDocs.lift(pointer)
 }
@@ -4434,18 +4290,13 @@ public func FfiConverterTypeDocs_lower(_ value: Docs) -> UnsafeMutableRawPointer
     return FfiConverterTypeDocs.lower(value)
 }
 
-
-
-
 /**
  * The `progress` method will be called for each `DownloadProgress` event that is emitted during
  * a `node.blobs_download`. Use the `DownloadProgress.type()` method to check the
  * `DownloadProgressType` of the event.
  */
-public protocol DownloadCallback : AnyObject {
-    
-    func progress(progress: DownloadProgress) async throws 
-    
+public protocol DownloadCallback: AnyObject {
+    func progress(progress: DownloadProgress) async throws
 }
 
 /**
@@ -4454,7 +4305,8 @@ public protocol DownloadCallback : AnyObject {
  * `DownloadProgressType` of the event.
  */
 open class DownloadCallbackImpl:
-    DownloadCallback {
+    DownloadCallback
+{
     fileprivate let pointer: UnsafeMutableRawPointer!
 
     /// Used to instantiate a [FFIObject] without an actual pointer, for fakes in tests, mostly.
@@ -4465,7 +4317,7 @@ open class DownloadCallbackImpl:
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-    required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
+    public required init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
 
@@ -4474,13 +4326,14 @@ open class DownloadCallbackImpl:
     ///
     /// - Warning:
     ///     Any object instantiated with this constructor cannot be passed to an actual Rust-backed object. Since there isn't a backing [Pointer] the FFI lower functions will crash.
-    public init(noPointer: NoPointer) {
-        self.pointer = nil
+    public init(noPointer _: NoPointer) {
+        pointer = nil
     }
 
     public func uniffiClonePointer() -> UnsafeMutableRawPointer {
         return try! rustCall { uniffi_iroh_ffi_fn_clone_downloadcallback(self.pointer, $0) }
     }
+
     // No primary constructor declared for this class.
 
     deinit {
@@ -4491,36 +4344,29 @@ open class DownloadCallbackImpl:
         try! rustCall { uniffi_iroh_ffi_fn_free_downloadcallback(pointer, $0) }
     }
 
-    
-
-    
-open func progress(progress: DownloadProgress)async throws  {
-    return
-        try  await uniffiRustCallAsync(
-            rustFutureFunc: {
-                uniffi_iroh_ffi_fn_method_downloadcallback_progress(
-                    self.uniffiClonePointer(),
-                    FfiConverterTypeDownloadProgress.lower(progress)
-                )
-            },
-            pollFunc: ffi_iroh_ffi_rust_future_poll_void,
-            completeFunc: ffi_iroh_ffi_rust_future_complete_void,
-            freeFunc: ffi_iroh_ffi_rust_future_free_void,
-            liftFunc: { $0 },
-            errorHandler: FfiConverterTypeCallbackError.lift
-        )
+    open func progress(progress: DownloadProgress) async throws {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_downloadcallback_progress(
+                        self.uniffiClonePointer(),
+                        FfiConverterTypeDownloadProgress.lower(progress)
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_void,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_void,
+                freeFunc: ffi_iroh_ffi_rust_future_free_void,
+                liftFunc: { $0 },
+                errorHandler: FfiConverterTypeCallbackError.lift
+            )
+    }
 }
-    
-
-}
-
 
 // Put the implementation in a struct so we don't pollute the top-level namespace
-fileprivate struct UniffiCallbackInterfaceDownloadCallback {
-
+private enum UniffiCallbackInterfaceDownloadCallback {
     // Create the VTable using a series of closures.
     // Swift automatically converts these into C callback functions.
-    static var vtable: UniffiVTableCallbackInterfaceDownloadCallback = UniffiVTableCallbackInterfaceDownloadCallback(
+    static var vtable: UniffiVTableCallbackInterfaceDownloadCallback = .init(
         progress: { (
             uniffiHandle: UInt64,
             progress: UnsafeMutableRawPointer,
@@ -4529,16 +4375,16 @@ fileprivate struct UniffiCallbackInterfaceDownloadCallback {
             uniffiOutReturn: UnsafeMutablePointer<UniffiForeignFuture>
         ) in
             let makeCall = {
-                () async throws -> () in
+                () async throws in
                 guard let uniffiObj = try? FfiConverterTypeDownloadCallback.handleMap.get(handle: uniffiHandle) else {
                     throw UniffiInternalError.unexpectedStaleHandle
                 }
                 return try await uniffiObj.progress(
-                     progress: try FfiConverterTypeDownloadProgress.lift(progress)
+                    progress: FfiConverterTypeDownloadProgress.lift(progress)
                 )
             }
 
-            let uniffiHandleSuccess = { (returnValue: ()) in
+            let uniffiHandleSuccess = { (_: ()) in
                 uniffiFutureCallback(
                     uniffiCallbackData,
                     UniffiForeignFutureStructVoid(
@@ -4546,7 +4392,7 @@ fileprivate struct UniffiCallbackInterfaceDownloadCallback {
                     )
                 )
             }
-            let uniffiHandleError = { (statusCode, errorBuf) in
+            let uniffiHandleError = { statusCode, errorBuf in
                 uniffiFutureCallback(
                     uniffiCallbackData,
                     UniffiForeignFutureStructVoid(
@@ -4562,7 +4408,7 @@ fileprivate struct UniffiCallbackInterfaceDownloadCallback {
             )
             uniffiOutReturn.pointee = uniffiForeignFuture
         },
-        uniffiFree: { (uniffiHandle: UInt64) -> () in
+        uniffiFree: { (uniffiHandle: UInt64) in
             let result = try? FfiConverterTypeDownloadCallback.handleMap.remove(handle: uniffiHandle)
             if result == nil {
                 print("Uniffi callback interface DownloadCallback: handle missing in uniffiFree")
@@ -4597,7 +4443,7 @@ public struct FfiConverterTypeDownloadCallback: FfiConverter {
         // The Rust code won't compile if a pointer won't fit in a UInt64.
         // We have to go via `UInt` because that's the thing that's the size of a pointer.
         let ptr = UnsafeMutableRawPointer(bitPattern: UInt(truncatingIfNeeded: v))
-        if (ptr == nil) {
+        if ptr == nil {
             throw UniffiInternalError.unexpectedNullPointer
         }
         return try lift(ptr!)
@@ -4610,9 +4456,6 @@ public struct FfiConverterTypeDownloadCallback: FfiConverter {
     }
 }
 
-
-
-
 public func FfiConverterTypeDownloadCallback_lift(_ pointer: UnsafeMutableRawPointer) throws -> DownloadCallback {
     return try FfiConverterTypeDownloadCallback.lift(pointer)
 }
@@ -4621,21 +4464,17 @@ public func FfiConverterTypeDownloadCallback_lower(_ value: DownloadCallback) ->
     return FfiConverterTypeDownloadCallback.lower(value)
 }
 
-
-
-
 /**
  * Download policy to decide which content blobs shall be downloaded.
  */
-public protocol DownloadPolicyProtocol : AnyObject {
-    
-}
+public protocol DownloadPolicyProtocol: AnyObject {}
 
 /**
  * Download policy to decide which content blobs shall be downloaded.
  */
 open class DownloadPolicy:
-    DownloadPolicyProtocol {
+    DownloadPolicyProtocol
+{
     fileprivate let pointer: UnsafeMutableRawPointer!
 
     /// Used to instantiate a [FFIObject] without an actual pointer, for fakes in tests, mostly.
@@ -4646,7 +4485,7 @@ open class DownloadPolicy:
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-    required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
+    public required init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
 
@@ -4655,13 +4494,14 @@ open class DownloadPolicy:
     ///
     /// - Warning:
     ///     Any object instantiated with this constructor cannot be passed to an actual Rust-backed object. Since there isn't a backing [Pointer] the FFI lower functions will crash.
-    public init(noPointer: NoPointer) {
-        self.pointer = nil
+    public init(noPointer _: NoPointer) {
+        pointer = nil
     }
 
     public func uniffiClonePointer() -> UnsafeMutableRawPointer {
         return try! rustCall { uniffi_iroh_ffi_fn_clone_downloadpolicy(self.pointer, $0) }
     }
+
     // No primary constructor declared for this class.
 
     deinit {
@@ -4672,56 +4512,50 @@ open class DownloadPolicy:
         try! rustCall { uniffi_iroh_ffi_fn_free_downloadpolicy(pointer, $0) }
     }
 
-    
     /**
      * Download everything
      */
-public static func everything() -> DownloadPolicy {
-    return try!  FfiConverterTypeDownloadPolicy.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_constructor_downloadpolicy_everything($0
-    )
-})
-}
-    
+    public static func everything() -> DownloadPolicy {
+        return try! FfiConverterTypeDownloadPolicy.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_constructor_downloadpolicy_everything($0
+            )
+        })
+    }
+
     /**
      * Download everything except keys that match the given filters
      */
-public static func everythingExcept(filters: [FilterKind]) -> DownloadPolicy {
-    return try!  FfiConverterTypeDownloadPolicy.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_constructor_downloadpolicy_everything_except(
-        FfiConverterSequenceTypeFilterKind.lower(filters),$0
-    )
-})
-}
-    
+    public static func everythingExcept(filters: [FilterKind]) -> DownloadPolicy {
+        return try! FfiConverterTypeDownloadPolicy.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_constructor_downloadpolicy_everything_except(
+                FfiConverterSequenceTypeFilterKind.lower(filters), $0
+            )
+        })
+    }
+
     /**
      * Download nothing
      */
-public static func nothing() -> DownloadPolicy {
-    return try!  FfiConverterTypeDownloadPolicy.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_constructor_downloadpolicy_nothing($0
-    )
-})
-}
-    
+    public static func nothing() -> DownloadPolicy {
+        return try! FfiConverterTypeDownloadPolicy.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_constructor_downloadpolicy_nothing($0
+            )
+        })
+    }
+
     /**
      * Download nothing except keys that match the given filters
      */
-public static func nothingExcept(filters: [FilterKind]) -> DownloadPolicy {
-    return try!  FfiConverterTypeDownloadPolicy.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_constructor_downloadpolicy_nothing_except(
-        FfiConverterSequenceTypeFilterKind.lower(filters),$0
-    )
-})
-}
-    
-
-    
-
+    public static func nothingExcept(filters: [FilterKind]) -> DownloadPolicy {
+        return try! FfiConverterTypeDownloadPolicy.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_constructor_downloadpolicy_nothing_except(
+                FfiConverterSequenceTypeFilterKind.lower(filters), $0
+            )
+        })
+    }
 }
 
 public struct FfiConverterTypeDownloadPolicy: FfiConverter {
-
     typealias FfiType = UnsafeMutableRawPointer
     typealias SwiftType = DownloadPolicy
 
@@ -4738,7 +4572,7 @@ public struct FfiConverterTypeDownloadPolicy: FfiConverter {
         // The Rust code won't compile if a pointer won't fit in a UInt64.
         // We have to go via `UInt` because that's the thing that's the size of a pointer.
         let ptr = UnsafeMutableRawPointer(bitPattern: UInt(truncatingIfNeeded: v))
-        if (ptr == nil) {
+        if ptr == nil {
             throw UniffiInternalError.unexpectedNullPointer
         }
         return try lift(ptr!)
@@ -4751,9 +4585,6 @@ public struct FfiConverterTypeDownloadPolicy: FfiConverter {
     }
 }
 
-
-
-
 public func FfiConverterTypeDownloadPolicy_lift(_ pointer: UnsafeMutableRawPointer) throws -> DownloadPolicy {
     return try FfiConverterTypeDownloadPolicy.lift(pointer)
 }
@@ -4762,62 +4593,58 @@ public func FfiConverterTypeDownloadPolicy_lower(_ value: DownloadPolicy) -> Uns
     return FfiConverterTypeDownloadPolicy.lower(value)
 }
 
-
-
-
 /**
  * Progress updates for the get operation.
  */
-public protocol DownloadProgressProtocol : AnyObject {
-    
+public protocol DownloadProgressProtocol: AnyObject {
     /**
      * Return the `DownloadProgressAbort` event
      */
-    func asAbort()  -> DownloadProgressAbort
-    
+    func asAbort() -> DownloadProgressAbort
+
     /**
      * Return the `DownloadProgressAllDone` event
      */
-    func asAllDone()  -> DownloadProgressAllDone
-    
+    func asAllDone() -> DownloadProgressAllDone
+
     /**
      * Return the `DownloadProgressDone` event
      */
-    func asDone()  -> DownloadProgressDone
-    
+    func asDone() -> DownloadProgressDone
+
     /**
      * Return the `DownloadProgressFound` event
      */
-    func asFound()  -> DownloadProgressFound
-    
+    func asFound() -> DownloadProgressFound
+
     /**
      * Return the `DownloadProgressFoundHashSeq` event
      */
-    func asFoundHashSeq()  -> DownloadProgressFoundHashSeq
-    
+    func asFoundHashSeq() -> DownloadProgressFoundHashSeq
+
     /**
      * Return the `DownloadProgressFoundLocal` event
      */
-    func asFoundLocal()  -> DownloadProgressFoundLocal
-    
+    func asFoundLocal() -> DownloadProgressFoundLocal
+
     /**
      * Return the `DownloadProgressProgress` event
      */
-    func asProgress()  -> DownloadProgressProgress
-    
+    func asProgress() -> DownloadProgressProgress
+
     /**
      * Get the type of event
      * note that there is no `as_connected` method, as the `Connected` event has no associated data
      */
-    func type()  -> DownloadProgressType
-    
+    func type() -> DownloadProgressType
 }
 
 /**
  * Progress updates for the get operation.
  */
 open class DownloadProgress:
-    DownloadProgressProtocol {
+    DownloadProgressProtocol
+{
     fileprivate let pointer: UnsafeMutableRawPointer!
 
     /// Used to instantiate a [FFIObject] without an actual pointer, for fakes in tests, mostly.
@@ -4828,7 +4655,7 @@ open class DownloadProgress:
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-    required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
+    public required init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
 
@@ -4837,13 +4664,14 @@ open class DownloadProgress:
     ///
     /// - Warning:
     ///     Any object instantiated with this constructor cannot be passed to an actual Rust-backed object. Since there isn't a backing [Pointer] the FFI lower functions will crash.
-    public init(noPointer: NoPointer) {
-        self.pointer = nil
+    public init(noPointer _: NoPointer) {
+        pointer = nil
     }
 
     public func uniffiClonePointer() -> UnsafeMutableRawPointer {
         return try! rustCall { uniffi_iroh_ffi_fn_clone_downloadprogress(self.pointer, $0) }
     }
+
     // No primary constructor declared for this class.
 
     deinit {
@@ -4854,95 +4682,81 @@ open class DownloadProgress:
         try! rustCall { uniffi_iroh_ffi_fn_free_downloadprogress(pointer, $0) }
     }
 
-    
-
-    
     /**
      * Return the `DownloadProgressAbort` event
      */
-open func asAbort() -> DownloadProgressAbort {
-    return try!  FfiConverterTypeDownloadProgressAbort.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_downloadprogress_as_abort(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
+    open func asAbort() -> DownloadProgressAbort {
+        return try! FfiConverterTypeDownloadProgressAbort.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_downloadprogress_as_abort(self.uniffiClonePointer(), $0)
+        })
+    }
+
     /**
      * Return the `DownloadProgressAllDone` event
      */
-open func asAllDone() -> DownloadProgressAllDone {
-    return try!  FfiConverterTypeDownloadProgressAllDone.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_downloadprogress_as_all_done(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
+    open func asAllDone() -> DownloadProgressAllDone {
+        return try! FfiConverterTypeDownloadProgressAllDone.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_downloadprogress_as_all_done(self.uniffiClonePointer(), $0)
+        })
+    }
+
     /**
      * Return the `DownloadProgressDone` event
      */
-open func asDone() -> DownloadProgressDone {
-    return try!  FfiConverterTypeDownloadProgressDone.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_downloadprogress_as_done(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
+    open func asDone() -> DownloadProgressDone {
+        return try! FfiConverterTypeDownloadProgressDone.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_downloadprogress_as_done(self.uniffiClonePointer(), $0)
+        })
+    }
+
     /**
      * Return the `DownloadProgressFound` event
      */
-open func asFound() -> DownloadProgressFound {
-    return try!  FfiConverterTypeDownloadProgressFound.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_downloadprogress_as_found(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
+    open func asFound() -> DownloadProgressFound {
+        return try! FfiConverterTypeDownloadProgressFound.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_downloadprogress_as_found(self.uniffiClonePointer(), $0)
+        })
+    }
+
     /**
      * Return the `DownloadProgressFoundHashSeq` event
      */
-open func asFoundHashSeq() -> DownloadProgressFoundHashSeq {
-    return try!  FfiConverterTypeDownloadProgressFoundHashSeq.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_downloadprogress_as_found_hash_seq(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
+    open func asFoundHashSeq() -> DownloadProgressFoundHashSeq {
+        return try! FfiConverterTypeDownloadProgressFoundHashSeq.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_downloadprogress_as_found_hash_seq(self.uniffiClonePointer(), $0)
+        })
+    }
+
     /**
      * Return the `DownloadProgressFoundLocal` event
      */
-open func asFoundLocal() -> DownloadProgressFoundLocal {
-    return try!  FfiConverterTypeDownloadProgressFoundLocal.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_downloadprogress_as_found_local(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
+    open func asFoundLocal() -> DownloadProgressFoundLocal {
+        return try! FfiConverterTypeDownloadProgressFoundLocal.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_downloadprogress_as_found_local(self.uniffiClonePointer(), $0)
+        })
+    }
+
     /**
      * Return the `DownloadProgressProgress` event
      */
-open func asProgress() -> DownloadProgressProgress {
-    return try!  FfiConverterTypeDownloadProgressProgress.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_downloadprogress_as_progress(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
+    open func asProgress() -> DownloadProgressProgress {
+        return try! FfiConverterTypeDownloadProgressProgress.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_downloadprogress_as_progress(self.uniffiClonePointer(), $0)
+        })
+    }
+
     /**
      * Get the type of event
      * note that there is no `as_connected` method, as the `Connected` event has no associated data
      */
-open func type() -> DownloadProgressType {
-    return try!  FfiConverterTypeDownloadProgressType.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_downloadprogress_type(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
-
+    open func type() -> DownloadProgressType {
+        return try! FfiConverterTypeDownloadProgressType.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_downloadprogress_type(self.uniffiClonePointer(), $0)
+        })
+    }
 }
 
 public struct FfiConverterTypeDownloadProgress: FfiConverter {
-
     typealias FfiType = UnsafeMutableRawPointer
     typealias SwiftType = DownloadProgress
 
@@ -4959,7 +4773,7 @@ public struct FfiConverterTypeDownloadProgress: FfiConverter {
         // The Rust code won't compile if a pointer won't fit in a UInt64.
         // We have to go via `UInt` because that's the thing that's the size of a pointer.
         let ptr = UnsafeMutableRawPointer(bitPattern: UInt(truncatingIfNeeded: v))
-        if (ptr == nil) {
+        if ptr == nil {
             throw UniffiInternalError.unexpectedNullPointer
         }
         return try lift(ptr!)
@@ -4972,9 +4786,6 @@ public struct FfiConverterTypeDownloadProgress: FfiConverter {
     }
 }
 
-
-
-
 public func FfiConverterTypeDownloadProgress_lift(_ pointer: UnsafeMutableRawPointer) throws -> DownloadProgress {
     return try FfiConverterTypeDownloadProgress.lift(pointer)
 }
@@ -4983,9 +4794,6 @@ public func FfiConverterTypeDownloadProgress_lower(_ value: DownloadProgress) ->
     return FfiConverterTypeDownloadProgress.lower(value)
 }
 
-
-
-
 /**
  * A single entry in a [`Doc`]
  *
@@ -4993,46 +4801,44 @@ public func FfiConverterTypeDownloadProgress_lower(_ value: DownloadProgress) ->
  * namespace id. Its value is the 32-byte BLAKE3 [`hash`]
  * of the entry's content data, the size of this content data, and a timestamp.
  */
-public protocol EntryProtocol : AnyObject {
-    
+public protocol EntryProtocol: AnyObject {
     /**
      * Get the [`AuthorId`] of this entry.
      */
-    func author()  -> AuthorId
-    
+    func author() -> AuthorId
+
     /**
      * Read all content of an [`Entry`] into a buffer.
      * This allocates a buffer for the full entry. Use only if you know that the entry you're
      * reading is small. If not sure, use [`Self::content_len`] and check the size with
      * before calling [`Self::content_bytes`].
      */
-    func contentBytes(doc: Doc) async throws  -> Data
-    
+    func contentBytes(doc: Doc) async throws -> Data
+
     /**
      * Get the content_hash of this entry.
      */
-    func contentHash()  -> Hash
-    
+    func contentHash() -> Hash
+
     /**
      * Get the content_length of this entry.
      */
-    func contentLen()  -> UInt64
-    
+    func contentLen() -> UInt64
+
     /**
      * Get the key of this entry.
      */
-    func key()  -> Data
-    
+    func key() -> Data
+
     /**
      * Get the namespace id of this entry.
      */
-    func namespace()  -> String
-    
+    func namespace() -> String
+
     /**
      * Get the timestamp when this entry was written.
      */
-    func timestamp()  -> UInt64
-    
+    func timestamp() -> UInt64
 }
 
 /**
@@ -5043,7 +4849,8 @@ public protocol EntryProtocol : AnyObject {
  * of the entry's content data, the size of this content data, and a timestamp.
  */
 open class Entry:
-    EntryProtocol {
+    EntryProtocol
+{
     fileprivate let pointer: UnsafeMutableRawPointer!
 
     /// Used to instantiate a [FFIObject] without an actual pointer, for fakes in tests, mostly.
@@ -5054,7 +4861,7 @@ open class Entry:
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-    required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
+    public required init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
 
@@ -5063,13 +4870,14 @@ open class Entry:
     ///
     /// - Warning:
     ///     Any object instantiated with this constructor cannot be passed to an actual Rust-backed object. Since there isn't a backing [Pointer] the FFI lower functions will crash.
-    public init(noPointer: NoPointer) {
-        self.pointer = nil
+    public init(noPointer _: NoPointer) {
+        pointer = nil
     }
 
     public func uniffiClonePointer() -> UnsafeMutableRawPointer {
         return try! rustCall { uniffi_iroh_ffi_fn_clone_entry(self.pointer, $0) }
     }
+
     // No primary constructor declared for this class.
 
     deinit {
@@ -5080,97 +4888,85 @@ open class Entry:
         try! rustCall { uniffi_iroh_ffi_fn_free_entry(pointer, $0) }
     }
 
-    
-
-    
     /**
      * Get the [`AuthorId`] of this entry.
      */
-open func author() -> AuthorId {
-    return try!  FfiConverterTypeAuthorId.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_entry_author(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
+    open func author() -> AuthorId {
+        return try! FfiConverterTypeAuthorId.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_entry_author(self.uniffiClonePointer(), $0)
+        })
+    }
+
     /**
      * Read all content of an [`Entry`] into a buffer.
      * This allocates a buffer for the full entry. Use only if you know that the entry you're
      * reading is small. If not sure, use [`Self::content_len`] and check the size with
      * before calling [`Self::content_bytes`].
      */
-open func contentBytes(doc: Doc)async throws  -> Data {
-    return
-        try  await uniffiRustCallAsync(
-            rustFutureFunc: {
-                uniffi_iroh_ffi_fn_method_entry_content_bytes(
-                    self.uniffiClonePointer(),
-                    FfiConverterTypeDoc.lower(doc)
-                )
-            },
-            pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
-            completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
-            freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
-            liftFunc: FfiConverterData.lift,
-            errorHandler: FfiConverterTypeIrohError__as_error.lift
-        )
-}
-    
+    open func contentBytes(doc: Doc) async throws -> Data {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_entry_content_bytes(
+                        self.uniffiClonePointer(),
+                        FfiConverterTypeDoc.lower(doc)
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
+                freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
+                liftFunc: FfiConverterData.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
     /**
      * Get the content_hash of this entry.
      */
-open func contentHash() -> Hash {
-    return try!  FfiConverterTypeHash.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_entry_content_hash(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
+    open func contentHash() -> Hash {
+        return try! FfiConverterTypeHash.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_entry_content_hash(self.uniffiClonePointer(), $0)
+        })
+    }
+
     /**
      * Get the content_length of this entry.
      */
-open func contentLen() -> UInt64 {
-    return try!  FfiConverterUInt64.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_entry_content_len(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
+    open func contentLen() -> UInt64 {
+        return try! FfiConverterUInt64.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_entry_content_len(self.uniffiClonePointer(), $0)
+        })
+    }
+
     /**
      * Get the key of this entry.
      */
-open func key() -> Data {
-    return try!  FfiConverterData.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_entry_key(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
+    open func key() -> Data {
+        return try! FfiConverterData.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_entry_key(self.uniffiClonePointer(), $0)
+        })
+    }
+
     /**
      * Get the namespace id of this entry.
      */
-open func namespace() -> String {
-    return try!  FfiConverterString.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_entry_namespace(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
+    open func namespace() -> String {
+        return try! FfiConverterString.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_entry_namespace(self.uniffiClonePointer(), $0)
+        })
+    }
+
     /**
      * Get the timestamp when this entry was written.
      */
-open func timestamp() -> UInt64 {
-    return try!  FfiConverterUInt64.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_entry_timestamp(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
-
+    open func timestamp() -> UInt64 {
+        return try! FfiConverterUInt64.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_entry_timestamp(self.uniffiClonePointer(), $0)
+        })
+    }
 }
 
 public struct FfiConverterTypeEntry: FfiConverter {
-
     typealias FfiType = UnsafeMutableRawPointer
     typealias SwiftType = Entry
 
@@ -5187,7 +4983,7 @@ public struct FfiConverterTypeEntry: FfiConverter {
         // The Rust code won't compile if a pointer won't fit in a UInt64.
         // We have to go via `UInt` because that's the thing that's the size of a pointer.
         let ptr = UnsafeMutableRawPointer(bitPattern: UInt(truncatingIfNeeded: v))
-        if (ptr == nil) {
+        if ptr == nil {
             throw UniffiInternalError.unexpectedNullPointer
         }
         return try lift(ptr!)
@@ -5200,9 +4996,6 @@ public struct FfiConverterTypeEntry: FfiConverter {
     }
 }
 
-
-
-
 public func FfiConverterTypeEntry_lift(_ pointer: UnsafeMutableRawPointer) throws -> Entry {
     return try FfiConverterTypeEntry.lift(pointer)
 }
@@ -5211,26 +5004,22 @@ public func FfiConverterTypeEntry_lower(_ value: Entry) -> UnsafeMutableRawPoint
     return FfiConverterTypeEntry.lower(value)
 }
 
-
-
-
 /**
  * Filter strategy used in download policies.
  */
-public protocol FilterKindProtocol : AnyObject {
-    
+public protocol FilterKindProtocol: AnyObject {
     /**
      * Verifies whether this filter matches a given key
      */
-    func matches(key: Data)  -> Bool
-    
+    func matches(key: Data) -> Bool
 }
 
 /**
  * Filter strategy used in download policies.
  */
 open class FilterKind:
-    FilterKindProtocol {
+    FilterKindProtocol
+{
     fileprivate let pointer: UnsafeMutableRawPointer!
 
     /// Used to instantiate a [FFIObject] without an actual pointer, for fakes in tests, mostly.
@@ -5241,7 +5030,7 @@ open class FilterKind:
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-    required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
+    public required init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
 
@@ -5250,13 +5039,14 @@ open class FilterKind:
     ///
     /// - Warning:
     ///     Any object instantiated with this constructor cannot be passed to an actual Rust-backed object. Since there isn't a backing [Pointer] the FFI lower functions will crash.
-    public init(noPointer: NoPointer) {
-        self.pointer = nil
+    public init(noPointer _: NoPointer) {
+        pointer = nil
     }
 
     public func uniffiClonePointer() -> UnsafeMutableRawPointer {
         return try! rustCall { uniffi_iroh_ffi_fn_clone_filterkind(self.pointer, $0) }
     }
+
     // No primary constructor declared for this class.
 
     deinit {
@@ -5267,47 +5057,40 @@ open class FilterKind:
         try! rustCall { uniffi_iroh_ffi_fn_free_filterkind(pointer, $0) }
     }
 
-    
     /**
      * Returns a FilterKind that matches if the contained bytes and the key are the same.
      */
-public static func exact(key: Data) -> FilterKind {
-    return try!  FfiConverterTypeFilterKind.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_constructor_filterkind_exact(
-        FfiConverterData.lower(key),$0
-    )
-})
-}
-    
+    public static func exact(key: Data) -> FilterKind {
+        return try! FfiConverterTypeFilterKind.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_constructor_filterkind_exact(
+                FfiConverterData.lower(key), $0
+            )
+        })
+    }
+
     /**
      * Returns a FilterKind that matches if the contained bytes are a prefix of the key.
      */
-public static func prefix(prefix: Data) -> FilterKind {
-    return try!  FfiConverterTypeFilterKind.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_constructor_filterkind_prefix(
-        FfiConverterData.lower(prefix),$0
-    )
-})
-}
-    
+    public static func prefix(prefix: Data) -> FilterKind {
+        return try! FfiConverterTypeFilterKind.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_constructor_filterkind_prefix(
+                FfiConverterData.lower(prefix), $0
+            )
+        })
+    }
 
-    
     /**
      * Verifies whether this filter matches a given key
      */
-open func matches(key: Data) -> Bool {
-    return try!  FfiConverterBool.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_filterkind_matches(self.uniffiClonePointer(),
-        FfiConverterData.lower(key),$0
-    )
-})
-}
-    
-
+    open func matches(key: Data) -> Bool {
+        return try! FfiConverterBool.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_filterkind_matches(self.uniffiClonePointer(),
+                                                         FfiConverterData.lower(key), $0)
+        })
+    }
 }
 
 public struct FfiConverterTypeFilterKind: FfiConverter {
-
     typealias FfiType = UnsafeMutableRawPointer
     typealias SwiftType = FilterKind
 
@@ -5324,7 +5107,7 @@ public struct FfiConverterTypeFilterKind: FfiConverter {
         // The Rust code won't compile if a pointer won't fit in a UInt64.
         // We have to go via `UInt` because that's the thing that's the size of a pointer.
         let ptr = UnsafeMutableRawPointer(bitPattern: UInt(truncatingIfNeeded: v))
-        if (ptr == nil) {
+        if ptr == nil {
             throw UniffiInternalError.unexpectedNullPointer
         }
         return try lift(ptr!)
@@ -5337,9 +5120,6 @@ public struct FfiConverterTypeFilterKind: FfiConverter {
     }
 }
 
-
-
-
 public func FfiConverterTypeFilterKind_lift(_ pointer: UnsafeMutableRawPointer) throws -> FilterKind {
     return try FfiConverterTypeFilterKind.lift(pointer)
 }
@@ -5348,23 +5128,19 @@ public func FfiConverterTypeFilterKind_lower(_ value: FilterKind) -> UnsafeMutab
     return FfiConverterTypeFilterKind.lower(value)
 }
 
-
-
-
 /**
  * Iroh gossip client.
  */
-public protocol GossipProtocol : AnyObject {
-    
-    func subscribe(topic: Data, bootstrap: [String], cb: GossipMessageCallback) async throws  -> Sender
-    
+public protocol GossipProtocol: AnyObject {
+    func subscribe(topic: Data, bootstrap: [String], cb: GossipMessageCallback) async throws -> Sender
 }
 
 /**
  * Iroh gossip client.
  */
 open class Gossip:
-    GossipProtocol {
+    GossipProtocol
+{
     fileprivate let pointer: UnsafeMutableRawPointer!
 
     /// Used to instantiate a [FFIObject] without an actual pointer, for fakes in tests, mostly.
@@ -5375,7 +5151,7 @@ open class Gossip:
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-    required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
+    public required init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
 
@@ -5384,13 +5160,14 @@ open class Gossip:
     ///
     /// - Warning:
     ///     Any object instantiated with this constructor cannot be passed to an actual Rust-backed object. Since there isn't a backing [Pointer] the FFI lower functions will crash.
-    public init(noPointer: NoPointer) {
-        self.pointer = nil
+    public init(noPointer _: NoPointer) {
+        pointer = nil
     }
 
     public func uniffiClonePointer() -> UnsafeMutableRawPointer {
         return try! rustCall { uniffi_iroh_ffi_fn_clone_gossip(self.pointer, $0) }
     }
+
     // No primary constructor declared for this class.
 
     deinit {
@@ -5401,31 +5178,25 @@ open class Gossip:
         try! rustCall { uniffi_iroh_ffi_fn_free_gossip(pointer, $0) }
     }
 
-    
-
-    
-open func subscribe(topic: Data, bootstrap: [String], cb: GossipMessageCallback)async throws  -> Sender {
-    return
-        try  await uniffiRustCallAsync(
-            rustFutureFunc: {
-                uniffi_iroh_ffi_fn_method_gossip_subscribe(
-                    self.uniffiClonePointer(),
-                    FfiConverterData.lower(topic),FfiConverterSequenceString.lower(bootstrap),FfiConverterTypeGossipMessageCallback.lower(cb)
-                )
-            },
-            pollFunc: ffi_iroh_ffi_rust_future_poll_pointer,
-            completeFunc: ffi_iroh_ffi_rust_future_complete_pointer,
-            freeFunc: ffi_iroh_ffi_rust_future_free_pointer,
-            liftFunc: FfiConverterTypeSender.lift,
-            errorHandler: FfiConverterTypeIrohError__as_error.lift
-        )
-}
-    
-
+    open func subscribe(topic: Data, bootstrap: [String], cb: GossipMessageCallback) async throws -> Sender {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_gossip_subscribe(
+                        self.uniffiClonePointer(),
+                        FfiConverterData.lower(topic), FfiConverterSequenceString.lower(bootstrap), FfiConverterTypeGossipMessageCallback.lower(cb)
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_pointer,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_pointer,
+                freeFunc: ffi_iroh_ffi_rust_future_free_pointer,
+                liftFunc: FfiConverterTypeSender.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
 }
 
 public struct FfiConverterTypeGossip: FfiConverter {
-
     typealias FfiType = UnsafeMutableRawPointer
     typealias SwiftType = Gossip
 
@@ -5442,7 +5213,7 @@ public struct FfiConverterTypeGossip: FfiConverter {
         // The Rust code won't compile if a pointer won't fit in a UInt64.
         // We have to go via `UInt` because that's the thing that's the size of a pointer.
         let ptr = UnsafeMutableRawPointer(bitPattern: UInt(truncatingIfNeeded: v))
-        if (ptr == nil) {
+        if ptr == nil {
             throw UniffiInternalError.unexpectedNullPointer
         }
         return try lift(ptr!)
@@ -5455,9 +5226,6 @@ public struct FfiConverterTypeGossip: FfiConverter {
     }
 }
 
-
-
-
 public func FfiConverterTypeGossip_lift(_ pointer: UnsafeMutableRawPointer) throws -> Gossip {
     return try FfiConverterTypeGossip.lift(pointer)
 }
@@ -5466,17 +5234,13 @@ public func FfiConverterTypeGossip_lower(_ value: Gossip) -> UnsafeMutableRawPoi
     return FfiConverterTypeGossip.lower(value)
 }
 
-
-
-
-public protocol GossipMessageCallback : AnyObject {
-    
-    func onMessage(msg: Message) async throws 
-    
+public protocol GossipMessageCallback: AnyObject {
+    func onMessage(msg: Message) async throws
 }
 
 open class GossipMessageCallbackImpl:
-    GossipMessageCallback {
+    GossipMessageCallback
+{
     fileprivate let pointer: UnsafeMutableRawPointer!
 
     /// Used to instantiate a [FFIObject] without an actual pointer, for fakes in tests, mostly.
@@ -5487,7 +5251,7 @@ open class GossipMessageCallbackImpl:
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-    required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
+    public required init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
 
@@ -5496,13 +5260,14 @@ open class GossipMessageCallbackImpl:
     ///
     /// - Warning:
     ///     Any object instantiated with this constructor cannot be passed to an actual Rust-backed object. Since there isn't a backing [Pointer] the FFI lower functions will crash.
-    public init(noPointer: NoPointer) {
-        self.pointer = nil
+    public init(noPointer _: NoPointer) {
+        pointer = nil
     }
 
     public func uniffiClonePointer() -> UnsafeMutableRawPointer {
         return try! rustCall { uniffi_iroh_ffi_fn_clone_gossipmessagecallback(self.pointer, $0) }
     }
+
     // No primary constructor declared for this class.
 
     deinit {
@@ -5513,36 +5278,29 @@ open class GossipMessageCallbackImpl:
         try! rustCall { uniffi_iroh_ffi_fn_free_gossipmessagecallback(pointer, $0) }
     }
 
-    
-
-    
-open func onMessage(msg: Message)async throws  {
-    return
-        try  await uniffiRustCallAsync(
-            rustFutureFunc: {
-                uniffi_iroh_ffi_fn_method_gossipmessagecallback_on_message(
-                    self.uniffiClonePointer(),
-                    FfiConverterTypeMessage.lower(msg)
-                )
-            },
-            pollFunc: ffi_iroh_ffi_rust_future_poll_void,
-            completeFunc: ffi_iroh_ffi_rust_future_complete_void,
-            freeFunc: ffi_iroh_ffi_rust_future_free_void,
-            liftFunc: { $0 },
-            errorHandler: FfiConverterTypeCallbackError.lift
-        )
+    open func onMessage(msg: Message) async throws {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_gossipmessagecallback_on_message(
+                        self.uniffiClonePointer(),
+                        FfiConverterTypeMessage.lower(msg)
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_void,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_void,
+                freeFunc: ffi_iroh_ffi_rust_future_free_void,
+                liftFunc: { $0 },
+                errorHandler: FfiConverterTypeCallbackError.lift
+            )
+    }
 }
-    
-
-}
-
 
 // Put the implementation in a struct so we don't pollute the top-level namespace
-fileprivate struct UniffiCallbackInterfaceGossipMessageCallback {
-
+private enum UniffiCallbackInterfaceGossipMessageCallback {
     // Create the VTable using a series of closures.
     // Swift automatically converts these into C callback functions.
-    static var vtable: UniffiVTableCallbackInterfaceGossipMessageCallback = UniffiVTableCallbackInterfaceGossipMessageCallback(
+    static var vtable: UniffiVTableCallbackInterfaceGossipMessageCallback = .init(
         onMessage: { (
             uniffiHandle: UInt64,
             msg: UnsafeMutableRawPointer,
@@ -5551,16 +5309,16 @@ fileprivate struct UniffiCallbackInterfaceGossipMessageCallback {
             uniffiOutReturn: UnsafeMutablePointer<UniffiForeignFuture>
         ) in
             let makeCall = {
-                () async throws -> () in
+                () async throws in
                 guard let uniffiObj = try? FfiConverterTypeGossipMessageCallback.handleMap.get(handle: uniffiHandle) else {
                     throw UniffiInternalError.unexpectedStaleHandle
                 }
                 return try await uniffiObj.onMessage(
-                     msg: try FfiConverterTypeMessage.lift(msg)
+                    msg: FfiConverterTypeMessage.lift(msg)
                 )
             }
 
-            let uniffiHandleSuccess = { (returnValue: ()) in
+            let uniffiHandleSuccess = { (_: ()) in
                 uniffiFutureCallback(
                     uniffiCallbackData,
                     UniffiForeignFutureStructVoid(
@@ -5568,7 +5326,7 @@ fileprivate struct UniffiCallbackInterfaceGossipMessageCallback {
                     )
                 )
             }
-            let uniffiHandleError = { (statusCode, errorBuf) in
+            let uniffiHandleError = { statusCode, errorBuf in
                 uniffiFutureCallback(
                     uniffiCallbackData,
                     UniffiForeignFutureStructVoid(
@@ -5584,7 +5342,7 @@ fileprivate struct UniffiCallbackInterfaceGossipMessageCallback {
             )
             uniffiOutReturn.pointee = uniffiForeignFuture
         },
-        uniffiFree: { (uniffiHandle: UInt64) -> () in
+        uniffiFree: { (uniffiHandle: UInt64) in
             let result = try? FfiConverterTypeGossipMessageCallback.handleMap.remove(handle: uniffiHandle)
             if result == nil {
                 print("Uniffi callback interface GossipMessageCallback: handle missing in uniffiFree")
@@ -5619,7 +5377,7 @@ public struct FfiConverterTypeGossipMessageCallback: FfiConverter {
         // The Rust code won't compile if a pointer won't fit in a UInt64.
         // We have to go via `UInt` because that's the thing that's the size of a pointer.
         let ptr = UnsafeMutableRawPointer(bitPattern: UInt(truncatingIfNeeded: v))
-        if (ptr == nil) {
+        if ptr == nil {
             throw UniffiInternalError.unexpectedNullPointer
         }
         return try lift(ptr!)
@@ -5632,9 +5390,6 @@ public struct FfiConverterTypeGossipMessageCallback: FfiConverter {
     }
 }
 
-
-
-
 public func FfiConverterTypeGossipMessageCallback_lift(_ pointer: UnsafeMutableRawPointer) throws -> GossipMessageCallback {
     return try FfiConverterTypeGossipMessageCallback.lift(pointer)
 }
@@ -5643,29 +5398,24 @@ public func FfiConverterTypeGossipMessageCallback_lower(_ value: GossipMessageCa
     return FfiConverterTypeGossipMessageCallback.lower(value)
 }
 
-
-
-
 /**
  * Hash type used throughout Iroh. A blake3 hash.
  */
-public protocol HashProtocol : AnyObject {
-    
+public protocol HashProtocol: AnyObject {
     /**
      * Returns true if the Hash's have the same value
      */
-    func equal(other: Hash)  -> Bool
-    
+    func equal(other: Hash) -> Bool
+
     /**
      * Bytes of the hash.
      */
-    func toBytes()  -> Data
-    
+    func toBytes() -> Data
+
     /**
      * Convert the hash to a hex string.
      */
-    func toHex()  -> String
-    
+    func toHex() -> String
 }
 
 /**
@@ -5673,7 +5423,8 @@ public protocol HashProtocol : AnyObject {
  */
 open class Hash:
     CustomStringConvertible,
-    HashProtocol {
+    HashProtocol
+{
     fileprivate let pointer: UnsafeMutableRawPointer!
 
     /// Used to instantiate a [FFIObject] without an actual pointer, for fakes in tests, mostly.
@@ -5684,7 +5435,7 @@ open class Hash:
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-    required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
+    public required init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
 
@@ -5693,25 +5444,26 @@ open class Hash:
     ///
     /// - Warning:
     ///     Any object instantiated with this constructor cannot be passed to an actual Rust-backed object. Since there isn't a backing [Pointer] the FFI lower functions will crash.
-    public init(noPointer: NoPointer) {
-        self.pointer = nil
+    public init(noPointer _: NoPointer) {
+        pointer = nil
     }
 
     public func uniffiClonePointer() -> UnsafeMutableRawPointer {
         return try! rustCall { uniffi_iroh_ffi_fn_clone_hash(self.pointer, $0) }
     }
+
     /**
      * Calculate the hash of the provide bytes.
      */
-public convenience init(buf: Data) {
-    let pointer =
-        try! rustCall() {
-    uniffi_iroh_ffi_fn_constructor_hash_new(
-        FfiConverterData.lower(buf),$0
-    )
-}
-    self.init(unsafeFromRawPointer: pointer)
-}
+    public convenience init(buf: Data) {
+        let pointer =
+            try! rustCall {
+                uniffi_iroh_ffi_fn_constructor_hash_new(
+                    FfiConverterData.lower(buf), $0
+                )
+            }
+        self.init(unsafeFromRawPointer: pointer)
+    }
 
     deinit {
         guard let pointer = pointer else {
@@ -5721,75 +5473,66 @@ public convenience init(buf: Data) {
         try! rustCall { uniffi_iroh_ffi_fn_free_hash(pointer, $0) }
     }
 
-    
     /**
      * Create a `Hash` from its raw bytes representation.
      */
-public static func fromBytes(bytes: Data)throws  -> Hash {
-    return try  FfiConverterTypeHash.lift(try rustCallWithError(FfiConverterTypeIrohError__as_error.lift) {
-    uniffi_iroh_ffi_fn_constructor_hash_from_bytes(
-        FfiConverterData.lower(bytes),$0
-    )
-})
-}
-    
+    public static func fromBytes(bytes: Data) throws -> Hash {
+        return try FfiConverterTypeHash.lift(rustCallWithError(FfiConverterTypeIrohError__as_error.lift) {
+            uniffi_iroh_ffi_fn_constructor_hash_from_bytes(
+                FfiConverterData.lower(bytes), $0
+            )
+        })
+    }
+
     /**
      * Make a Hash from hex string
      */
-public static func fromString(s: String)throws  -> Hash {
-    return try  FfiConverterTypeHash.lift(try rustCallWithError(FfiConverterTypeIrohError__as_error.lift) {
-    uniffi_iroh_ffi_fn_constructor_hash_from_string(
-        FfiConverterString.lower(s),$0
-    )
-})
-}
-    
+    public static func fromString(s: String) throws -> Hash {
+        return try FfiConverterTypeHash.lift(rustCallWithError(FfiConverterTypeIrohError__as_error.lift) {
+            uniffi_iroh_ffi_fn_constructor_hash_from_string(
+                FfiConverterString.lower(s), $0
+            )
+        })
+    }
 
-    
     /**
      * Returns true if the Hash's have the same value
      */
-open func equal(other: Hash) -> Bool {
-    return try!  FfiConverterBool.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_hash_equal(self.uniffiClonePointer(),
-        FfiConverterTypeHash.lower(other),$0
-    )
-})
-}
-    
+    open func equal(other: Hash) -> Bool {
+        return try! FfiConverterBool.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_hash_equal(self.uniffiClonePointer(),
+                                                 FfiConverterTypeHash.lower(other), $0)
+        })
+    }
+
     /**
      * Bytes of the hash.
      */
-open func toBytes() -> Data {
-    return try!  FfiConverterData.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_hash_to_bytes(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
+    open func toBytes() -> Data {
+        return try! FfiConverterData.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_hash_to_bytes(self.uniffiClonePointer(), $0)
+        })
+    }
+
     /**
      * Convert the hash to a hex string.
      */
-open func toHex() -> String {
-    return try!  FfiConverterString.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_hash_to_hex(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
-    open var description: String {
-        return try!  FfiConverterString.lift(
-            try! rustCall() {
-    uniffi_iroh_ffi_fn_method_hash_uniffi_trait_display(self.uniffiClonePointer(),$0
-    )
-}
-        )
+    open func toHex() -> String {
+        return try! FfiConverterString.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_hash_to_hex(self.uniffiClonePointer(), $0)
+        })
     }
 
+    open var description: String {
+        return try! FfiConverterString.lift(
+            try! rustCall {
+                uniffi_iroh_ffi_fn_method_hash_uniffi_trait_display(self.uniffiClonePointer(), $0)
+            }
+        )
+    }
 }
 
 public struct FfiConverterTypeHash: FfiConverter {
-
     typealias FfiType = UnsafeMutableRawPointer
     typealias SwiftType = Hash
 
@@ -5806,7 +5549,7 @@ public struct FfiConverterTypeHash: FfiConverter {
         // The Rust code won't compile if a pointer won't fit in a UInt64.
         // We have to go via `UInt` because that's the thing that's the size of a pointer.
         let ptr = UnsafeMutableRawPointer(bitPattern: UInt(truncatingIfNeeded: v))
-        if (ptr == nil) {
+        if ptr == nil {
             throw UniffiInternalError.unexpectedNullPointer
         }
         return try lift(ptr!)
@@ -5819,9 +5562,6 @@ public struct FfiConverterTypeHash: FfiConverter {
     }
 }
 
-
-
-
 public func FfiConverterTypeHash_lift(_ pointer: UnsafeMutableRawPointer) throws -> Hash {
     return try FfiConverterTypeHash.lift(pointer)
 }
@@ -5830,51 +5570,47 @@ public func FfiConverterTypeHash_lower(_ value: Hash) -> UnsafeMutableRawPointer
     return FfiConverterTypeHash.lower(value)
 }
 
-
-
-
 /**
  * An Iroh node. Allows you to sync, store, and transfer data.
  */
-public protocol IrohProtocol : AnyObject {
-    
+public protocol IrohProtocol: AnyObject {
     /**
      * Access to authors specific funtionaliy.
      */
-    func authors()  -> Authors
-    
+    func authors() -> Authors
+
     /**
      * Access to blob specific funtionaliy.
      */
-    func blobs()  -> Blobs
-    
+    func blobs() -> Blobs
+
     /**
      * Access to docs specific funtionaliy.
      */
-    func docs()  -> Docs
-    
+    func docs() -> Docs
+
     /**
      * Access to gossip specific funtionaliy.
      */
-    func gossip()  -> Gossip
-    
+    func gossip() -> Gossip
+
     /**
      * Access to node specific funtionaliy.
      */
-    func node()  -> Node
-    
+    func node() -> Node
+
     /**
      * Access to tags specific funtionaliy.
      */
-    func tags()  -> Tags
-    
+    func tags() -> Tags
 }
 
 /**
  * An Iroh node. Allows you to sync, store, and transfer data.
  */
 open class Iroh:
-    IrohProtocol {
+    IrohProtocol
+{
     fileprivate let pointer: UnsafeMutableRawPointer!
 
     /// Used to instantiate a [FFIObject] without an actual pointer, for fakes in tests, mostly.
@@ -5885,7 +5621,7 @@ open class Iroh:
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-    required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
+    public required init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
 
@@ -5894,13 +5630,14 @@ open class Iroh:
     ///
     /// - Warning:
     ///     Any object instantiated with this constructor cannot be passed to an actual Rust-backed object. Since there isn't a backing [Pointer] the FFI lower functions will crash.
-    public init(noPointer: NoPointer) {
-        self.pointer = nil
+    public init(noPointer _: NoPointer) {
+        pointer = nil
     }
 
     public func uniffiClonePointer() -> UnsafeMutableRawPointer {
         return try! rustCall { uniffi_iroh_ffi_fn_clone_iroh(self.pointer, $0) }
     }
+
     // No primary constructor declared for this class.
 
     deinit {
@@ -5911,151 +5648,138 @@ open class Iroh:
         try! rustCall { uniffi_iroh_ffi_fn_free_iroh(pointer, $0) }
     }
 
-    
     /**
      * Create a new iroh node.
      *
      * All data will be only persistet in memory.
      */
-public static func memory()async throws  -> Iroh {
-    return
-        try  await uniffiRustCallAsync(
-            rustFutureFunc: {
-                uniffi_iroh_ffi_fn_constructor_iroh_memory(
-                )
-            },
-            pollFunc: ffi_iroh_ffi_rust_future_poll_pointer,
-            completeFunc: ffi_iroh_ffi_rust_future_complete_pointer,
-            freeFunc: ffi_iroh_ffi_rust_future_free_pointer,
-            liftFunc: FfiConverterTypeIroh.lift,
-            errorHandler: FfiConverterTypeIrohError__as_error.lift
-        )
-}
-    
+    public static func memory() async throws -> Iroh {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_constructor_iroh_memory(
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_pointer,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_pointer,
+                freeFunc: ffi_iroh_ffi_rust_future_free_pointer,
+                liftFunc: FfiConverterTypeIroh.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
     /**
      * Create a new in memory iroh node with options.
      */
-public static func memoryWithOptions(options: NodeOptions)async throws  -> Iroh {
-    return
-        try  await uniffiRustCallAsync(
-            rustFutureFunc: {
-                uniffi_iroh_ffi_fn_constructor_iroh_memory_with_options(FfiConverterTypeNodeOptions.lower(options)
-                )
-            },
-            pollFunc: ffi_iroh_ffi_rust_future_poll_pointer,
-            completeFunc: ffi_iroh_ffi_rust_future_complete_pointer,
-            freeFunc: ffi_iroh_ffi_rust_future_free_pointer,
-            liftFunc: FfiConverterTypeIroh.lift,
-            errorHandler: FfiConverterTypeIrohError__as_error.lift
-        )
-}
-    
+    public static func memoryWithOptions(options: NodeOptions) async throws -> Iroh {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_constructor_iroh_memory_with_options(FfiConverterTypeNodeOptions.lower(options)
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_pointer,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_pointer,
+                freeFunc: ffi_iroh_ffi_rust_future_free_pointer,
+                liftFunc: FfiConverterTypeIroh.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
     /**
      * Create a new iroh node.
      *
      * The `path` param should be a directory where we can store or load
      * iroh data from a previous session.
      */
-public static func persistent(path: String)async throws  -> Iroh {
-    return
-        try  await uniffiRustCallAsync(
-            rustFutureFunc: {
-                uniffi_iroh_ffi_fn_constructor_iroh_persistent(FfiConverterString.lower(path)
-                )
-            },
-            pollFunc: ffi_iroh_ffi_rust_future_poll_pointer,
-            completeFunc: ffi_iroh_ffi_rust_future_complete_pointer,
-            freeFunc: ffi_iroh_ffi_rust_future_free_pointer,
-            liftFunc: FfiConverterTypeIroh.lift,
-            errorHandler: FfiConverterTypeIrohError__as_error.lift
-        )
-}
-    
+    public static func persistent(path: String) async throws -> Iroh {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_constructor_iroh_persistent(FfiConverterString.lower(path)
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_pointer,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_pointer,
+                freeFunc: ffi_iroh_ffi_rust_future_free_pointer,
+                liftFunc: FfiConverterTypeIroh.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
     /**
      * Create a new iroh node with options.
      */
-public static func persistentWithOptions(path: String, options: NodeOptions)async throws  -> Iroh {
-    return
-        try  await uniffiRustCallAsync(
-            rustFutureFunc: {
-                uniffi_iroh_ffi_fn_constructor_iroh_persistent_with_options(FfiConverterString.lower(path),FfiConverterTypeNodeOptions.lower(options)
-                )
-            },
-            pollFunc: ffi_iroh_ffi_rust_future_poll_pointer,
-            completeFunc: ffi_iroh_ffi_rust_future_complete_pointer,
-            freeFunc: ffi_iroh_ffi_rust_future_free_pointer,
-            liftFunc: FfiConverterTypeIroh.lift,
-            errorHandler: FfiConverterTypeIrohError__as_error.lift
-        )
-}
-    
+    public static func persistentWithOptions(path: String, options: NodeOptions) async throws -> Iroh {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_constructor_iroh_persistent_with_options(FfiConverterString.lower(path), FfiConverterTypeNodeOptions.lower(options))
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_pointer,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_pointer,
+                freeFunc: ffi_iroh_ffi_rust_future_free_pointer,
+                liftFunc: FfiConverterTypeIroh.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
 
-    
     /**
      * Access to authors specific funtionaliy.
      */
-open func authors() -> Authors {
-    return try!  FfiConverterTypeAuthors.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_iroh_authors(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
+    open func authors() -> Authors {
+        return try! FfiConverterTypeAuthors.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_iroh_authors(self.uniffiClonePointer(), $0)
+        })
+    }
+
     /**
      * Access to blob specific funtionaliy.
      */
-open func blobs() -> Blobs {
-    return try!  FfiConverterTypeBlobs.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_iroh_blobs(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
+    open func blobs() -> Blobs {
+        return try! FfiConverterTypeBlobs.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_iroh_blobs(self.uniffiClonePointer(), $0)
+        })
+    }
+
     /**
      * Access to docs specific funtionaliy.
      */
-open func docs() -> Docs {
-    return try!  FfiConverterTypeDocs.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_iroh_docs(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
+    open func docs() -> Docs {
+        return try! FfiConverterTypeDocs.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_iroh_docs(self.uniffiClonePointer(), $0)
+        })
+    }
+
     /**
      * Access to gossip specific funtionaliy.
      */
-open func gossip() -> Gossip {
-    return try!  FfiConverterTypeGossip.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_iroh_gossip(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
+    open func gossip() -> Gossip {
+        return try! FfiConverterTypeGossip.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_iroh_gossip(self.uniffiClonePointer(), $0)
+        })
+    }
+
     /**
      * Access to node specific funtionaliy.
      */
-open func node() -> Node {
-    return try!  FfiConverterTypeNode.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_iroh_node(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
+    open func node() -> Node {
+        return try! FfiConverterTypeNode.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_iroh_node(self.uniffiClonePointer(), $0)
+        })
+    }
+
     /**
      * Access to tags specific funtionaliy.
      */
-open func tags() -> Tags {
-    return try!  FfiConverterTypeTags.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_iroh_tags(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
-
+    open func tags() -> Tags {
+        return try! FfiConverterTypeTags.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_iroh_tags(self.uniffiClonePointer(), $0)
+        })
+    }
 }
 
 public struct FfiConverterTypeIroh: FfiConverter {
-
     typealias FfiType = UnsafeMutableRawPointer
     typealias SwiftType = Iroh
 
@@ -6072,7 +5796,7 @@ public struct FfiConverterTypeIroh: FfiConverter {
         // The Rust code won't compile if a pointer won't fit in a UInt64.
         // We have to go via `UInt` because that's the thing that's the size of a pointer.
         let ptr = UnsafeMutableRawPointer(bitPattern: UInt(truncatingIfNeeded: v))
-        if (ptr == nil) {
+        if ptr == nil {
             throw UniffiInternalError.unexpectedNullPointer
         }
         return try lift(ptr!)
@@ -6085,9 +5809,6 @@ public struct FfiConverterTypeIroh: FfiConverter {
     }
 }
 
-
-
-
 public func FfiConverterTypeIroh_lift(_ pointer: UnsafeMutableRawPointer) throws -> Iroh {
     return try FfiConverterTypeIroh.lift(pointer)
 }
@@ -6096,16 +5817,11 @@ public func FfiConverterTypeIroh_lower(_ value: Iroh) -> UnsafeMutableRawPointer
     return FfiConverterTypeIroh.lower(value)
 }
 
-
-
-
 /**
  * An Error.
  */
-public protocol IrohErrorProtocol : AnyObject {
-    
-    func message()  -> String
-    
+public protocol IrohErrorProtocol: AnyObject {
+    func message() -> String
 }
 
 /**
@@ -6114,8 +5830,9 @@ public protocol IrohErrorProtocol : AnyObject {
 open class IrohError:
     CustomDebugStringConvertible,
     Swift.Error,
-    
-    IrohErrorProtocol {
+
+    IrohErrorProtocol
+{
     fileprivate let pointer: UnsafeMutableRawPointer!
 
     /// Used to instantiate a [FFIObject] without an actual pointer, for fakes in tests, mostly.
@@ -6126,7 +5843,7 @@ open class IrohError:
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-    required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
+    public required init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
 
@@ -6135,13 +5852,14 @@ open class IrohError:
     ///
     /// - Warning:
     ///     Any object instantiated with this constructor cannot be passed to an actual Rust-backed object. Since there isn't a backing [Pointer] the FFI lower functions will crash.
-    public init(noPointer: NoPointer) {
-        self.pointer = nil
+    public init(noPointer _: NoPointer) {
+        pointer = nil
     }
 
     public func uniffiClonePointer() -> UnsafeMutableRawPointer {
         return try! rustCall { uniffi_iroh_ffi_fn_clone_iroherror(self.pointer, $0) }
     }
+
     // No primary constructor declared for this class.
 
     deinit {
@@ -6152,29 +5870,22 @@ open class IrohError:
         try! rustCall { uniffi_iroh_ffi_fn_free_iroherror(pointer, $0) }
     }
 
-    
-
-    
-open func message() -> String {
-    return try!  FfiConverterString.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_iroherror_message(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
-    open var debugDescription: String {
-        return try!  FfiConverterString.lift(
-            try! rustCall() {
-    uniffi_iroh_ffi_fn_method_iroherror_uniffi_trait_debug(self.uniffiClonePointer(),$0
-    )
-}
-        )
+    open func message() -> String {
+        return try! FfiConverterString.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_iroherror_message(self.uniffiClonePointer(), $0)
+        })
     }
 
+    open var debugDescription: String {
+        return try! FfiConverterString.lift(
+            try! rustCall {
+                uniffi_iroh_ffi_fn_method_iroherror_uniffi_trait_debug(self.uniffiClonePointer(), $0)
+            }
+        )
+    }
 }
 
 public struct FfiConverterTypeIrohError: FfiConverter {
-
     typealias FfiType = UnsafeMutableRawPointer
     typealias SwiftType = IrohError
 
@@ -6191,7 +5902,7 @@ public struct FfiConverterTypeIrohError: FfiConverter {
         // The Rust code won't compile if a pointer won't fit in a UInt64.
         // We have to go via `UInt` because that's the thing that's the size of a pointer.
         let ptr = UnsafeMutableRawPointer(bitPattern: UInt(truncatingIfNeeded: v))
-        if (ptr == nil) {
+        if ptr == nil {
             throw UniffiInternalError.unexpectedNullPointer
         }
         return try lift(ptr!)
@@ -6204,14 +5915,11 @@ public struct FfiConverterTypeIrohError: FfiConverter {
     }
 }
 
-
-
 extension IrohError: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
     }
 }
-
 
 public struct FfiConverterTypeIrohError__as_error: FfiConverterRustBuffer {
     public static func lift(_ buf: RustBuffer) throws -> IrohError {
@@ -6219,19 +5927,18 @@ public struct FfiConverterTypeIrohError__as_error: FfiConverterRustBuffer {
         return try FfiConverterTypeIrohError.read(from: &reader)
     }
 
-    public static func lower(_ value: IrohError) -> RustBuffer {
+    public static func lower(_: IrohError) -> RustBuffer {
         fatalError("not implemented")
     }
 
-    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> IrohError {
+    public static func read(from _: inout (data: Data, offset: Data.Index)) throws -> IrohError {
         fatalError("not implemented")
     }
 
-    public static func write(_ value: IrohError, into buf: inout [UInt8]) {
+    public static func write(_: IrohError, into _: inout [UInt8]) {
         fatalError("not implemented")
     }
 }
-
 
 public func FfiConverterTypeIrohError_lift(_ pointer: UnsafeMutableRawPointer) throws -> IrohError {
     return try FfiConverterTypeIrohError.lift(pointer)
@@ -6241,56 +5948,52 @@ public func FfiConverterTypeIrohError_lower(_ value: IrohError) -> UnsafeMutable
     return FfiConverterTypeIrohError.lower(value)
 }
 
-
-
-
 /**
  * Events informing about actions of the live sync progress
  */
-public protocol LiveEventProtocol : AnyObject {
-    
+public protocol LiveEventProtocol: AnyObject {
     /**
      * For `LiveEventType::ContentReady`, returns a Hash
      */
-    func asContentReady()  -> Hash
-    
+    func asContentReady() -> Hash
+
     /**
      * For `LiveEventType::InsertLocal`, returns an Entry
      */
-    func asInsertLocal()  -> Entry
-    
+    func asInsertLocal() -> Entry
+
     /**
      * For `LiveEventType::InsertRemote`, returns an InsertRemoteEvent
      */
-    func asInsertRemote()  -> InsertRemoteEvent
-    
+    func asInsertRemote() -> InsertRemoteEvent
+
     /**
      * For `LiveEventType::NeighborDown`, returns a PublicKey
      */
-    func asNeighborDown()  -> PublicKey
-    
+    func asNeighborDown() -> PublicKey
+
     /**
      * For `LiveEventType::NeighborUp`, returns a PublicKey
      */
-    func asNeighborUp()  -> PublicKey
-    
+    func asNeighborUp() -> PublicKey
+
     /**
      * For `LiveEventType::SyncFinished`, returns a SyncEvent
      */
-    func asSyncFinished()  -> SyncEvent
-    
+    func asSyncFinished() -> SyncEvent
+
     /**
      * The type LiveEvent
      */
-    func type()  -> LiveEventType
-    
+    func type() -> LiveEventType
 }
 
 /**
  * Events informing about actions of the live sync progress
  */
 open class LiveEvent:
-    LiveEventProtocol {
+    LiveEventProtocol
+{
     fileprivate let pointer: UnsafeMutableRawPointer!
 
     /// Used to instantiate a [FFIObject] without an actual pointer, for fakes in tests, mostly.
@@ -6301,7 +6004,7 @@ open class LiveEvent:
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-    required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
+    public required init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
 
@@ -6310,13 +6013,14 @@ open class LiveEvent:
     ///
     /// - Warning:
     ///     Any object instantiated with this constructor cannot be passed to an actual Rust-backed object. Since there isn't a backing [Pointer] the FFI lower functions will crash.
-    public init(noPointer: NoPointer) {
-        self.pointer = nil
+    public init(noPointer _: NoPointer) {
+        pointer = nil
     }
 
     public func uniffiClonePointer() -> UnsafeMutableRawPointer {
         return try! rustCall { uniffi_iroh_ffi_fn_clone_liveevent(self.pointer, $0) }
     }
+
     // No primary constructor declared for this class.
 
     deinit {
@@ -6327,84 +6031,71 @@ open class LiveEvent:
         try! rustCall { uniffi_iroh_ffi_fn_free_liveevent(pointer, $0) }
     }
 
-    
-
-    
     /**
      * For `LiveEventType::ContentReady`, returns a Hash
      */
-open func asContentReady() -> Hash {
-    return try!  FfiConverterTypeHash.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_liveevent_as_content_ready(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
+    open func asContentReady() -> Hash {
+        return try! FfiConverterTypeHash.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_liveevent_as_content_ready(self.uniffiClonePointer(), $0)
+        })
+    }
+
     /**
      * For `LiveEventType::InsertLocal`, returns an Entry
      */
-open func asInsertLocal() -> Entry {
-    return try!  FfiConverterTypeEntry.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_liveevent_as_insert_local(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
+    open func asInsertLocal() -> Entry {
+        return try! FfiConverterTypeEntry.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_liveevent_as_insert_local(self.uniffiClonePointer(), $0)
+        })
+    }
+
     /**
      * For `LiveEventType::InsertRemote`, returns an InsertRemoteEvent
      */
-open func asInsertRemote() -> InsertRemoteEvent {
-    return try!  FfiConverterTypeInsertRemoteEvent.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_liveevent_as_insert_remote(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
+    open func asInsertRemote() -> InsertRemoteEvent {
+        return try! FfiConverterTypeInsertRemoteEvent.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_liveevent_as_insert_remote(self.uniffiClonePointer(), $0)
+        })
+    }
+
     /**
      * For `LiveEventType::NeighborDown`, returns a PublicKey
      */
-open func asNeighborDown() -> PublicKey {
-    return try!  FfiConverterTypePublicKey.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_liveevent_as_neighbor_down(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
+    open func asNeighborDown() -> PublicKey {
+        return try! FfiConverterTypePublicKey.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_liveevent_as_neighbor_down(self.uniffiClonePointer(), $0)
+        })
+    }
+
     /**
      * For `LiveEventType::NeighborUp`, returns a PublicKey
      */
-open func asNeighborUp() -> PublicKey {
-    return try!  FfiConverterTypePublicKey.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_liveevent_as_neighbor_up(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
+    open func asNeighborUp() -> PublicKey {
+        return try! FfiConverterTypePublicKey.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_liveevent_as_neighbor_up(self.uniffiClonePointer(), $0)
+        })
+    }
+
     /**
      * For `LiveEventType::SyncFinished`, returns a SyncEvent
      */
-open func asSyncFinished() -> SyncEvent {
-    return try!  FfiConverterTypeSyncEvent.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_liveevent_as_sync_finished(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
+    open func asSyncFinished() -> SyncEvent {
+        return try! FfiConverterTypeSyncEvent.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_liveevent_as_sync_finished(self.uniffiClonePointer(), $0)
+        })
+    }
+
     /**
      * The type LiveEvent
      */
-open func type() -> LiveEventType {
-    return try!  FfiConverterTypeLiveEventType.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_liveevent_type(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
-
+    open func type() -> LiveEventType {
+        return try! FfiConverterTypeLiveEventType.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_liveevent_type(self.uniffiClonePointer(), $0)
+        })
+    }
 }
 
 public struct FfiConverterTypeLiveEvent: FfiConverter {
-
     typealias FfiType = UnsafeMutableRawPointer
     typealias SwiftType = LiveEvent
 
@@ -6421,7 +6112,7 @@ public struct FfiConverterTypeLiveEvent: FfiConverter {
         // The Rust code won't compile if a pointer won't fit in a UInt64.
         // We have to go via `UInt` because that's the thing that's the size of a pointer.
         let ptr = UnsafeMutableRawPointer(bitPattern: UInt(truncatingIfNeeded: v))
-        if (ptr == nil) {
+        if ptr == nil {
             throw UniffiInternalError.unexpectedNullPointer
         }
         return try lift(ptr!)
@@ -6434,9 +6125,6 @@ public struct FfiConverterTypeLiveEvent: FfiConverter {
     }
 }
 
-
-
-
 public func FfiConverterTypeLiveEvent_lift(_ pointer: UnsafeMutableRawPointer) throws -> LiveEvent {
     return try FfiConverterTypeLiveEvent.lift(pointer)
 }
@@ -6445,33 +6133,29 @@ public func FfiConverterTypeLiveEvent_lower(_ value: LiveEvent) -> UnsafeMutable
     return FfiConverterTypeLiveEvent.lower(value)
 }
 
-
-
-
 /**
  * Gossip message
  */
-public protocol MessageProtocol : AnyObject {
-    
-    func asError()  -> String
-    
-    func asJoined()  -> [String]
-    
-    func asNeighborDown()  -> String
-    
-    func asNeighborUp()  -> String
-    
-    func asReceived()  -> MessageContent
-    
-    func type()  -> MessageType
-    
+public protocol MessageProtocol: AnyObject {
+    func asError() -> String
+
+    func asJoined() -> [String]
+
+    func asNeighborDown() -> String
+
+    func asNeighborUp() -> String
+
+    func asReceived() -> MessageContent
+
+    func type() -> MessageType
 }
 
 /**
  * Gossip message
  */
 open class Message:
-    MessageProtocol {
+    MessageProtocol
+{
     fileprivate let pointer: UnsafeMutableRawPointer!
 
     /// Used to instantiate a [FFIObject] without an actual pointer, for fakes in tests, mostly.
@@ -6482,7 +6166,7 @@ open class Message:
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-    required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
+    public required init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
 
@@ -6491,13 +6175,14 @@ open class Message:
     ///
     /// - Warning:
     ///     Any object instantiated with this constructor cannot be passed to an actual Rust-backed object. Since there isn't a backing [Pointer] the FFI lower functions will crash.
-    public init(noPointer: NoPointer) {
-        self.pointer = nil
+    public init(noPointer _: NoPointer) {
+        pointer = nil
     }
 
     public func uniffiClonePointer() -> UnsafeMutableRawPointer {
         return try! rustCall { uniffi_iroh_ffi_fn_clone_message(self.pointer, $0) }
     }
+
     // No primary constructor declared for this class.
 
     deinit {
@@ -6508,56 +6193,44 @@ open class Message:
         try! rustCall { uniffi_iroh_ffi_fn_free_message(pointer, $0) }
     }
 
-    
+    open func asError() -> String {
+        return try! FfiConverterString.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_message_as_error(self.uniffiClonePointer(), $0)
+        })
+    }
 
-    
-open func asError() -> String {
-    return try!  FfiConverterString.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_message_as_error(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
-open func asJoined() -> [String] {
-    return try!  FfiConverterSequenceString.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_message_as_joined(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
-open func asNeighborDown() -> String {
-    return try!  FfiConverterString.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_message_as_neighbor_down(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
-open func asNeighborUp() -> String {
-    return try!  FfiConverterString.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_message_as_neighbor_up(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
-open func asReceived() -> MessageContent {
-    return try!  FfiConverterTypeMessageContent.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_message_as_received(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
-open func type() -> MessageType {
-    return try!  FfiConverterTypeMessageType.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_message_type(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
+    open func asJoined() -> [String] {
+        return try! FfiConverterSequenceString.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_message_as_joined(self.uniffiClonePointer(), $0)
+        })
+    }
 
+    open func asNeighborDown() -> String {
+        return try! FfiConverterString.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_message_as_neighbor_down(self.uniffiClonePointer(), $0)
+        })
+    }
+
+    open func asNeighborUp() -> String {
+        return try! FfiConverterString.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_message_as_neighbor_up(self.uniffiClonePointer(), $0)
+        })
+    }
+
+    open func asReceived() -> MessageContent {
+        return try! FfiConverterTypeMessageContent.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_message_as_received(self.uniffiClonePointer(), $0)
+        })
+    }
+
+    open func type() -> MessageType {
+        return try! FfiConverterTypeMessageType.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_message_type(self.uniffiClonePointer(), $0)
+        })
+    }
 }
 
 public struct FfiConverterTypeMessage: FfiConverter {
-
     typealias FfiType = UnsafeMutableRawPointer
     typealias SwiftType = Message
 
@@ -6574,7 +6247,7 @@ public struct FfiConverterTypeMessage: FfiConverter {
         // The Rust code won't compile if a pointer won't fit in a UInt64.
         // We have to go via `UInt` because that's the thing that's the size of a pointer.
         let ptr = UnsafeMutableRawPointer(bitPattern: UInt(truncatingIfNeeded: v))
-        if (ptr == nil) {
+        if ptr == nil {
             throw UniffiInternalError.unexpectedNullPointer
         }
         return try lift(ptr!)
@@ -6587,9 +6260,6 @@ public struct FfiConverterTypeMessage: FfiConverter {
     }
 }
 
-
-
-
 public func FfiConverterTypeMessage_lift(_ pointer: UnsafeMutableRawPointer) throws -> Message {
     return try FfiConverterTypeMessage.lift(pointer)
 }
@@ -6598,71 +6268,67 @@ public func FfiConverterTypeMessage_lower(_ value: Message) -> UnsafeMutableRawP
     return FfiConverterTypeMessage.lower(value)
 }
 
-
-
-
 /**
  * Iroh node client.
  */
-public protocol NodeProtocol : AnyObject {
-    
+public protocol NodeProtocol: AnyObject {
     /**
      * Add a known node address to the node.
      */
-    func addNodeAddr(addr: NodeAddr) async throws 
-    
+    func addNodeAddr(addr: NodeAddr) async throws
+
     /**
      * Return connection information on the currently running node.
      */
-    func connectionInfo(nodeId: PublicKey) async throws  -> ConnectionInfo?
-    
+    func connectionInfo(nodeId: PublicKey) async throws -> ConnectionInfo?
+
     /**
      * Return `ConnectionInfo`s for each connection we have to another iroh node.
      */
-    func connections() async throws  -> [ConnectionInfo]
-    
+    func connections() async throws -> [ConnectionInfo]
+
     /**
      * Get the relay server we are connected to.
      */
-    func homeRelay() async throws  -> String?
-    
+    func homeRelay() async throws -> String?
+
     /**
      * Returns `Some(addr)` if an RPC endpoint is running, `None` otherwise.
      */
-    func myRpcAddr()  -> String?
-    
+    func myRpcAddr() -> String?
+
     /**
      * Return the [`NodeAddr`] for this node.
      */
-    func nodeAddr() async throws  -> NodeAddr
-    
+    func nodeAddr() async throws -> NodeAddr
+
     /**
      * The string representation of the PublicKey of this node.
      */
-    func nodeId() async throws  -> String
-    
+    func nodeId() async throws -> String
+
     /**
      * Shutdown this iroh node.
      */
-    func shutdown(force: Bool) async throws 
-    
+    func shutdown(force: Bool) async throws
+
     /**
      * Get statistics of the running node.
      */
-    func stats() async throws  -> [String: CounterStats]
-    
+    func stats() async throws -> [String: CounterStats]
+
     /**
      * Get status information about a node
      */
-    func status() async throws  -> NodeStatus
-    
+    func status() async throws -> NodeStatus
 }
 
 /**
  * Iroh node client.
  */
 open class Node:
-    NodeProtocol {
+    NodeProtocol
+{
     fileprivate let pointer: UnsafeMutableRawPointer!
 
     /// Used to instantiate a [FFIObject] without an actual pointer, for fakes in tests, mostly.
@@ -6673,7 +6339,7 @@ open class Node:
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-    required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
+    public required init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
 
@@ -6682,13 +6348,14 @@ open class Node:
     ///
     /// - Warning:
     ///     Any object instantiated with this constructor cannot be passed to an actual Rust-backed object. Since there isn't a backing [Pointer] the FFI lower functions will crash.
-    public init(noPointer: NoPointer) {
-        self.pointer = nil
+    public init(noPointer _: NoPointer) {
+        pointer = nil
     }
 
     public func uniffiClonePointer() -> UnsafeMutableRawPointer {
         return try! rustCall { uniffi_iroh_ffi_fn_clone_node(self.pointer, $0) }
     }
+
     // No primary constructor declared for this class.
 
     deinit {
@@ -6699,204 +6366,191 @@ open class Node:
         try! rustCall { uniffi_iroh_ffi_fn_free_node(pointer, $0) }
     }
 
-    
-
-    
     /**
      * Add a known node address to the node.
      */
-open func addNodeAddr(addr: NodeAddr)async throws  {
-    return
-        try  await uniffiRustCallAsync(
-            rustFutureFunc: {
-                uniffi_iroh_ffi_fn_method_node_add_node_addr(
-                    self.uniffiClonePointer(),
-                    FfiConverterTypeNodeAddr.lower(addr)
-                )
-            },
-            pollFunc: ffi_iroh_ffi_rust_future_poll_void,
-            completeFunc: ffi_iroh_ffi_rust_future_complete_void,
-            freeFunc: ffi_iroh_ffi_rust_future_free_void,
-            liftFunc: { $0 },
-            errorHandler: FfiConverterTypeIrohError__as_error.lift
-        )
-}
-    
+    open func addNodeAddr(addr: NodeAddr) async throws {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_node_add_node_addr(
+                        self.uniffiClonePointer(),
+                        FfiConverterTypeNodeAddr.lower(addr)
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_void,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_void,
+                freeFunc: ffi_iroh_ffi_rust_future_free_void,
+                liftFunc: { $0 },
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
     /**
      * Return connection information on the currently running node.
      */
-open func connectionInfo(nodeId: PublicKey)async throws  -> ConnectionInfo? {
-    return
-        try  await uniffiRustCallAsync(
-            rustFutureFunc: {
-                uniffi_iroh_ffi_fn_method_node_connection_info(
-                    self.uniffiClonePointer(),
-                    FfiConverterTypePublicKey.lower(nodeId)
-                )
-            },
-            pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
-            completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
-            freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
-            liftFunc: FfiConverterOptionTypeConnectionInfo.lift,
-            errorHandler: FfiConverterTypeIrohError__as_error.lift
-        )
-}
-    
+    open func connectionInfo(nodeId: PublicKey) async throws -> ConnectionInfo? {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_node_connection_info(
+                        self.uniffiClonePointer(),
+                        FfiConverterTypePublicKey.lower(nodeId)
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
+                freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
+                liftFunc: FfiConverterOptionTypeConnectionInfo.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
     /**
      * Return `ConnectionInfo`s for each connection we have to another iroh node.
      */
-open func connections()async throws  -> [ConnectionInfo] {
-    return
-        try  await uniffiRustCallAsync(
-            rustFutureFunc: {
-                uniffi_iroh_ffi_fn_method_node_connections(
-                    self.uniffiClonePointer()
-                    
-                )
-            },
-            pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
-            completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
-            freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
-            liftFunc: FfiConverterSequenceTypeConnectionInfo.lift,
-            errorHandler: FfiConverterTypeIrohError__as_error.lift
-        )
-}
-    
+    open func connections() async throws -> [ConnectionInfo] {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_node_connections(
+                        self.uniffiClonePointer()
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
+                freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
+                liftFunc: FfiConverterSequenceTypeConnectionInfo.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
     /**
      * Get the relay server we are connected to.
      */
-open func homeRelay()async throws  -> String? {
-    return
-        try  await uniffiRustCallAsync(
-            rustFutureFunc: {
-                uniffi_iroh_ffi_fn_method_node_home_relay(
-                    self.uniffiClonePointer()
-                    
-                )
-            },
-            pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
-            completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
-            freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
-            liftFunc: FfiConverterOptionString.lift,
-            errorHandler: FfiConverterTypeIrohError__as_error.lift
-        )
-}
-    
+    open func homeRelay() async throws -> String? {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_node_home_relay(
+                        self.uniffiClonePointer()
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
+                freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
+                liftFunc: FfiConverterOptionString.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
     /**
      * Returns `Some(addr)` if an RPC endpoint is running, `None` otherwise.
      */
-open func myRpcAddr() -> String? {
-    return try!  FfiConverterOptionString.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_node_my_rpc_addr(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
+    open func myRpcAddr() -> String? {
+        return try! FfiConverterOptionString.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_node_my_rpc_addr(self.uniffiClonePointer(), $0)
+        })
+    }
+
     /**
      * Return the [`NodeAddr`] for this node.
      */
-open func nodeAddr()async throws  -> NodeAddr {
-    return
-        try  await uniffiRustCallAsync(
-            rustFutureFunc: {
-                uniffi_iroh_ffi_fn_method_node_node_addr(
-                    self.uniffiClonePointer()
-                    
-                )
-            },
-            pollFunc: ffi_iroh_ffi_rust_future_poll_pointer,
-            completeFunc: ffi_iroh_ffi_rust_future_complete_pointer,
-            freeFunc: ffi_iroh_ffi_rust_future_free_pointer,
-            liftFunc: FfiConverterTypeNodeAddr.lift,
-            errorHandler: FfiConverterTypeIrohError__as_error.lift
-        )
-}
-    
+    open func nodeAddr() async throws -> NodeAddr {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_node_node_addr(
+                        self.uniffiClonePointer()
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_pointer,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_pointer,
+                freeFunc: ffi_iroh_ffi_rust_future_free_pointer,
+                liftFunc: FfiConverterTypeNodeAddr.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
     /**
      * The string representation of the PublicKey of this node.
      */
-open func nodeId()async throws  -> String {
-    return
-        try  await uniffiRustCallAsync(
-            rustFutureFunc: {
-                uniffi_iroh_ffi_fn_method_node_node_id(
-                    self.uniffiClonePointer()
-                    
-                )
-            },
-            pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
-            completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
-            freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
-            liftFunc: FfiConverterString.lift,
-            errorHandler: FfiConverterTypeIrohError__as_error.lift
-        )
-}
-    
+    open func nodeId() async throws -> String {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_node_node_id(
+                        self.uniffiClonePointer()
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
+                freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
+                liftFunc: FfiConverterString.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
     /**
      * Shutdown this iroh node.
      */
-open func shutdown(force: Bool)async throws  {
-    return
-        try  await uniffiRustCallAsync(
-            rustFutureFunc: {
-                uniffi_iroh_ffi_fn_method_node_shutdown(
-                    self.uniffiClonePointer(),
-                    FfiConverterBool.lower(force)
-                )
-            },
-            pollFunc: ffi_iroh_ffi_rust_future_poll_void,
-            completeFunc: ffi_iroh_ffi_rust_future_complete_void,
-            freeFunc: ffi_iroh_ffi_rust_future_free_void,
-            liftFunc: { $0 },
-            errorHandler: FfiConverterTypeIrohError__as_error.lift
-        )
-}
-    
+    open func shutdown(force: Bool) async throws {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_node_shutdown(
+                        self.uniffiClonePointer(),
+                        FfiConverterBool.lower(force)
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_void,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_void,
+                freeFunc: ffi_iroh_ffi_rust_future_free_void,
+                liftFunc: { $0 },
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
     /**
      * Get statistics of the running node.
      */
-open func stats()async throws  -> [String: CounterStats] {
-    return
-        try  await uniffiRustCallAsync(
-            rustFutureFunc: {
-                uniffi_iroh_ffi_fn_method_node_stats(
-                    self.uniffiClonePointer()
-                    
-                )
-            },
-            pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
-            completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
-            freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
-            liftFunc: FfiConverterDictionaryStringTypeCounterStats.lift,
-            errorHandler: FfiConverterTypeIrohError__as_error.lift
-        )
-}
-    
+    open func stats() async throws -> [String: CounterStats] {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_node_stats(
+                        self.uniffiClonePointer()
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
+                freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
+                liftFunc: FfiConverterDictionaryStringTypeCounterStats.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
     /**
      * Get status information about a node
      */
-open func status()async throws  -> NodeStatus {
-    return
-        try  await uniffiRustCallAsync(
-            rustFutureFunc: {
-                uniffi_iroh_ffi_fn_method_node_status(
-                    self.uniffiClonePointer()
-                    
-                )
-            },
-            pollFunc: ffi_iroh_ffi_rust_future_poll_pointer,
-            completeFunc: ffi_iroh_ffi_rust_future_complete_pointer,
-            freeFunc: ffi_iroh_ffi_rust_future_free_pointer,
-            liftFunc: FfiConverterTypeNodeStatus.lift,
-            errorHandler: FfiConverterTypeIrohError__as_error.lift
-        )
-}
-    
-
+    open func status() async throws -> NodeStatus {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_node_status(
+                        self.uniffiClonePointer()
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_pointer,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_pointer,
+                freeFunc: ffi_iroh_ffi_rust_future_free_pointer,
+                liftFunc: FfiConverterTypeNodeStatus.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
 }
 
 public struct FfiConverterTypeNode: FfiConverter {
-
     typealias FfiType = UnsafeMutableRawPointer
     typealias SwiftType = Node
 
@@ -6913,7 +6567,7 @@ public struct FfiConverterTypeNode: FfiConverter {
         // The Rust code won't compile if a pointer won't fit in a UInt64.
         // We have to go via `UInt` because that's the thing that's the size of a pointer.
         let ptr = UnsafeMutableRawPointer(bitPattern: UInt(truncatingIfNeeded: v))
-        if (ptr == nil) {
+        if ptr == nil {
             throw UniffiInternalError.unexpectedNullPointer
         }
         return try lift(ptr!)
@@ -6926,9 +6580,6 @@ public struct FfiConverterTypeNode: FfiConverter {
     }
 }
 
-
-
-
 public func FfiConverterTypeNode_lift(_ pointer: UnsafeMutableRawPointer) throws -> Node {
     return try FfiConverterTypeNode.lift(pointer)
 }
@@ -6937,36 +6588,32 @@ public func FfiConverterTypeNode_lower(_ value: Node) -> UnsafeMutableRawPointer
     return FfiConverterTypeNode.lower(value)
 }
 
-
-
-
 /**
  * A peer and it's addressing information.
  */
-public protocol NodeAddrProtocol : AnyObject {
-    
+public protocol NodeAddrProtocol: AnyObject {
     /**
      * Get the direct addresses of this peer.
      */
-    func directAddresses()  -> [String]
-    
+    func directAddresses() -> [String]
+
     /**
      * Returns true if both NodeAddr's have the same values
      */
-    func equal(other: NodeAddr)  -> Bool
-    
+    func equal(other: NodeAddr) -> Bool
+
     /**
      * Get the home relay URL for this peer
      */
-    func relayUrl()  -> String?
-    
+    func relayUrl() -> String?
 }
 
 /**
  * A peer and it's addressing information.
  */
 open class NodeAddr:
-    NodeAddrProtocol {
+    NodeAddrProtocol
+{
     fileprivate let pointer: UnsafeMutableRawPointer!
 
     /// Used to instantiate a [FFIObject] without an actual pointer, for fakes in tests, mostly.
@@ -6977,7 +6624,7 @@ open class NodeAddr:
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-    required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
+    public required init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
 
@@ -6986,27 +6633,28 @@ open class NodeAddr:
     ///
     /// - Warning:
     ///     Any object instantiated with this constructor cannot be passed to an actual Rust-backed object. Since there isn't a backing [Pointer] the FFI lower functions will crash.
-    public init(noPointer: NoPointer) {
-        self.pointer = nil
+    public init(noPointer _: NoPointer) {
+        pointer = nil
     }
 
     public func uniffiClonePointer() -> UnsafeMutableRawPointer {
         return try! rustCall { uniffi_iroh_ffi_fn_clone_nodeaddr(self.pointer, $0) }
     }
+
     /**
      * Create a new [`NodeAddr`] with empty [`AddrInfo`].
      */
-public convenience init(nodeId: PublicKey, derpUrl: String?, addresses: [String]) {
-    let pointer =
-        try! rustCall() {
-    uniffi_iroh_ffi_fn_constructor_nodeaddr_new(
-        FfiConverterTypePublicKey.lower(nodeId),
-        FfiConverterOptionString.lower(derpUrl),
-        FfiConverterSequenceString.lower(addresses),$0
-    )
-}
-    self.init(unsafeFromRawPointer: pointer)
-}
+    public convenience init(nodeId: PublicKey, derpUrl: String?, addresses: [String]) {
+        let pointer =
+            try! rustCall {
+                uniffi_iroh_ffi_fn_constructor_nodeaddr_new(
+                    FfiConverterTypePublicKey.lower(nodeId),
+                    FfiConverterOptionString.lower(derpUrl),
+                    FfiConverterSequenceString.lower(addresses), $0
+                )
+            }
+        self.init(unsafeFromRawPointer: pointer)
+    }
 
     deinit {
         guard let pointer = pointer else {
@@ -7016,45 +6664,36 @@ public convenience init(nodeId: PublicKey, derpUrl: String?, addresses: [String]
         try! rustCall { uniffi_iroh_ffi_fn_free_nodeaddr(pointer, $0) }
     }
 
-    
-
-    
     /**
      * Get the direct addresses of this peer.
      */
-open func directAddresses() -> [String] {
-    return try!  FfiConverterSequenceString.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_nodeaddr_direct_addresses(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
+    open func directAddresses() -> [String] {
+        return try! FfiConverterSequenceString.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_nodeaddr_direct_addresses(self.uniffiClonePointer(), $0)
+        })
+    }
+
     /**
      * Returns true if both NodeAddr's have the same values
      */
-open func equal(other: NodeAddr) -> Bool {
-    return try!  FfiConverterBool.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_nodeaddr_equal(self.uniffiClonePointer(),
-        FfiConverterTypeNodeAddr.lower(other),$0
-    )
-})
-}
-    
+    open func equal(other: NodeAddr) -> Bool {
+        return try! FfiConverterBool.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_nodeaddr_equal(self.uniffiClonePointer(),
+                                                     FfiConverterTypeNodeAddr.lower(other), $0)
+        })
+    }
+
     /**
      * Get the home relay URL for this peer
      */
-open func relayUrl() -> String? {
-    return try!  FfiConverterOptionString.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_nodeaddr_relay_url(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
-
+    open func relayUrl() -> String? {
+        return try! FfiConverterOptionString.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_nodeaddr_relay_url(self.uniffiClonePointer(), $0)
+        })
+    }
 }
 
 public struct FfiConverterTypeNodeAddr: FfiConverter {
-
     typealias FfiType = UnsafeMutableRawPointer
     typealias SwiftType = NodeAddr
 
@@ -7071,7 +6710,7 @@ public struct FfiConverterTypeNodeAddr: FfiConverter {
         // The Rust code won't compile if a pointer won't fit in a UInt64.
         // We have to go via `UInt` because that's the thing that's the size of a pointer.
         let ptr = UnsafeMutableRawPointer(bitPattern: UInt(truncatingIfNeeded: v))
-        if (ptr == nil) {
+        if ptr == nil {
             throw UniffiInternalError.unexpectedNullPointer
         }
         return try lift(ptr!)
@@ -7084,9 +6723,6 @@ public struct FfiConverterTypeNodeAddr: FfiConverter {
     }
 }
 
-
-
-
 public func FfiConverterTypeNodeAddr_lift(_ pointer: UnsafeMutableRawPointer) throws -> NodeAddr {
     return try FfiConverterTypeNodeAddr.lift(pointer)
 }
@@ -7095,41 +6731,37 @@ public func FfiConverterTypeNodeAddr_lower(_ value: NodeAddr) -> UnsafeMutableRa
     return FfiConverterTypeNodeAddr.lower(value)
 }
 
-
-
-
 /**
  * The response to a status request
  */
-public protocol NodeStatusProtocol : AnyObject {
-    
+public protocol NodeStatusProtocol: AnyObject {
     /**
      * The bound listening addresses of the node
      */
-    func listenAddrs()  -> [String]
-    
+    func listenAddrs() -> [String]
+
     /**
      * The node id and socket addresses of this node.
      */
-    func nodeAddr()  -> NodeAddr
-    
+    func nodeAddr() -> NodeAddr
+
     /**
      * The address of the RPC of the node
      */
-    func rpcAddr()  -> String?
-    
+    func rpcAddr() -> String?
+
     /**
      * The version of the node
      */
-    func version()  -> String
-    
+    func version() -> String
 }
 
 /**
  * The response to a status request
  */
 open class NodeStatus:
-    NodeStatusProtocol {
+    NodeStatusProtocol
+{
     fileprivate let pointer: UnsafeMutableRawPointer!
 
     /// Used to instantiate a [FFIObject] without an actual pointer, for fakes in tests, mostly.
@@ -7140,7 +6772,7 @@ open class NodeStatus:
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-    required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
+    public required init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
 
@@ -7149,13 +6781,14 @@ open class NodeStatus:
     ///
     /// - Warning:
     ///     Any object instantiated with this constructor cannot be passed to an actual Rust-backed object. Since there isn't a backing [Pointer] the FFI lower functions will crash.
-    public init(noPointer: NoPointer) {
-        self.pointer = nil
+    public init(noPointer _: NoPointer) {
+        pointer = nil
     }
 
     public func uniffiClonePointer() -> UnsafeMutableRawPointer {
         return try! rustCall { uniffi_iroh_ffi_fn_clone_nodestatus(self.pointer, $0) }
     }
+
     // No primary constructor declared for this class.
 
     deinit {
@@ -7166,54 +6799,44 @@ open class NodeStatus:
         try! rustCall { uniffi_iroh_ffi_fn_free_nodestatus(pointer, $0) }
     }
 
-    
-
-    
     /**
      * The bound listening addresses of the node
      */
-open func listenAddrs() -> [String] {
-    return try!  FfiConverterSequenceString.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_nodestatus_listen_addrs(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
+    open func listenAddrs() -> [String] {
+        return try! FfiConverterSequenceString.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_nodestatus_listen_addrs(self.uniffiClonePointer(), $0)
+        })
+    }
+
     /**
      * The node id and socket addresses of this node.
      */
-open func nodeAddr() -> NodeAddr {
-    return try!  FfiConverterTypeNodeAddr.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_nodestatus_node_addr(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
+    open func nodeAddr() -> NodeAddr {
+        return try! FfiConverterTypeNodeAddr.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_nodestatus_node_addr(self.uniffiClonePointer(), $0)
+        })
+    }
+
     /**
      * The address of the RPC of the node
      */
-open func rpcAddr() -> String? {
-    return try!  FfiConverterOptionString.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_nodestatus_rpc_addr(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
+    open func rpcAddr() -> String? {
+        return try! FfiConverterOptionString.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_nodestatus_rpc_addr(self.uniffiClonePointer(), $0)
+        })
+    }
+
     /**
      * The version of the node
      */
-open func version() -> String {
-    return try!  FfiConverterString.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_nodestatus_version(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
-
+    open func version() -> String {
+        return try! FfiConverterString.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_nodestatus_version(self.uniffiClonePointer(), $0)
+        })
+    }
 }
 
 public struct FfiConverterTypeNodeStatus: FfiConverter {
-
     typealias FfiType = UnsafeMutableRawPointer
     typealias SwiftType = NodeStatus
 
@@ -7230,7 +6853,7 @@ public struct FfiConverterTypeNodeStatus: FfiConverter {
         // The Rust code won't compile if a pointer won't fit in a UInt64.
         // We have to go via `UInt` because that's the thing that's the size of a pointer.
         let ptr = UnsafeMutableRawPointer(bitPattern: UInt(truncatingIfNeeded: v))
-        if (ptr == nil) {
+        if ptr == nil {
             throw UniffiInternalError.unexpectedNullPointer
         }
         return try lift(ptr!)
@@ -7243,9 +6866,6 @@ public struct FfiConverterTypeNodeStatus: FfiConverter {
     }
 }
 
-
-
-
 public func FfiConverterTypeNodeStatus_lift(_ pointer: UnsafeMutableRawPointer) throws -> NodeStatus {
     return try FfiConverterTypeNodeStatus.lift(pointer)
 }
@@ -7254,33 +6874,28 @@ public func FfiConverterTypeNodeStatus_lower(_ value: NodeStatus) -> UnsafeMutab
     return FfiConverterTypeNodeStatus.lower(value)
 }
 
-
-
-
 /**
  * A public key.
  *
  * The key itself is just a 32 byte array, but a key has associated crypto
  * information that is cached for performance reasons.
  */
-public protocol PublicKeyProtocol : AnyObject {
-    
+public protocol PublicKeyProtocol: AnyObject {
     /**
      * Returns true if the PublicKeys are equal
      */
-    func equal(other: PublicKey)  -> Bool
-    
+    func equal(other: PublicKey) -> Bool
+
     /**
      * Convert to a base32 string limited to the first 10 bytes for a friendly string
      * representation of the key.
      */
-    func fmtShort()  -> String
-    
+    func fmtShort() -> String
+
     /**
      * Express the PublicKey as a byte array
      */
-    func toBytes()  -> Data
-    
+    func toBytes() -> Data
 }
 
 /**
@@ -7291,7 +6906,8 @@ public protocol PublicKeyProtocol : AnyObject {
  */
 open class PublicKey:
     CustomStringConvertible,
-    PublicKeyProtocol {
+    PublicKeyProtocol
+{
     fileprivate let pointer: UnsafeMutableRawPointer!
 
     /// Used to instantiate a [FFIObject] without an actual pointer, for fakes in tests, mostly.
@@ -7302,7 +6918,7 @@ open class PublicKey:
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-    required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
+    public required init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
 
@@ -7311,13 +6927,14 @@ open class PublicKey:
     ///
     /// - Warning:
     ///     Any object instantiated with this constructor cannot be passed to an actual Rust-backed object. Since there isn't a backing [Pointer] the FFI lower functions will crash.
-    public init(noPointer: NoPointer) {
-        self.pointer = nil
+    public init(noPointer _: NoPointer) {
+        pointer = nil
     }
 
     public func uniffiClonePointer() -> UnsafeMutableRawPointer {
         return try! rustCall { uniffi_iroh_ffi_fn_clone_publickey(self.pointer, $0) }
     }
+
     // No primary constructor declared for this class.
 
     deinit {
@@ -7328,76 +6945,67 @@ open class PublicKey:
         try! rustCall { uniffi_iroh_ffi_fn_free_publickey(pointer, $0) }
     }
 
-    
     /**
      * Make a PublicKey from byte array
      */
-public static func fromBytes(bytes: Data)throws  -> PublicKey {
-    return try  FfiConverterTypePublicKey.lift(try rustCallWithError(FfiConverterTypeIrohError__as_error.lift) {
-    uniffi_iroh_ffi_fn_constructor_publickey_from_bytes(
-        FfiConverterData.lower(bytes),$0
-    )
-})
-}
-    
+    public static func fromBytes(bytes: Data) throws -> PublicKey {
+        return try FfiConverterTypePublicKey.lift(rustCallWithError(FfiConverterTypeIrohError__as_error.lift) {
+            uniffi_iroh_ffi_fn_constructor_publickey_from_bytes(
+                FfiConverterData.lower(bytes), $0
+            )
+        })
+    }
+
     /**
      * Make a PublicKey from base32 string
      */
-public static func fromString(s: String)throws  -> PublicKey {
-    return try  FfiConverterTypePublicKey.lift(try rustCallWithError(FfiConverterTypeIrohError__as_error.lift) {
-    uniffi_iroh_ffi_fn_constructor_publickey_from_string(
-        FfiConverterString.lower(s),$0
-    )
-})
-}
-    
+    public static func fromString(s: String) throws -> PublicKey {
+        return try FfiConverterTypePublicKey.lift(rustCallWithError(FfiConverterTypeIrohError__as_error.lift) {
+            uniffi_iroh_ffi_fn_constructor_publickey_from_string(
+                FfiConverterString.lower(s), $0
+            )
+        })
+    }
 
-    
     /**
      * Returns true if the PublicKeys are equal
      */
-open func equal(other: PublicKey) -> Bool {
-    return try!  FfiConverterBool.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_publickey_equal(self.uniffiClonePointer(),
-        FfiConverterTypePublicKey.lower(other),$0
-    )
-})
-}
-    
+    open func equal(other: PublicKey) -> Bool {
+        return try! FfiConverterBool.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_publickey_equal(self.uniffiClonePointer(),
+                                                      FfiConverterTypePublicKey.lower(other), $0)
+        })
+    }
+
     /**
      * Convert to a base32 string limited to the first 10 bytes for a friendly string
      * representation of the key.
      */
-open func fmtShort() -> String {
-    return try!  FfiConverterString.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_publickey_fmt_short(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
+    open func fmtShort() -> String {
+        return try! FfiConverterString.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_publickey_fmt_short(self.uniffiClonePointer(), $0)
+        })
+    }
+
     /**
      * Express the PublicKey as a byte array
      */
-open func toBytes() -> Data {
-    return try!  FfiConverterData.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_publickey_to_bytes(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
-    open var description: String {
-        return try!  FfiConverterString.lift(
-            try! rustCall() {
-    uniffi_iroh_ffi_fn_method_publickey_uniffi_trait_display(self.uniffiClonePointer(),$0
-    )
-}
-        )
+    open func toBytes() -> Data {
+        return try! FfiConverterData.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_publickey_to_bytes(self.uniffiClonePointer(), $0)
+        })
     }
 
+    open var description: String {
+        return try! FfiConverterString.lift(
+            try! rustCall {
+                uniffi_iroh_ffi_fn_method_publickey_uniffi_trait_display(self.uniffiClonePointer(), $0)
+            }
+        )
+    }
 }
 
 public struct FfiConverterTypePublicKey: FfiConverter {
-
     typealias FfiType = UnsafeMutableRawPointer
     typealias SwiftType = PublicKey
 
@@ -7414,7 +7022,7 @@ public struct FfiConverterTypePublicKey: FfiConverter {
         // The Rust code won't compile if a pointer won't fit in a UInt64.
         // We have to go via `UInt` because that's the thing that's the size of a pointer.
         let ptr = UnsafeMutableRawPointer(bitPattern: UInt(truncatingIfNeeded: v))
-        if (ptr == nil) {
+        if ptr == nil {
             throw UniffiInternalError.unexpectedNullPointer
         }
         return try lift(ptr!)
@@ -7427,9 +7035,6 @@ public struct FfiConverterTypePublicKey: FfiConverter {
     }
 }
 
-
-
-
 public func FfiConverterTypePublicKey_lift(_ pointer: UnsafeMutableRawPointer) throws -> PublicKey {
     return try FfiConverterTypePublicKey.lift(pointer)
 }
@@ -7438,26 +7043,21 @@ public func FfiConverterTypePublicKey_lower(_ value: PublicKey) -> UnsafeMutable
     return FfiConverterTypePublicKey.lower(value)
 }
 
-
-
-
 /**
  * Build a Query to search for an entry or entries in a doc.
  *
  * Use this with `QueryOptions` to determine sorting, grouping, and pagination.
  */
-public protocol QueryProtocol : AnyObject {
-    
+public protocol QueryProtocol: AnyObject {
     /**
      * Get the limit for this query (max. number of entries to emit).
      */
-    func limit()  -> UInt64?
-    
+    func limit() -> UInt64?
+
     /**
      * Get the offset for this query (number of entries to skip at the beginning).
      */
-    func offset()  -> UInt64
-    
+    func offset() -> UInt64
 }
 
 /**
@@ -7466,7 +7066,8 @@ public protocol QueryProtocol : AnyObject {
  * Use this with `QueryOptions` to determine sorting, grouping, and pagination.
  */
 open class Query:
-    QueryProtocol {
+    QueryProtocol
+{
     fileprivate let pointer: UnsafeMutableRawPointer!
 
     /// Used to instantiate a [FFIObject] without an actual pointer, for fakes in tests, mostly.
@@ -7477,7 +7078,7 @@ open class Query:
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-    required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
+    public required init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
 
@@ -7486,13 +7087,14 @@ open class Query:
     ///
     /// - Warning:
     ///     Any object instantiated with this constructor cannot be passed to an actual Rust-backed object. Since there isn't a backing [Pointer] the FFI lower functions will crash.
-    public init(noPointer: NoPointer) {
-        self.pointer = nil
+    public init(noPointer _: NoPointer) {
+        pointer = nil
     }
 
     public func uniffiClonePointer() -> UnsafeMutableRawPointer {
         return try! rustCall { uniffi_iroh_ffi_fn_clone_query(self.pointer, $0) }
     }
+
     // No primary constructor declared for this class.
 
     deinit {
@@ -7503,7 +7105,6 @@ open class Query:
         try! rustCall { uniffi_iroh_ffi_fn_free_query(pointer, $0) }
     }
 
-    
     /**
      * Query all records.
      *
@@ -7513,14 +7114,14 @@ open class Query:
      * offset: None
      * limit: None
      */
-public static func all(opts: QueryOptions?) -> Query {
-    return try!  FfiConverterTypeQuery.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_constructor_query_all(
-        FfiConverterOptionTypeQueryOptions.lower(opts),$0
-    )
-})
-}
-    
+    public static func all(opts: QueryOptions?) -> Query {
+        return try! FfiConverterTypeQuery.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_constructor_query_all(
+                FfiConverterOptionTypeQueryOptions.lower(opts), $0
+            )
+        })
+    }
+
     /**
      * Query all entries for by a single author.
      *
@@ -7530,27 +7131,27 @@ public static func all(opts: QueryOptions?) -> Query {
      * offset: None
      * limit: None
      */
-public static func author(author: AuthorId, opts: QueryOptions?) -> Query {
-    return try!  FfiConverterTypeQuery.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_constructor_query_author(
-        FfiConverterTypeAuthorId.lower(author),
-        FfiConverterOptionTypeQueryOptions.lower(opts),$0
-    )
-})
-}
-    
+    public static func author(author: AuthorId, opts: QueryOptions?) -> Query {
+        return try! FfiConverterTypeQuery.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_constructor_query_author(
+                FfiConverterTypeAuthorId.lower(author),
+                FfiConverterOptionTypeQueryOptions.lower(opts), $0
+            )
+        })
+    }
+
     /**
      * Create a Query for a single key and author.
      */
-public static func authorKeyExact(author: AuthorId, key: Data) -> Query {
-    return try!  FfiConverterTypeQuery.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_constructor_query_author_key_exact(
-        FfiConverterTypeAuthorId.lower(author),
-        FfiConverterData.lower(key),$0
-    )
-})
-}
-    
+    public static func authorKeyExact(author: AuthorId, key: Data) -> Query {
+        return try! FfiConverterTypeQuery.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_constructor_query_author_key_exact(
+                FfiConverterTypeAuthorId.lower(author),
+                FfiConverterData.lower(key), $0
+            )
+        })
+    }
+
     /**
      * Create a query for all entries of a single author with a given key prefix.
      *
@@ -7559,16 +7160,16 @@ public static func authorKeyExact(author: AuthorId, key: Data) -> Query {
      * offset: None
      * limit: None
      */
-public static func authorKeyPrefix(author: AuthorId, prefix: Data, opts: QueryOptions?) -> Query {
-    return try!  FfiConverterTypeQuery.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_constructor_query_author_key_prefix(
-        FfiConverterTypeAuthorId.lower(author),
-        FfiConverterData.lower(prefix),
-        FfiConverterOptionTypeQueryOptions.lower(opts),$0
-    )
-})
-}
-    
+    public static func authorKeyPrefix(author: AuthorId, prefix: Data, opts: QueryOptions?) -> Query {
+        return try! FfiConverterTypeQuery.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_constructor_query_author_key_prefix(
+                FfiConverterTypeAuthorId.lower(author),
+                FfiConverterData.lower(prefix),
+                FfiConverterOptionTypeQueryOptions.lower(opts), $0
+            )
+        })
+    }
+
     /**
      * Query all entries that have an exact key.
      *
@@ -7578,15 +7179,15 @@ public static func authorKeyPrefix(author: AuthorId, prefix: Data, opts: QueryOp
      * offset: None
      * limit: None
      */
-public static func keyExact(key: Data, opts: QueryOptions?) -> Query {
-    return try!  FfiConverterTypeQuery.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_constructor_query_key_exact(
-        FfiConverterData.lower(key),
-        FfiConverterOptionTypeQueryOptions.lower(opts),$0
-    )
-})
-}
-    
+    public static func keyExact(key: Data, opts: QueryOptions?) -> Query {
+        return try! FfiConverterTypeQuery.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_constructor_query_key_exact(
+                FfiConverterData.lower(key),
+                FfiConverterOptionTypeQueryOptions.lower(opts), $0
+            )
+        })
+    }
+
     /**
      * Create a query for all entries with a given key prefix.
      *
@@ -7596,15 +7197,15 @@ public static func keyExact(key: Data, opts: QueryOptions?) -> Query {
      * offset: None
      * limit: None
      */
-public static func keyPrefix(prefix: Data, opts: QueryOptions?) -> Query {
-    return try!  FfiConverterTypeQuery.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_constructor_query_key_prefix(
-        FfiConverterData.lower(prefix),
-        FfiConverterOptionTypeQueryOptions.lower(opts),$0
-    )
-})
-}
-    
+    public static func keyPrefix(prefix: Data, opts: QueryOptions?) -> Query {
+        return try! FfiConverterTypeQuery.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_constructor_query_key_prefix(
+                FfiConverterData.lower(prefix),
+                FfiConverterOptionTypeQueryOptions.lower(opts), $0
+            )
+        })
+    }
+
     /**
      * Query only the latest entry for each key, omitting older entries if the entry was written
      * to by multiple authors.
@@ -7614,26 +7215,26 @@ public static func keyPrefix(prefix: Data, opts: QueryOptions?) -> Query {
      * offset: None
      * limit: None
      */
-public static func singleLatestPerKey(opts: QueryOptions?) -> Query {
-    return try!  FfiConverterTypeQuery.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_constructor_query_single_latest_per_key(
-        FfiConverterOptionTypeQueryOptions.lower(opts),$0
-    )
-})
-}
-    
+    public static func singleLatestPerKey(opts: QueryOptions?) -> Query {
+        return try! FfiConverterTypeQuery.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_constructor_query_single_latest_per_key(
+                FfiConverterOptionTypeQueryOptions.lower(opts), $0
+            )
+        })
+    }
+
     /**
      * Query exactly the key, but only the latest entry for it, omitting older entries if the entry was written
      * to by multiple authors.
      */
-public static func singleLatestPerKeyExact(key: Data) -> Query {
-    return try!  FfiConverterTypeQuery.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_constructor_query_single_latest_per_key_exact(
-        FfiConverterData.lower(key),$0
-    )
-})
-}
-    
+    public static func singleLatestPerKeyExact(key: Data) -> Query {
+        return try! FfiConverterTypeQuery.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_constructor_query_single_latest_per_key_exact(
+                FfiConverterData.lower(key), $0
+            )
+        })
+    }
+
     /**
      * Query only the latest entry for each key, with this prefix, omitting older entries if the entry was written
      * to by multiple authors.
@@ -7643,42 +7244,35 @@ public static func singleLatestPerKeyExact(key: Data) -> Query {
      * offset: None
      * limit: None
      */
-public static func singleLatestPerKeyPrefix(prefix: Data, opts: QueryOptions?) -> Query {
-    return try!  FfiConverterTypeQuery.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_constructor_query_single_latest_per_key_prefix(
-        FfiConverterData.lower(prefix),
-        FfiConverterOptionTypeQueryOptions.lower(opts),$0
-    )
-})
-}
-    
+    public static func singleLatestPerKeyPrefix(prefix: Data, opts: QueryOptions?) -> Query {
+        return try! FfiConverterTypeQuery.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_constructor_query_single_latest_per_key_prefix(
+                FfiConverterData.lower(prefix),
+                FfiConverterOptionTypeQueryOptions.lower(opts), $0
+            )
+        })
+    }
 
-    
     /**
      * Get the limit for this query (max. number of entries to emit).
      */
-open func limit() -> UInt64? {
-    return try!  FfiConverterOptionUInt64.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_query_limit(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
+    open func limit() -> UInt64? {
+        return try! FfiConverterOptionUInt64.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_query_limit(self.uniffiClonePointer(), $0)
+        })
+    }
+
     /**
      * Get the offset for this query (number of entries to skip at the beginning).
      */
-open func offset() -> UInt64 {
-    return try!  FfiConverterUInt64.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_query_offset(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
-
+    open func offset() -> UInt64 {
+        return try! FfiConverterUInt64.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_query_offset(self.uniffiClonePointer(), $0)
+        })
+    }
 }
 
 public struct FfiConverterTypeQuery: FfiConverter {
-
     typealias FfiType = UnsafeMutableRawPointer
     typealias SwiftType = Query
 
@@ -7695,7 +7289,7 @@ public struct FfiConverterTypeQuery: FfiConverter {
         // The Rust code won't compile if a pointer won't fit in a UInt64.
         // We have to go via `UInt` because that's the thing that's the size of a pointer.
         let ptr = UnsafeMutableRawPointer(bitPattern: UInt(truncatingIfNeeded: v))
-        if (ptr == nil) {
+        if ptr == nil {
             throw UniffiInternalError.unexpectedNullPointer
         }
         return try lift(ptr!)
@@ -7708,9 +7302,6 @@ public struct FfiConverterTypeQuery: FfiConverter {
     }
 }
 
-
-
-
 public func FfiConverterTypeQuery_lift(_ pointer: UnsafeMutableRawPointer) throws -> Query {
     return try FfiConverterTypeQuery.lift(pointer)
 }
@@ -7719,31 +7310,27 @@ public func FfiConverterTypeQuery_lower(_ value: Query) -> UnsafeMutableRawPoint
     return FfiConverterTypeQuery.lower(value)
 }
 
-
-
-
 /**
  * A chunk range specification as a sequence of chunk offsets
  */
-public protocol RangeSpecProtocol : AnyObject {
-    
+public protocol RangeSpecProtocol: AnyObject {
     /**
      * Check if this [`RangeSpec`] selects all chunks in the blob
      */
-    func isAll()  -> Bool
-    
+    func isAll() -> Bool
+
     /**
      * Checks if this [`RangeSpec`] does not select any chunks in the blob
      */
-    func isEmpty()  -> Bool
-    
+    func isEmpty() -> Bool
 }
 
 /**
  * A chunk range specification as a sequence of chunk offsets
  */
 open class RangeSpec:
-    RangeSpecProtocol {
+    RangeSpecProtocol
+{
     fileprivate let pointer: UnsafeMutableRawPointer!
 
     /// Used to instantiate a [FFIObject] without an actual pointer, for fakes in tests, mostly.
@@ -7754,7 +7341,7 @@ open class RangeSpec:
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-    required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
+    public required init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
 
@@ -7763,13 +7350,14 @@ open class RangeSpec:
     ///
     /// - Warning:
     ///     Any object instantiated with this constructor cannot be passed to an actual Rust-backed object. Since there isn't a backing [Pointer] the FFI lower functions will crash.
-    public init(noPointer: NoPointer) {
-        self.pointer = nil
+    public init(noPointer _: NoPointer) {
+        pointer = nil
     }
 
     public func uniffiClonePointer() -> UnsafeMutableRawPointer {
         return try! rustCall { uniffi_iroh_ffi_fn_clone_rangespec(self.pointer, $0) }
     }
+
     // No primary constructor declared for this class.
 
     deinit {
@@ -7780,34 +7368,26 @@ open class RangeSpec:
         try! rustCall { uniffi_iroh_ffi_fn_free_rangespec(pointer, $0) }
     }
 
-    
-
-    
     /**
      * Check if this [`RangeSpec`] selects all chunks in the blob
      */
-open func isAll() -> Bool {
-    return try!  FfiConverterBool.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_rangespec_is_all(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
+    open func isAll() -> Bool {
+        return try! FfiConverterBool.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_rangespec_is_all(self.uniffiClonePointer(), $0)
+        })
+    }
+
     /**
      * Checks if this [`RangeSpec`] does not select any chunks in the blob
      */
-open func isEmpty() -> Bool {
-    return try!  FfiConverterBool.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_method_rangespec_is_empty(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
-
+    open func isEmpty() -> Bool {
+        return try! FfiConverterBool.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_method_rangespec_is_empty(self.uniffiClonePointer(), $0)
+        })
+    }
 }
 
 public struct FfiConverterTypeRangeSpec: FfiConverter {
-
     typealias FfiType = UnsafeMutableRawPointer
     typealias SwiftType = RangeSpec
 
@@ -7824,7 +7404,7 @@ public struct FfiConverterTypeRangeSpec: FfiConverter {
         // The Rust code won't compile if a pointer won't fit in a UInt64.
         // We have to go via `UInt` because that's the thing that's the size of a pointer.
         let ptr = UnsafeMutableRawPointer(bitPattern: UInt(truncatingIfNeeded: v))
-        if (ptr == nil) {
+        if ptr == nil {
             throw UniffiInternalError.unexpectedNullPointer
         }
         return try lift(ptr!)
@@ -7837,9 +7417,6 @@ public struct FfiConverterTypeRangeSpec: FfiConverter {
     }
 }
 
-
-
-
 public func FfiConverterTypeRangeSpec_lift(_ pointer: UnsafeMutableRawPointer) throws -> RangeSpec {
     return try FfiConverterTypeRangeSpec.lift(pointer)
 }
@@ -7848,31 +7425,27 @@ public func FfiConverterTypeRangeSpec_lower(_ value: RangeSpec) -> UnsafeMutable
     return FfiConverterTypeRangeSpec.lower(value)
 }
 
-
-
-
 /**
  * Gossip sender
  */
-public protocol SenderProtocol : AnyObject {
-    
+public protocol SenderProtocol: AnyObject {
     /**
      * Broadcast a message to all nodes in the swarm
      */
-    func broadcast(msg: Data) async throws 
-    
+    func broadcast(msg: Data) async throws
+
     /**
      * Broadcast a message to all direct neighbors.
      */
-    func broadcastNeighbors(msg: Data) async throws 
-    
+    func broadcastNeighbors(msg: Data) async throws
 }
 
 /**
  * Gossip sender
  */
 open class Sender:
-    SenderProtocol {
+    SenderProtocol
+{
     fileprivate let pointer: UnsafeMutableRawPointer!
 
     /// Used to instantiate a [FFIObject] without an actual pointer, for fakes in tests, mostly.
@@ -7883,7 +7456,7 @@ open class Sender:
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-    required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
+    public required init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
 
@@ -7892,13 +7465,14 @@ open class Sender:
     ///
     /// - Warning:
     ///     Any object instantiated with this constructor cannot be passed to an actual Rust-backed object. Since there isn't a backing [Pointer] the FFI lower functions will crash.
-    public init(noPointer: NoPointer) {
-        self.pointer = nil
+    public init(noPointer _: NoPointer) {
+        pointer = nil
     }
 
     public func uniffiClonePointer() -> UnsafeMutableRawPointer {
         return try! rustCall { uniffi_iroh_ffi_fn_clone_sender(self.pointer, $0) }
     }
+
     // No primary constructor declared for this class.
 
     deinit {
@@ -7909,54 +7483,48 @@ open class Sender:
         try! rustCall { uniffi_iroh_ffi_fn_free_sender(pointer, $0) }
     }
 
-    
-
-    
     /**
      * Broadcast a message to all nodes in the swarm
      */
-open func broadcast(msg: Data)async throws  {
-    return
-        try  await uniffiRustCallAsync(
-            rustFutureFunc: {
-                uniffi_iroh_ffi_fn_method_sender_broadcast(
-                    self.uniffiClonePointer(),
-                    FfiConverterData.lower(msg)
-                )
-            },
-            pollFunc: ffi_iroh_ffi_rust_future_poll_void,
-            completeFunc: ffi_iroh_ffi_rust_future_complete_void,
-            freeFunc: ffi_iroh_ffi_rust_future_free_void,
-            liftFunc: { $0 },
-            errorHandler: FfiConverterTypeIrohError__as_error.lift
-        )
-}
-    
+    open func broadcast(msg: Data) async throws {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_sender_broadcast(
+                        self.uniffiClonePointer(),
+                        FfiConverterData.lower(msg)
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_void,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_void,
+                freeFunc: ffi_iroh_ffi_rust_future_free_void,
+                liftFunc: { $0 },
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
     /**
      * Broadcast a message to all direct neighbors.
      */
-open func broadcastNeighbors(msg: Data)async throws  {
-    return
-        try  await uniffiRustCallAsync(
-            rustFutureFunc: {
-                uniffi_iroh_ffi_fn_method_sender_broadcast_neighbors(
-                    self.uniffiClonePointer(),
-                    FfiConverterData.lower(msg)
-                )
-            },
-            pollFunc: ffi_iroh_ffi_rust_future_poll_void,
-            completeFunc: ffi_iroh_ffi_rust_future_complete_void,
-            freeFunc: ffi_iroh_ffi_rust_future_free_void,
-            liftFunc: { $0 },
-            errorHandler: FfiConverterTypeIrohError__as_error.lift
-        )
-}
-    
-
+    open func broadcastNeighbors(msg: Data) async throws {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_sender_broadcast_neighbors(
+                        self.uniffiClonePointer(),
+                        FfiConverterData.lower(msg)
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_void,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_void,
+                freeFunc: ffi_iroh_ffi_rust_future_free_void,
+                liftFunc: { $0 },
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
 }
 
 public struct FfiConverterTypeSender: FfiConverter {
-
     typealias FfiType = UnsafeMutableRawPointer
     typealias SwiftType = Sender
 
@@ -7973,7 +7541,7 @@ public struct FfiConverterTypeSender: FfiConverter {
         // The Rust code won't compile if a pointer won't fit in a UInt64.
         // We have to go via `UInt` because that's the thing that's the size of a pointer.
         let ptr = UnsafeMutableRawPointer(bitPattern: UInt(truncatingIfNeeded: v))
-        if (ptr == nil) {
+        if ptr == nil {
             throw UniffiInternalError.unexpectedNullPointer
         }
         return try lift(ptr!)
@@ -7986,9 +7554,6 @@ public struct FfiConverterTypeSender: FfiConverter {
     }
 }
 
-
-
-
 public func FfiConverterTypeSender_lift(_ pointer: UnsafeMutableRawPointer) throws -> Sender {
     return try FfiConverterTypeSender.lift(pointer)
 }
@@ -7997,21 +7562,17 @@ public func FfiConverterTypeSender_lower(_ value: Sender) -> UnsafeMutableRawPoi
     return FfiConverterTypeSender.lower(value)
 }
 
-
-
-
 /**
  * An option for commands that allow setting a Tag
  */
-public protocol SetTagOptionProtocol : AnyObject {
-    
-}
+public protocol SetTagOptionProtocol: AnyObject {}
 
 /**
  * An option for commands that allow setting a Tag
  */
 open class SetTagOption:
-    SetTagOptionProtocol {
+    SetTagOptionProtocol
+{
     fileprivate let pointer: UnsafeMutableRawPointer!
 
     /// Used to instantiate a [FFIObject] without an actual pointer, for fakes in tests, mostly.
@@ -8022,7 +7583,7 @@ open class SetTagOption:
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-    required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
+    public required init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
 
@@ -8031,13 +7592,14 @@ open class SetTagOption:
     ///
     /// - Warning:
     ///     Any object instantiated with this constructor cannot be passed to an actual Rust-backed object. Since there isn't a backing [Pointer] the FFI lower functions will crash.
-    public init(noPointer: NoPointer) {
-        self.pointer = nil
+    public init(noPointer _: NoPointer) {
+        pointer = nil
     }
 
     public func uniffiClonePointer() -> UnsafeMutableRawPointer {
         return try! rustCall { uniffi_iroh_ffi_fn_clone_settagoption(self.pointer, $0) }
     }
+
     // No primary constructor declared for this class.
 
     deinit {
@@ -8048,35 +7610,29 @@ open class SetTagOption:
         try! rustCall { uniffi_iroh_ffi_fn_free_settagoption(pointer, $0) }
     }
 
-    
     /**
      * Indicate you want an automatically generated tag
      */
-public static func auto() -> SetTagOption {
-    return try!  FfiConverterTypeSetTagOption.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_constructor_settagoption_auto($0
-    )
-})
-}
-    
+    public static func auto() -> SetTagOption {
+        return try! FfiConverterTypeSetTagOption.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_constructor_settagoption_auto($0
+            )
+        })
+    }
+
     /**
      * Indicate you want a named tag
      */
-public static func named(tag: Data) -> SetTagOption {
-    return try!  FfiConverterTypeSetTagOption.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_constructor_settagoption_named(
-        FfiConverterData.lower(tag),$0
-    )
-})
-}
-    
-
-    
-
+    public static func named(tag: Data) -> SetTagOption {
+        return try! FfiConverterTypeSetTagOption.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_constructor_settagoption_named(
+                FfiConverterData.lower(tag), $0
+            )
+        })
+    }
 }
 
 public struct FfiConverterTypeSetTagOption: FfiConverter {
-
     typealias FfiType = UnsafeMutableRawPointer
     typealias SwiftType = SetTagOption
 
@@ -8093,7 +7649,7 @@ public struct FfiConverterTypeSetTagOption: FfiConverter {
         // The Rust code won't compile if a pointer won't fit in a UInt64.
         // We have to go via `UInt` because that's the thing that's the size of a pointer.
         let ptr = UnsafeMutableRawPointer(bitPattern: UInt(truncatingIfNeeded: v))
-        if (ptr == nil) {
+        if ptr == nil {
             throw UniffiInternalError.unexpectedNullPointer
         }
         return try lift(ptr!)
@@ -8106,9 +7662,6 @@ public struct FfiConverterTypeSetTagOption: FfiConverter {
     }
 }
 
-
-
-
 public func FfiConverterTypeSetTagOption_lift(_ pointer: UnsafeMutableRawPointer) throws -> SetTagOption {
     return try FfiConverterTypeSetTagOption.lift(pointer)
 }
@@ -8117,18 +7670,13 @@ public func FfiConverterTypeSetTagOption_lower(_ value: SetTagOption) -> UnsafeM
     return FfiConverterTypeSetTagOption.lower(value)
 }
 
-
-
-
 /**
  * The `progress` method will be called for each `SubscribeProgress` event that is
  * emitted during a `node.doc_subscribe`. Use the `SubscribeProgress.type()`
  * method to check the `LiveEvent`
  */
-public protocol SubscribeCallback : AnyObject {
-    
-    func event(event: LiveEvent) async throws 
-    
+public protocol SubscribeCallback: AnyObject {
+    func event(event: LiveEvent) async throws
 }
 
 /**
@@ -8137,7 +7685,8 @@ public protocol SubscribeCallback : AnyObject {
  * method to check the `LiveEvent`
  */
 open class SubscribeCallbackImpl:
-    SubscribeCallback {
+    SubscribeCallback
+{
     fileprivate let pointer: UnsafeMutableRawPointer!
 
     /// Used to instantiate a [FFIObject] without an actual pointer, for fakes in tests, mostly.
@@ -8148,7 +7697,7 @@ open class SubscribeCallbackImpl:
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-    required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
+    public required init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
 
@@ -8157,13 +7706,14 @@ open class SubscribeCallbackImpl:
     ///
     /// - Warning:
     ///     Any object instantiated with this constructor cannot be passed to an actual Rust-backed object. Since there isn't a backing [Pointer] the FFI lower functions will crash.
-    public init(noPointer: NoPointer) {
-        self.pointer = nil
+    public init(noPointer _: NoPointer) {
+        pointer = nil
     }
 
     public func uniffiClonePointer() -> UnsafeMutableRawPointer {
         return try! rustCall { uniffi_iroh_ffi_fn_clone_subscribecallback(self.pointer, $0) }
     }
+
     // No primary constructor declared for this class.
 
     deinit {
@@ -8174,36 +7724,29 @@ open class SubscribeCallbackImpl:
         try! rustCall { uniffi_iroh_ffi_fn_free_subscribecallback(pointer, $0) }
     }
 
-    
-
-    
-open func event(event: LiveEvent)async throws  {
-    return
-        try  await uniffiRustCallAsync(
-            rustFutureFunc: {
-                uniffi_iroh_ffi_fn_method_subscribecallback_event(
-                    self.uniffiClonePointer(),
-                    FfiConverterTypeLiveEvent.lower(event)
-                )
-            },
-            pollFunc: ffi_iroh_ffi_rust_future_poll_void,
-            completeFunc: ffi_iroh_ffi_rust_future_complete_void,
-            freeFunc: ffi_iroh_ffi_rust_future_free_void,
-            liftFunc: { $0 },
-            errorHandler: FfiConverterTypeCallbackError.lift
-        )
+    open func event(event: LiveEvent) async throws {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_subscribecallback_event(
+                        self.uniffiClonePointer(),
+                        FfiConverterTypeLiveEvent.lower(event)
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_void,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_void,
+                freeFunc: ffi_iroh_ffi_rust_future_free_void,
+                liftFunc: { $0 },
+                errorHandler: FfiConverterTypeCallbackError.lift
+            )
+    }
 }
-    
-
-}
-
 
 // Put the implementation in a struct so we don't pollute the top-level namespace
-fileprivate struct UniffiCallbackInterfaceSubscribeCallback {
-
+private enum UniffiCallbackInterfaceSubscribeCallback {
     // Create the VTable using a series of closures.
     // Swift automatically converts these into C callback functions.
-    static var vtable: UniffiVTableCallbackInterfaceSubscribeCallback = UniffiVTableCallbackInterfaceSubscribeCallback(
+    static var vtable: UniffiVTableCallbackInterfaceSubscribeCallback = .init(
         event: { (
             uniffiHandle: UInt64,
             event: UnsafeMutableRawPointer,
@@ -8212,16 +7755,16 @@ fileprivate struct UniffiCallbackInterfaceSubscribeCallback {
             uniffiOutReturn: UnsafeMutablePointer<UniffiForeignFuture>
         ) in
             let makeCall = {
-                () async throws -> () in
+                () async throws in
                 guard let uniffiObj = try? FfiConverterTypeSubscribeCallback.handleMap.get(handle: uniffiHandle) else {
                     throw UniffiInternalError.unexpectedStaleHandle
                 }
                 return try await uniffiObj.event(
-                     event: try FfiConverterTypeLiveEvent.lift(event)
+                    event: FfiConverterTypeLiveEvent.lift(event)
                 )
             }
 
-            let uniffiHandleSuccess = { (returnValue: ()) in
+            let uniffiHandleSuccess = { (_: ()) in
                 uniffiFutureCallback(
                     uniffiCallbackData,
                     UniffiForeignFutureStructVoid(
@@ -8229,7 +7772,7 @@ fileprivate struct UniffiCallbackInterfaceSubscribeCallback {
                     )
                 )
             }
-            let uniffiHandleError = { (statusCode, errorBuf) in
+            let uniffiHandleError = { statusCode, errorBuf in
                 uniffiFutureCallback(
                     uniffiCallbackData,
                     UniffiForeignFutureStructVoid(
@@ -8245,7 +7788,7 @@ fileprivate struct UniffiCallbackInterfaceSubscribeCallback {
             )
             uniffiOutReturn.pointee = uniffiForeignFuture
         },
-        uniffiFree: { (uniffiHandle: UInt64) -> () in
+        uniffiFree: { (uniffiHandle: UInt64) in
             let result = try? FfiConverterTypeSubscribeCallback.handleMap.remove(handle: uniffiHandle)
             if result == nil {
                 print("Uniffi callback interface SubscribeCallback: handle missing in uniffiFree")
@@ -8280,7 +7823,7 @@ public struct FfiConverterTypeSubscribeCallback: FfiConverter {
         // The Rust code won't compile if a pointer won't fit in a UInt64.
         // We have to go via `UInt` because that's the thing that's the size of a pointer.
         let ptr = UnsafeMutableRawPointer(bitPattern: UInt(truncatingIfNeeded: v))
-        if (ptr == nil) {
+        if ptr == nil {
             throw UniffiInternalError.unexpectedNullPointer
         }
         return try lift(ptr!)
@@ -8293,9 +7836,6 @@ public struct FfiConverterTypeSubscribeCallback: FfiConverter {
     }
 }
 
-
-
-
 public func FfiConverterTypeSubscribeCallback_lift(_ pointer: UnsafeMutableRawPointer) throws -> SubscribeCallback {
     return try FfiConverterTypeSubscribeCallback.lift(pointer)
 }
@@ -8304,34 +7844,30 @@ public func FfiConverterTypeSubscribeCallback_lower(_ value: SubscribeCallback) 
     return FfiConverterTypeSubscribeCallback.lower(value)
 }
 
-
-
-
 /**
  * Iroh tags client.
  */
-public protocol TagsProtocol : AnyObject {
-    
+public protocol TagsProtocol: AnyObject {
     /**
      * Delete a tag
      */
-    func delete(name: Data) async throws 
-    
+    func delete(name: Data) async throws
+
     /**
      * List all tags
      *
      * Note: this allocates for each `ListTagsResponse`, if you have many `Tags`s this may be a prohibitively large list.
      * Please file an [issue](https://github.com/n0-computer/iroh-ffi/issues/new) if you run into this issue
      */
-    func list() async throws  -> [TagInfo]
-    
+    func list() async throws -> [TagInfo]
 }
 
 /**
  * Iroh tags client.
  */
 open class Tags:
-    TagsProtocol {
+    TagsProtocol
+{
     fileprivate let pointer: UnsafeMutableRawPointer!
 
     /// Used to instantiate a [FFIObject] without an actual pointer, for fakes in tests, mostly.
@@ -8342,7 +7878,7 @@ open class Tags:
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-    required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
+    public required init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
 
@@ -8351,13 +7887,14 @@ open class Tags:
     ///
     /// - Warning:
     ///     Any object instantiated with this constructor cannot be passed to an actual Rust-backed object. Since there isn't a backing [Pointer] the FFI lower functions will crash.
-    public init(noPointer: NoPointer) {
-        self.pointer = nil
+    public init(noPointer _: NoPointer) {
+        pointer = nil
     }
 
     public func uniffiClonePointer() -> UnsafeMutableRawPointer {
         return try! rustCall { uniffi_iroh_ffi_fn_clone_tags(self.pointer, $0) }
     }
+
     // No primary constructor declared for this class.
 
     deinit {
@@ -8368,57 +7905,50 @@ open class Tags:
         try! rustCall { uniffi_iroh_ffi_fn_free_tags(pointer, $0) }
     }
 
-    
-
-    
     /**
      * Delete a tag
      */
-open func delete(name: Data)async throws  {
-    return
-        try  await uniffiRustCallAsync(
-            rustFutureFunc: {
-                uniffi_iroh_ffi_fn_method_tags_delete(
-                    self.uniffiClonePointer(),
-                    FfiConverterData.lower(name)
-                )
-            },
-            pollFunc: ffi_iroh_ffi_rust_future_poll_void,
-            completeFunc: ffi_iroh_ffi_rust_future_complete_void,
-            freeFunc: ffi_iroh_ffi_rust_future_free_void,
-            liftFunc: { $0 },
-            errorHandler: FfiConverterTypeIrohError__as_error.lift
-        )
-}
-    
+    open func delete(name: Data) async throws {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_tags_delete(
+                        self.uniffiClonePointer(),
+                        FfiConverterData.lower(name)
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_void,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_void,
+                freeFunc: ffi_iroh_ffi_rust_future_free_void,
+                liftFunc: { $0 },
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
+
     /**
      * List all tags
      *
      * Note: this allocates for each `ListTagsResponse`, if you have many `Tags`s this may be a prohibitively large list.
      * Please file an [issue](https://github.com/n0-computer/iroh-ffi/issues/new) if you run into this issue
      */
-open func list()async throws  -> [TagInfo] {
-    return
-        try  await uniffiRustCallAsync(
-            rustFutureFunc: {
-                uniffi_iroh_ffi_fn_method_tags_list(
-                    self.uniffiClonePointer()
-                    
-                )
-            },
-            pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
-            completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
-            freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
-            liftFunc: FfiConverterSequenceTypeTagInfo.lift,
-            errorHandler: FfiConverterTypeIrohError__as_error.lift
-        )
-}
-    
-
+    open func list() async throws -> [TagInfo] {
+        return
+            try await uniffiRustCallAsync(
+                rustFutureFunc: {
+                    uniffi_iroh_ffi_fn_method_tags_list(
+                        self.uniffiClonePointer()
+                    )
+                },
+                pollFunc: ffi_iroh_ffi_rust_future_poll_rust_buffer,
+                completeFunc: ffi_iroh_ffi_rust_future_complete_rust_buffer,
+                freeFunc: ffi_iroh_ffi_rust_future_free_rust_buffer,
+                liftFunc: FfiConverterSequenceTypeTagInfo.lift,
+                errorHandler: FfiConverterTypeIrohError__as_error.lift
+            )
+    }
 }
 
 public struct FfiConverterTypeTags: FfiConverter {
-
     typealias FfiType = UnsafeMutableRawPointer
     typealias SwiftType = Tags
 
@@ -8435,7 +7965,7 @@ public struct FfiConverterTypeTags: FfiConverter {
         // The Rust code won't compile if a pointer won't fit in a UInt64.
         // We have to go via `UInt` because that's the thing that's the size of a pointer.
         let ptr = UnsafeMutableRawPointer(bitPattern: UInt(truncatingIfNeeded: v))
-        if (ptr == nil) {
+        if ptr == nil {
             throw UniffiInternalError.unexpectedNullPointer
         }
         return try lift(ptr!)
@@ -8448,9 +7978,6 @@ public struct FfiConverterTypeTags: FfiConverter {
     }
 }
 
-
-
-
 public func FfiConverterTypeTags_lift(_ pointer: UnsafeMutableRawPointer) throws -> Tags {
     return try FfiConverterTypeTags.lift(pointer)
 }
@@ -8459,21 +7986,17 @@ public func FfiConverterTypeTags_lower(_ value: Tags) -> UnsafeMutableRawPointer
     return FfiConverterTypeTags.lower(value)
 }
 
-
-
-
 /**
  * Whether to wrap the added data in a collection.
  */
-public protocol WrapOptionProtocol : AnyObject {
-    
-}
+public protocol WrapOptionProtocol: AnyObject {}
 
 /**
  * Whether to wrap the added data in a collection.
  */
 open class WrapOption:
-    WrapOptionProtocol {
+    WrapOptionProtocol
+{
     fileprivate let pointer: UnsafeMutableRawPointer!
 
     /// Used to instantiate a [FFIObject] without an actual pointer, for fakes in tests, mostly.
@@ -8484,7 +8007,7 @@ open class WrapOption:
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-    required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
+    public required init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
 
@@ -8493,13 +8016,14 @@ open class WrapOption:
     ///
     /// - Warning:
     ///     Any object instantiated with this constructor cannot be passed to an actual Rust-backed object. Since there isn't a backing [Pointer] the FFI lower functions will crash.
-    public init(noPointer: NoPointer) {
-        self.pointer = nil
+    public init(noPointer _: NoPointer) {
+        pointer = nil
     }
 
     public func uniffiClonePointer() -> UnsafeMutableRawPointer {
         return try! rustCall { uniffi_iroh_ffi_fn_clone_wrapoption(self.pointer, $0) }
     }
+
     // No primary constructor declared for this class.
 
     deinit {
@@ -8510,35 +8034,29 @@ open class WrapOption:
         try! rustCall { uniffi_iroh_ffi_fn_free_wrapoption(pointer, $0) }
     }
 
-    
     /**
      * Indicate you do not wrap the file or directory.
      */
-public static func noWrap() -> WrapOption {
-    return try!  FfiConverterTypeWrapOption.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_constructor_wrapoption_no_wrap($0
-    )
-})
-}
-    
+    public static func noWrap() -> WrapOption {
+        return try! FfiConverterTypeWrapOption.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_constructor_wrapoption_no_wrap($0
+            )
+        })
+    }
+
     /**
      * Indicate you want to wrap the file or directory in a colletion, with an optional name
      */
-public static func wrap(name: String?) -> WrapOption {
-    return try!  FfiConverterTypeWrapOption.lift(try! rustCall() {
-    uniffi_iroh_ffi_fn_constructor_wrapoption_wrap(
-        FfiConverterOptionString.lower(name),$0
-    )
-})
-}
-    
-
-    
-
+    public static func wrap(name: String?) -> WrapOption {
+        return try! FfiConverterTypeWrapOption.lift(try! rustCall {
+            uniffi_iroh_ffi_fn_constructor_wrapoption_wrap(
+                FfiConverterOptionString.lower(name), $0
+            )
+        })
+    }
 }
 
 public struct FfiConverterTypeWrapOption: FfiConverter {
-
     typealias FfiType = UnsafeMutableRawPointer
     typealias SwiftType = WrapOption
 
@@ -8555,7 +8073,7 @@ public struct FfiConverterTypeWrapOption: FfiConverter {
         // The Rust code won't compile if a pointer won't fit in a UInt64.
         // We have to go via `UInt` because that's the thing that's the size of a pointer.
         let ptr = UnsafeMutableRawPointer(bitPattern: UInt(truncatingIfNeeded: v))
-        if (ptr == nil) {
+        if ptr == nil {
             throw UniffiInternalError.unexpectedNullPointer
         }
         return try lift(ptr!)
@@ -8568,9 +8086,6 @@ public struct FfiConverterTypeWrapOption: FfiConverter {
     }
 }
 
-
-
-
 public func FfiConverterTypeWrapOption_lift(_ pointer: UnsafeMutableRawPointer) throws -> WrapOption {
     return try FfiConverterTypeWrapOption.lift(pointer)
 }
@@ -8578,7 +8093,6 @@ public func FfiConverterTypeWrapOption_lift(_ pointer: UnsafeMutableRawPointer) 
 public func FfiConverterTypeWrapOption_lower(_ value: WrapOption) -> UnsafeMutableRawPointer {
     return FfiConverterTypeWrapOption.lower(value)
 }
-
 
 /**
  * An AddProgress event indicating we got an error and need to abort
@@ -8593,10 +8107,8 @@ public struct AddProgressAbort {
     }
 }
 
-
-
 extension AddProgressAbort: Equatable, Hashable {
-    public static func ==(lhs: AddProgressAbort, rhs: AddProgressAbort) -> Bool {
+    public static func == (lhs: AddProgressAbort, rhs: AddProgressAbort) -> Bool {
         if lhs.error != rhs.error {
             return false
         }
@@ -8608,20 +8120,18 @@ extension AddProgressAbort: Equatable, Hashable {
     }
 }
 
-
 public struct FfiConverterTypeAddProgressAbort: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> AddProgressAbort {
         return
             try AddProgressAbort(
                 error: FfiConverterString.read(from: &buf)
-        )
+            )
     }
 
     public static func write(_ value: AddProgressAbort, into buf: inout [UInt8]) {
         FfiConverterString.write(value.error, into: &buf)
     }
 }
-
 
 public func FfiConverterTypeAddProgressAbort_lift(_ buf: RustBuffer) throws -> AddProgressAbort {
     return try FfiConverterTypeAddProgressAbort.lift(buf)
@@ -8630,7 +8140,6 @@ public func FfiConverterTypeAddProgressAbort_lift(_ buf: RustBuffer) throws -> A
 public func FfiConverterTypeAddProgressAbort_lower(_ value: AddProgressAbort) -> RustBuffer {
     return FfiConverterTypeAddProgressAbort.lower(value)
 }
-
 
 /**
  * An AddProgress event indicating we are done with the the whole operation
@@ -8654,29 +8163,28 @@ public struct AddProgressAllDone {
     public init(
         /**
          * The hash of the created data.
-         */hash: Hash, 
+         */ hash: Hash,
         /**
-         * The format of the added data.
-         */format: BlobFormat, 
+            * The format of the added data.
+            */ format: BlobFormat,
         /**
-         * The tag of the added data.
-         */tag: Data) {
+            * The tag of the added data.
+            */ tag: Data
+    ) {
         self.hash = hash
         self.format = format
         self.tag = tag
     }
 }
 
-
-
 public struct FfiConverterTypeAddProgressAllDone: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> AddProgressAllDone {
         return
             try AddProgressAllDone(
-                hash: FfiConverterTypeHash.read(from: &buf), 
-                format: FfiConverterTypeBlobFormat.read(from: &buf), 
+                hash: FfiConverterTypeHash.read(from: &buf),
+                format: FfiConverterTypeBlobFormat.read(from: &buf),
                 tag: FfiConverterData.read(from: &buf)
-        )
+            )
     }
 
     public static func write(_ value: AddProgressAllDone, into buf: inout [UInt8]) {
@@ -8686,7 +8194,6 @@ public struct FfiConverterTypeAddProgressAllDone: FfiConverterRustBuffer {
     }
 }
 
-
 public func FfiConverterTypeAddProgressAllDone_lift(_ buf: RustBuffer) throws -> AddProgressAllDone {
     return try FfiConverterTypeAddProgressAllDone.lift(buf)
 }
@@ -8694,7 +8201,6 @@ public func FfiConverterTypeAddProgressAllDone_lift(_ buf: RustBuffer) throws ->
 public func FfiConverterTypeAddProgressAllDone_lower(_ value: AddProgressAllDone) -> RustBuffer {
     return FfiConverterTypeAddProgressAllDone.lower(value)
 }
-
 
 /**
  * An AddProgress event indicated we are done with `id` and now have a hash `hash`
@@ -8714,24 +8220,23 @@ public struct AddProgressDone {
     public init(
         /**
          * The unique id of the entry.
-         */id: UInt64, 
+         */ id: UInt64,
         /**
-         * The hash of the entry.
-         */hash: Hash) {
+            * The hash of the entry.
+            */ hash: Hash
+    ) {
         self.id = id
         self.hash = hash
     }
 }
 
-
-
 public struct FfiConverterTypeAddProgressDone: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> AddProgressDone {
         return
             try AddProgressDone(
-                id: FfiConverterUInt64.read(from: &buf), 
+                id: FfiConverterUInt64.read(from: &buf),
                 hash: FfiConverterTypeHash.read(from: &buf)
-        )
+            )
     }
 
     public static func write(_ value: AddProgressDone, into buf: inout [UInt8]) {
@@ -8740,7 +8245,6 @@ public struct FfiConverterTypeAddProgressDone: FfiConverterRustBuffer {
     }
 }
 
-
 public func FfiConverterTypeAddProgressDone_lift(_ buf: RustBuffer) throws -> AddProgressDone {
     return try FfiConverterTypeAddProgressDone.lift(buf)
 }
@@ -8748,7 +8252,6 @@ public func FfiConverterTypeAddProgressDone_lift(_ buf: RustBuffer) throws -> Ad
 public func FfiConverterTypeAddProgressDone_lower(_ value: AddProgressDone) -> RustBuffer {
     return FfiConverterTypeAddProgressDone.lower(value)
 }
-
 
 /**
  * An AddProgress event indicating an item was found with name `name`, that can be referred to by `id`
@@ -8772,23 +8275,22 @@ public struct AddProgressFound {
     public init(
         /**
          * A new unique id for this entry.
-         */id: UInt64, 
+         */ id: UInt64,
         /**
-         * The name of the entry.
-         */name: String, 
+            * The name of the entry.
+            */ name: String,
         /**
-         * The size of the entry in bytes.
-         */size: UInt64) {
+            * The size of the entry in bytes.
+            */ size: UInt64
+    ) {
         self.id = id
         self.name = name
         self.size = size
     }
 }
 
-
-
 extension AddProgressFound: Equatable, Hashable {
-    public static func ==(lhs: AddProgressFound, rhs: AddProgressFound) -> Bool {
+    public static func == (lhs: AddProgressFound, rhs: AddProgressFound) -> Bool {
         if lhs.id != rhs.id {
             return false
         }
@@ -8808,15 +8310,14 @@ extension AddProgressFound: Equatable, Hashable {
     }
 }
 
-
 public struct FfiConverterTypeAddProgressFound: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> AddProgressFound {
         return
             try AddProgressFound(
-                id: FfiConverterUInt64.read(from: &buf), 
-                name: FfiConverterString.read(from: &buf), 
+                id: FfiConverterUInt64.read(from: &buf),
+                name: FfiConverterString.read(from: &buf),
                 size: FfiConverterUInt64.read(from: &buf)
-        )
+            )
     }
 
     public static func write(_ value: AddProgressFound, into buf: inout [UInt8]) {
@@ -8826,7 +8327,6 @@ public struct FfiConverterTypeAddProgressFound: FfiConverterRustBuffer {
     }
 }
 
-
 public func FfiConverterTypeAddProgressFound_lift(_ buf: RustBuffer) throws -> AddProgressFound {
     return try FfiConverterTypeAddProgressFound.lift(buf)
 }
@@ -8834,7 +8334,6 @@ public func FfiConverterTypeAddProgressFound_lift(_ buf: RustBuffer) throws -> A
 public func FfiConverterTypeAddProgressFound_lower(_ value: AddProgressFound) -> RustBuffer {
     return FfiConverterTypeAddProgressFound.lower(value)
 }
-
 
 /**
  * An AddProgress event indicating we got progress ingesting item `id`.
@@ -8854,19 +8353,18 @@ public struct AddProgressProgress {
     public init(
         /**
          * The unique id of the entry.
-         */id: UInt64, 
+         */ id: UInt64,
         /**
-         * The offset of the progress, in bytes.
-         */offset: UInt64) {
+            * The offset of the progress, in bytes.
+            */ offset: UInt64
+    ) {
         self.id = id
         self.offset = offset
     }
 }
 
-
-
 extension AddProgressProgress: Equatable, Hashable {
-    public static func ==(lhs: AddProgressProgress, rhs: AddProgressProgress) -> Bool {
+    public static func == (lhs: AddProgressProgress, rhs: AddProgressProgress) -> Bool {
         if lhs.id != rhs.id {
             return false
         }
@@ -8882,14 +8380,13 @@ extension AddProgressProgress: Equatable, Hashable {
     }
 }
 
-
 public struct FfiConverterTypeAddProgressProgress: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> AddProgressProgress {
         return
             try AddProgressProgress(
-                id: FfiConverterUInt64.read(from: &buf), 
+                id: FfiConverterUInt64.read(from: &buf),
                 offset: FfiConverterUInt64.read(from: &buf)
-        )
+            )
     }
 
     public static func write(_ value: AddProgressProgress, into buf: inout [UInt8]) {
@@ -8898,7 +8395,6 @@ public struct FfiConverterTypeAddProgressProgress: FfiConverterRustBuffer {
     }
 }
 
-
 public func FfiConverterTypeAddProgressProgress_lift(_ buf: RustBuffer) throws -> AddProgressProgress {
     return try FfiConverterTypeAddProgressProgress.lift(buf)
 }
@@ -8906,7 +8402,6 @@ public func FfiConverterTypeAddProgressProgress_lift(_ buf: RustBuffer) throws -
 public func FfiConverterTypeAddProgressProgress_lower(_ value: AddProgressProgress) -> RustBuffer {
     return FfiConverterTypeAddProgressProgress.lower(value)
 }
-
 
 /**
  * Outcome of a blob add operation.
@@ -8934,16 +8429,17 @@ public struct BlobAddOutcome {
     public init(
         /**
          * The hash of the blob
-         */hash: Hash, 
+         */ hash: Hash,
         /**
-         * The format the blob
-         */format: BlobFormat, 
+            * The format the blob
+            */ format: BlobFormat,
         /**
-         * The size of the blob
-         */size: UInt64, 
+            * The size of the blob
+            */ size: UInt64,
         /**
-         * The tag of the blob
-         */tag: Data) {
+            * The tag of the blob
+            */ tag: Data
+    ) {
         self.hash = hash
         self.format = format
         self.size = size
@@ -8951,17 +8447,15 @@ public struct BlobAddOutcome {
     }
 }
 
-
-
 public struct FfiConverterTypeBlobAddOutcome: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> BlobAddOutcome {
         return
             try BlobAddOutcome(
-                hash: FfiConverterTypeHash.read(from: &buf), 
-                format: FfiConverterTypeBlobFormat.read(from: &buf), 
-                size: FfiConverterUInt64.read(from: &buf), 
+                hash: FfiConverterTypeHash.read(from: &buf),
+                format: FfiConverterTypeBlobFormat.read(from: &buf),
+                size: FfiConverterUInt64.read(from: &buf),
                 tag: FfiConverterData.read(from: &buf)
-        )
+            )
     }
 
     public static func write(_ value: BlobAddOutcome, into buf: inout [UInt8]) {
@@ -8972,7 +8466,6 @@ public struct FfiConverterTypeBlobAddOutcome: FfiConverterRustBuffer {
     }
 }
 
-
 public func FfiConverterTypeBlobAddOutcome_lift(_ buf: RustBuffer) throws -> BlobAddOutcome {
     return try FfiConverterTypeBlobAddOutcome.lift(buf)
 }
@@ -8980,7 +8473,6 @@ public func FfiConverterTypeBlobAddOutcome_lift(_ buf: RustBuffer) throws -> Blo
 public func FfiConverterTypeBlobAddOutcome_lower(_ value: BlobAddOutcome) -> RustBuffer {
     return FfiConverterTypeBlobAddOutcome.lower(value)
 }
-
 
 /**
  * A response to a list blobs request
@@ -9004,29 +8496,28 @@ public struct BlobInfo {
     public init(
         /**
          * Location of the blob
-         */path: String, 
+         */ path: String,
         /**
-         * The hash of the blob
-         */hash: Hash, 
+            * The hash of the blob
+            */ hash: Hash,
         /**
-         * The size of the blob
-         */size: UInt64) {
+            * The size of the blob
+            */ size: UInt64
+    ) {
         self.path = path
         self.hash = hash
         self.size = size
     }
 }
 
-
-
 public struct FfiConverterTypeBlobInfo: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> BlobInfo {
         return
             try BlobInfo(
-                path: FfiConverterString.read(from: &buf), 
-                hash: FfiConverterTypeHash.read(from: &buf), 
+                path: FfiConverterString.read(from: &buf),
+                hash: FfiConverterTypeHash.read(from: &buf),
                 size: FfiConverterUInt64.read(from: &buf)
-        )
+            )
     }
 
     public static func write(_ value: BlobInfo, into buf: inout [UInt8]) {
@@ -9036,7 +8527,6 @@ public struct FfiConverterTypeBlobInfo: FfiConverterRustBuffer {
     }
 }
 
-
 public func FfiConverterTypeBlobInfo_lift(_ buf: RustBuffer) throws -> BlobInfo {
     return try FfiConverterTypeBlobInfo.lift(buf)
 }
@@ -9044,7 +8534,6 @@ public func FfiConverterTypeBlobInfo_lift(_ buf: RustBuffer) throws -> BlobInfo 
 public func FfiConverterTypeBlobInfo_lower(_ value: BlobInfo) -> RustBuffer {
     return FfiConverterTypeBlobInfo.lower(value)
 }
-
 
 /**
  * A response to a list collections request
@@ -9076,20 +8565,21 @@ public struct CollectionInfo {
     public init(
         /**
          * Tag of the collection
-         */tag: Data, 
+         */ tag: Data,
         /**
-         * Hash of the collection
-         */hash: Hash, 
+            * Hash of the collection
+            */ hash: Hash,
         /**
-         * Number of children in the collection
-         *
-         * This is an optional field, because the data is not always available.
-         */totalBlobsCount: UInt64?, 
+            * Number of children in the collection
+            *
+            * This is an optional field, because the data is not always available.
+            */ totalBlobsCount: UInt64?,
         /**
-         * Total size of the raw data referred to by all links
-         *
-         * This is an optional field, because the data is not always available.
-         */totalBlobsSize: UInt64?) {
+            * Total size of the raw data referred to by all links
+            *
+            * This is an optional field, because the data is not always available.
+            */ totalBlobsSize: UInt64?
+    ) {
         self.tag = tag
         self.hash = hash
         self.totalBlobsCount = totalBlobsCount
@@ -9097,17 +8587,15 @@ public struct CollectionInfo {
     }
 }
 
-
-
 public struct FfiConverterTypeCollectionInfo: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> CollectionInfo {
         return
             try CollectionInfo(
-                tag: FfiConverterData.read(from: &buf), 
-                hash: FfiConverterTypeHash.read(from: &buf), 
-                totalBlobsCount: FfiConverterOptionUInt64.read(from: &buf), 
+                tag: FfiConverterData.read(from: &buf),
+                hash: FfiConverterTypeHash.read(from: &buf),
+                totalBlobsCount: FfiConverterOptionUInt64.read(from: &buf),
                 totalBlobsSize: FfiConverterOptionUInt64.read(from: &buf)
-        )
+            )
     }
 
     public static func write(_ value: CollectionInfo, into buf: inout [UInt8]) {
@@ -9118,7 +8606,6 @@ public struct FfiConverterTypeCollectionInfo: FfiConverterRustBuffer {
     }
 }
 
-
 public func FfiConverterTypeCollectionInfo_lift(_ buf: RustBuffer) throws -> CollectionInfo {
     return try FfiConverterTypeCollectionInfo.lift(buf)
 }
@@ -9126,7 +8613,6 @@ public func FfiConverterTypeCollectionInfo_lift(_ buf: RustBuffer) throws -> Col
 public func FfiConverterTypeCollectionInfo_lower(_ value: CollectionInfo) -> RustBuffer {
     return FfiConverterTypeCollectionInfo.lower(value)
 }
-
 
 /**
  * The kinds of control messages that can be sent
@@ -9164,23 +8650,24 @@ public struct ConnectionInfo {
     public init(
         /**
          * The node identifier of the endpoint. Also a public key.
-         */nodeId: PublicKey, 
+         */ nodeId: PublicKey,
         /**
-         * Relay url, if available.
-         */relayUrl: String?, 
+            * Relay url, if available.
+            */ relayUrl: String?,
         /**
-         * List of addresses at which this node might be reachable, plus any latency information we
-         * have about that address and the last time the address was used.
-         */addrs: [DirectAddrInfo], 
+            * List of addresses at which this node might be reachable, plus any latency information we
+            * have about that address and the last time the address was used.
+            */ addrs: [DirectAddrInfo],
         /**
-         * The type of connection we have to the peer, either direct or over relay.
-         */connType: ConnectionType, 
+            * The type of connection we have to the peer, either direct or over relay.
+            */ connType: ConnectionType,
         /**
-         * The latency of the `conn_type`.
-         */latency: TimeInterval?, 
+            * The latency of the `conn_type`.
+            */ latency: TimeInterval?,
         /**
-         * Duration since the last time this peer was used.
-         */lastUsed: TimeInterval?) {
+            * Duration since the last time this peer was used.
+            */ lastUsed: TimeInterval?
+    ) {
         self.nodeId = nodeId
         self.relayUrl = relayUrl
         self.addrs = addrs
@@ -9190,19 +8677,17 @@ public struct ConnectionInfo {
     }
 }
 
-
-
 public struct FfiConverterTypeConnectionInfo: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> ConnectionInfo {
         return
             try ConnectionInfo(
-                nodeId: FfiConverterTypePublicKey.read(from: &buf), 
-                relayUrl: FfiConverterOptionString.read(from: &buf), 
-                addrs: FfiConverterSequenceTypeDirectAddrInfo.read(from: &buf), 
-                connType: FfiConverterTypeConnectionType.read(from: &buf), 
-                latency: FfiConverterOptionDuration.read(from: &buf), 
+                nodeId: FfiConverterTypePublicKey.read(from: &buf),
+                relayUrl: FfiConverterOptionString.read(from: &buf),
+                addrs: FfiConverterSequenceTypeDirectAddrInfo.read(from: &buf),
+                connType: FfiConverterTypeConnectionType.read(from: &buf),
+                latency: FfiConverterOptionDuration.read(from: &buf),
                 lastUsed: FfiConverterOptionDuration.read(from: &buf)
-        )
+            )
     }
 
     public static func write(_ value: ConnectionInfo, into buf: inout [UInt8]) {
@@ -9215,7 +8700,6 @@ public struct FfiConverterTypeConnectionInfo: FfiConverterRustBuffer {
     }
 }
 
-
 public func FfiConverterTypeConnectionInfo_lift(_ buf: RustBuffer) throws -> ConnectionInfo {
     return try FfiConverterTypeConnectionInfo.lift(buf)
 }
@@ -9223,7 +8707,6 @@ public func FfiConverterTypeConnectionInfo_lift(_ buf: RustBuffer) throws -> Con
 public func FfiConverterTypeConnectionInfo_lower(_ value: ConnectionInfo) -> RustBuffer {
     return FfiConverterTypeConnectionInfo.lower(value)
 }
-
 
 /**
  * The socket address and url of the mixed connection
@@ -9243,19 +8726,18 @@ public struct ConnectionTypeMixed {
     public init(
         /**
          * Address of the node
-         */addr: String, 
+         */ addr: String,
         /**
-         * Url of the relay node to which the node is connected
-         */relayUrl: String) {
+            * Url of the relay node to which the node is connected
+            */ relayUrl: String
+    ) {
         self.addr = addr
         self.relayUrl = relayUrl
     }
 }
 
-
-
 extension ConnectionTypeMixed: Equatable, Hashable {
-    public static func ==(lhs: ConnectionTypeMixed, rhs: ConnectionTypeMixed) -> Bool {
+    public static func == (lhs: ConnectionTypeMixed, rhs: ConnectionTypeMixed) -> Bool {
         if lhs.addr != rhs.addr {
             return false
         }
@@ -9271,14 +8753,13 @@ extension ConnectionTypeMixed: Equatable, Hashable {
     }
 }
 
-
 public struct FfiConverterTypeConnectionTypeMixed: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> ConnectionTypeMixed {
         return
             try ConnectionTypeMixed(
-                addr: FfiConverterString.read(from: &buf), 
+                addr: FfiConverterString.read(from: &buf),
                 relayUrl: FfiConverterString.read(from: &buf)
-        )
+            )
     }
 
     public static func write(_ value: ConnectionTypeMixed, into buf: inout [UInt8]) {
@@ -9287,7 +8768,6 @@ public struct FfiConverterTypeConnectionTypeMixed: FfiConverterRustBuffer {
     }
 }
 
-
 public func FfiConverterTypeConnectionTypeMixed_lift(_ buf: RustBuffer) throws -> ConnectionTypeMixed {
     return try FfiConverterTypeConnectionTypeMixed.lift(buf)
 }
@@ -9295,7 +8775,6 @@ public func FfiConverterTypeConnectionTypeMixed_lift(_ buf: RustBuffer) throws -
 public func FfiConverterTypeConnectionTypeMixed_lower(_ value: ConnectionTypeMixed) -> RustBuffer {
     return FfiConverterTypeConnectionTypeMixed.lower(value)
 }
-
 
 /**
  * Stats counter
@@ -9315,19 +8794,18 @@ public struct CounterStats {
     public init(
         /**
          * The counter value
-         */value: UInt32, 
+         */ value: UInt32,
         /**
-         * The counter description
-         */description: String) {
+            * The counter description
+            */ description: String
+    ) {
         self.value = value
         self.description = description
     }
 }
 
-
-
 extension CounterStats: Equatable, Hashable {
-    public static func ==(lhs: CounterStats, rhs: CounterStats) -> Bool {
+    public static func == (lhs: CounterStats, rhs: CounterStats) -> Bool {
         if lhs.value != rhs.value {
             return false
         }
@@ -9343,14 +8821,13 @@ extension CounterStats: Equatable, Hashable {
     }
 }
 
-
 public struct FfiConverterTypeCounterStats: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> CounterStats {
         return
             try CounterStats(
-                value: FfiConverterUInt32.read(from: &buf), 
+                value: FfiConverterUInt32.read(from: &buf),
                 description: FfiConverterString.read(from: &buf)
-        )
+            )
     }
 
     public static func write(_ value: CounterStats, into buf: inout [UInt8]) {
@@ -9359,7 +8836,6 @@ public struct FfiConverterTypeCounterStats: FfiConverterRustBuffer {
     }
 }
 
-
 public func FfiConverterTypeCounterStats_lift(_ buf: RustBuffer) throws -> CounterStats {
     return try FfiConverterTypeCounterStats.lift(buf)
 }
@@ -9367,7 +8843,6 @@ public func FfiConverterTypeCounterStats_lift(_ buf: RustBuffer) throws -> Count
 public func FfiConverterTypeCounterStats_lower(_ value: CounterStats) -> RustBuffer {
     return FfiConverterTypeCounterStats.lower(value)
 }
-
 
 /**
  * A DocExportProgress event indicating we got an error and need to abort
@@ -9383,15 +8858,14 @@ public struct DocExportProgressAbort {
     public init(
         /**
          * The error message
-         */error: String) {
+         */ error: String
+    ) {
         self.error = error
     }
 }
 
-
-
 extension DocExportProgressAbort: Equatable, Hashable {
-    public static func ==(lhs: DocExportProgressAbort, rhs: DocExportProgressAbort) -> Bool {
+    public static func == (lhs: DocExportProgressAbort, rhs: DocExportProgressAbort) -> Bool {
         if lhs.error != rhs.error {
             return false
         }
@@ -9403,20 +8877,18 @@ extension DocExportProgressAbort: Equatable, Hashable {
     }
 }
 
-
 public struct FfiConverterTypeDocExportProgressAbort: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> DocExportProgressAbort {
         return
             try DocExportProgressAbort(
                 error: FfiConverterString.read(from: &buf)
-        )
+            )
     }
 
     public static func write(_ value: DocExportProgressAbort, into buf: inout [UInt8]) {
         FfiConverterString.write(value.error, into: &buf)
     }
 }
-
 
 public func FfiConverterTypeDocExportProgressAbort_lift(_ buf: RustBuffer) throws -> DocExportProgressAbort {
     return try FfiConverterTypeDocExportProgressAbort.lift(buf)
@@ -9425,7 +8897,6 @@ public func FfiConverterTypeDocExportProgressAbort_lift(_ buf: RustBuffer) throw
 public func FfiConverterTypeDocExportProgressAbort_lower(_ value: DocExportProgressAbort) -> RustBuffer {
     return FfiConverterTypeDocExportProgressAbort.lower(value)
 }
-
 
 /**
  * A DocExportProgress event indicating a single blob wit `id` is done
@@ -9441,15 +8912,14 @@ public struct DocExportProgressDone {
     public init(
         /**
          * The unique id of the entry.
-         */id: UInt64) {
+         */ id: UInt64
+    ) {
         self.id = id
     }
 }
 
-
-
 extension DocExportProgressDone: Equatable, Hashable {
-    public static func ==(lhs: DocExportProgressDone, rhs: DocExportProgressDone) -> Bool {
+    public static func == (lhs: DocExportProgressDone, rhs: DocExportProgressDone) -> Bool {
         if lhs.id != rhs.id {
             return false
         }
@@ -9461,20 +8931,18 @@ extension DocExportProgressDone: Equatable, Hashable {
     }
 }
 
-
 public struct FfiConverterTypeDocExportProgressDone: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> DocExportProgressDone {
         return
             try DocExportProgressDone(
                 id: FfiConverterUInt64.read(from: &buf)
-        )
+            )
     }
 
     public static func write(_ value: DocExportProgressDone, into buf: inout [UInt8]) {
         FfiConverterUInt64.write(value.id, into: &buf)
     }
 }
-
 
 public func FfiConverterTypeDocExportProgressDone_lift(_ buf: RustBuffer) throws -> DocExportProgressDone {
     return try FfiConverterTypeDocExportProgressDone.lift(buf)
@@ -9483,7 +8951,6 @@ public func FfiConverterTypeDocExportProgressDone_lift(_ buf: RustBuffer) throws
 public func FfiConverterTypeDocExportProgressDone_lower(_ value: DocExportProgressDone) -> RustBuffer {
     return FfiConverterTypeDocExportProgressDone.lower(value)
 }
-
 
 /**
  * A DocExportProgress event indicating a file was found with name `name`, from now on referred to via `id`
@@ -9511,16 +8978,17 @@ public struct DocExportProgressFound {
     public init(
         /**
          * A new unique id for this entry.
-         */id: UInt64, 
+         */ id: UInt64,
         /**
-         * The hash of the entry.
-         */hash: Hash, 
+            * The hash of the entry.
+            */ hash: Hash,
         /**
-         * The size of the entry in bytes.
-         */size: UInt64, 
+            * The size of the entry in bytes.
+            */ size: UInt64,
         /**
-         * The path where we are writing the entry
-         */outpath: String) {
+            * The path where we are writing the entry
+            */ outpath: String
+    ) {
         self.id = id
         self.hash = hash
         self.size = size
@@ -9528,17 +8996,15 @@ public struct DocExportProgressFound {
     }
 }
 
-
-
 public struct FfiConverterTypeDocExportProgressFound: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> DocExportProgressFound {
         return
             try DocExportProgressFound(
-                id: FfiConverterUInt64.read(from: &buf), 
-                hash: FfiConverterTypeHash.read(from: &buf), 
-                size: FfiConverterUInt64.read(from: &buf), 
+                id: FfiConverterUInt64.read(from: &buf),
+                hash: FfiConverterTypeHash.read(from: &buf),
+                size: FfiConverterUInt64.read(from: &buf),
                 outpath: FfiConverterString.read(from: &buf)
-        )
+            )
     }
 
     public static func write(_ value: DocExportProgressFound, into buf: inout [UInt8]) {
@@ -9549,7 +9015,6 @@ public struct FfiConverterTypeDocExportProgressFound: FfiConverterRustBuffer {
     }
 }
 
-
 public func FfiConverterTypeDocExportProgressFound_lift(_ buf: RustBuffer) throws -> DocExportProgressFound {
     return try FfiConverterTypeDocExportProgressFound.lift(buf)
 }
@@ -9557,7 +9022,6 @@ public func FfiConverterTypeDocExportProgressFound_lift(_ buf: RustBuffer) throw
 public func FfiConverterTypeDocExportProgressFound_lower(_ value: DocExportProgressFound) -> RustBuffer {
     return FfiConverterTypeDocExportProgressFound.lower(value)
 }
-
 
 /**
  * A DocExportProgress event indicating we've made progress exporting item `id`.
@@ -9577,19 +9041,18 @@ public struct DocExportProgressProgress {
     public init(
         /**
          * The unique id of the entry.
-         */id: UInt64, 
+         */ id: UInt64,
         /**
-         * The offset of the progress, in bytes.
-         */offset: UInt64) {
+            * The offset of the progress, in bytes.
+            */ offset: UInt64
+    ) {
         self.id = id
         self.offset = offset
     }
 }
 
-
-
 extension DocExportProgressProgress: Equatable, Hashable {
-    public static func ==(lhs: DocExportProgressProgress, rhs: DocExportProgressProgress) -> Bool {
+    public static func == (lhs: DocExportProgressProgress, rhs: DocExportProgressProgress) -> Bool {
         if lhs.id != rhs.id {
             return false
         }
@@ -9605,14 +9068,13 @@ extension DocExportProgressProgress: Equatable, Hashable {
     }
 }
 
-
 public struct FfiConverterTypeDocExportProgressProgress: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> DocExportProgressProgress {
         return
             try DocExportProgressProgress(
-                id: FfiConverterUInt64.read(from: &buf), 
+                id: FfiConverterUInt64.read(from: &buf),
                 offset: FfiConverterUInt64.read(from: &buf)
-        )
+            )
     }
 
     public static func write(_ value: DocExportProgressProgress, into buf: inout [UInt8]) {
@@ -9621,7 +9083,6 @@ public struct FfiConverterTypeDocExportProgressProgress: FfiConverterRustBuffer 
     }
 }
 
-
 public func FfiConverterTypeDocExportProgressProgress_lift(_ buf: RustBuffer) throws -> DocExportProgressProgress {
     return try FfiConverterTypeDocExportProgressProgress.lift(buf)
 }
@@ -9629,7 +9090,6 @@ public func FfiConverterTypeDocExportProgressProgress_lift(_ buf: RustBuffer) th
 public func FfiConverterTypeDocExportProgressProgress_lower(_ value: DocExportProgressProgress) -> RustBuffer {
     return FfiConverterTypeDocExportProgressProgress.lower(value)
 }
-
 
 /**
  * A DocImportProgress event indicating we got an error and need to abort
@@ -9645,15 +9105,14 @@ public struct DocImportProgressAbort {
     public init(
         /**
          * The error message
-         */error: String) {
+         */ error: String
+    ) {
         self.error = error
     }
 }
 
-
-
 extension DocImportProgressAbort: Equatable, Hashable {
-    public static func ==(lhs: DocImportProgressAbort, rhs: DocImportProgressAbort) -> Bool {
+    public static func == (lhs: DocImportProgressAbort, rhs: DocImportProgressAbort) -> Bool {
         if lhs.error != rhs.error {
             return false
         }
@@ -9665,20 +9124,18 @@ extension DocImportProgressAbort: Equatable, Hashable {
     }
 }
 
-
 public struct FfiConverterTypeDocImportProgressAbort: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> DocImportProgressAbort {
         return
             try DocImportProgressAbort(
                 error: FfiConverterString.read(from: &buf)
-        )
+            )
     }
 
     public static func write(_ value: DocImportProgressAbort, into buf: inout [UInt8]) {
         FfiConverterString.write(value.error, into: &buf)
     }
 }
-
 
 public func FfiConverterTypeDocImportProgressAbort_lift(_ buf: RustBuffer) throws -> DocImportProgressAbort {
     return try FfiConverterTypeDocImportProgressAbort.lift(buf)
@@ -9687,7 +9144,6 @@ public func FfiConverterTypeDocImportProgressAbort_lift(_ buf: RustBuffer) throw
 public func FfiConverterTypeDocImportProgressAbort_lower(_ value: DocImportProgressAbort) -> RustBuffer {
     return FfiConverterTypeDocImportProgressAbort.lower(value)
 }
-
 
 /**
  * A DocImportProgress event indicating we are done setting the entry to the doc
@@ -9703,15 +9159,14 @@ public struct DocImportProgressAllDone {
     public init(
         /**
          * The key of the entry
-         */key: Data) {
+         */ key: Data
+    ) {
         self.key = key
     }
 }
 
-
-
 extension DocImportProgressAllDone: Equatable, Hashable {
-    public static func ==(lhs: DocImportProgressAllDone, rhs: DocImportProgressAllDone) -> Bool {
+    public static func == (lhs: DocImportProgressAllDone, rhs: DocImportProgressAllDone) -> Bool {
         if lhs.key != rhs.key {
             return false
         }
@@ -9723,20 +9178,18 @@ extension DocImportProgressAllDone: Equatable, Hashable {
     }
 }
 
-
 public struct FfiConverterTypeDocImportProgressAllDone: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> DocImportProgressAllDone {
         return
             try DocImportProgressAllDone(
                 key: FfiConverterData.read(from: &buf)
-        )
+            )
     }
 
     public static func write(_ value: DocImportProgressAllDone, into buf: inout [UInt8]) {
         FfiConverterData.write(value.key, into: &buf)
     }
 }
-
 
 public func FfiConverterTypeDocImportProgressAllDone_lift(_ buf: RustBuffer) throws -> DocImportProgressAllDone {
     return try FfiConverterTypeDocImportProgressAllDone.lift(buf)
@@ -9745,7 +9198,6 @@ public func FfiConverterTypeDocImportProgressAllDone_lift(_ buf: RustBuffer) thr
 public func FfiConverterTypeDocImportProgressAllDone_lower(_ value: DocImportProgressAllDone) -> RustBuffer {
     return FfiConverterTypeDocImportProgressAllDone.lower(value)
 }
-
 
 /**
  * A DocImportProgress event indicating a file was found with name `name`, from now on referred to via `id`
@@ -9769,23 +9221,22 @@ public struct DocImportProgressFound {
     public init(
         /**
          * A new unique id for this entry.
-         */id: UInt64, 
+         */ id: UInt64,
         /**
-         * The name of the entry.
-         */name: String, 
+            * The name of the entry.
+            */ name: String,
         /**
-         * The size of the entry in bytes.
-         */size: UInt64) {
+            * The size of the entry in bytes.
+            */ size: UInt64
+    ) {
         self.id = id
         self.name = name
         self.size = size
     }
 }
 
-
-
 extension DocImportProgressFound: Equatable, Hashable {
-    public static func ==(lhs: DocImportProgressFound, rhs: DocImportProgressFound) -> Bool {
+    public static func == (lhs: DocImportProgressFound, rhs: DocImportProgressFound) -> Bool {
         if lhs.id != rhs.id {
             return false
         }
@@ -9805,15 +9256,14 @@ extension DocImportProgressFound: Equatable, Hashable {
     }
 }
 
-
 public struct FfiConverterTypeDocImportProgressFound: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> DocImportProgressFound {
         return
             try DocImportProgressFound(
-                id: FfiConverterUInt64.read(from: &buf), 
-                name: FfiConverterString.read(from: &buf), 
+                id: FfiConverterUInt64.read(from: &buf),
+                name: FfiConverterString.read(from: &buf),
                 size: FfiConverterUInt64.read(from: &buf)
-        )
+            )
     }
 
     public static func write(_ value: DocImportProgressFound, into buf: inout [UInt8]) {
@@ -9823,7 +9273,6 @@ public struct FfiConverterTypeDocImportProgressFound: FfiConverterRustBuffer {
     }
 }
 
-
 public func FfiConverterTypeDocImportProgressFound_lift(_ buf: RustBuffer) throws -> DocImportProgressFound {
     return try FfiConverterTypeDocImportProgressFound.lift(buf)
 }
@@ -9831,7 +9280,6 @@ public func FfiConverterTypeDocImportProgressFound_lift(_ buf: RustBuffer) throw
 public func FfiConverterTypeDocImportProgressFound_lower(_ value: DocImportProgressFound) -> RustBuffer {
     return FfiConverterTypeDocImportProgressFound.lower(value)
 }
-
 
 /**
  * A DocImportProgress event indicating we are finished adding `id` to the data store and the hash is `hash`.
@@ -9851,24 +9299,23 @@ public struct DocImportProgressIngestDone {
     public init(
         /**
          * The unique id of the entry.
-         */id: UInt64, 
+         */ id: UInt64,
         /**
-         * The hash of the entry.
-         */hash: Hash) {
+            * The hash of the entry.
+            */ hash: Hash
+    ) {
         self.id = id
         self.hash = hash
     }
 }
 
-
-
 public struct FfiConverterTypeDocImportProgressIngestDone: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> DocImportProgressIngestDone {
         return
             try DocImportProgressIngestDone(
-                id: FfiConverterUInt64.read(from: &buf), 
+                id: FfiConverterUInt64.read(from: &buf),
                 hash: FfiConverterTypeHash.read(from: &buf)
-        )
+            )
     }
 
     public static func write(_ value: DocImportProgressIngestDone, into buf: inout [UInt8]) {
@@ -9877,7 +9324,6 @@ public struct FfiConverterTypeDocImportProgressIngestDone: FfiConverterRustBuffe
     }
 }
 
-
 public func FfiConverterTypeDocImportProgressIngestDone_lift(_ buf: RustBuffer) throws -> DocImportProgressIngestDone {
     return try FfiConverterTypeDocImportProgressIngestDone.lift(buf)
 }
@@ -9885,7 +9331,6 @@ public func FfiConverterTypeDocImportProgressIngestDone_lift(_ buf: RustBuffer) 
 public func FfiConverterTypeDocImportProgressIngestDone_lower(_ value: DocImportProgressIngestDone) -> RustBuffer {
     return FfiConverterTypeDocImportProgressIngestDone.lower(value)
 }
-
 
 /**
  * A DocImportProgress event indicating we've made progress ingesting item `id`.
@@ -9905,19 +9350,18 @@ public struct DocImportProgressProgress {
     public init(
         /**
          * The unique id of the entry.
-         */id: UInt64, 
+         */ id: UInt64,
         /**
-         * The offset of the progress, in bytes.
-         */offset: UInt64) {
+            * The offset of the progress, in bytes.
+            */ offset: UInt64
+    ) {
         self.id = id
         self.offset = offset
     }
 }
 
-
-
 extension DocImportProgressProgress: Equatable, Hashable {
-    public static func ==(lhs: DocImportProgressProgress, rhs: DocImportProgressProgress) -> Bool {
+    public static func == (lhs: DocImportProgressProgress, rhs: DocImportProgressProgress) -> Bool {
         if lhs.id != rhs.id {
             return false
         }
@@ -9933,14 +9377,13 @@ extension DocImportProgressProgress: Equatable, Hashable {
     }
 }
 
-
 public struct FfiConverterTypeDocImportProgressProgress: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> DocImportProgressProgress {
         return
             try DocImportProgressProgress(
-                id: FfiConverterUInt64.read(from: &buf), 
+                id: FfiConverterUInt64.read(from: &buf),
                 offset: FfiConverterUInt64.read(from: &buf)
-        )
+            )
     }
 
     public static func write(_ value: DocImportProgressProgress, into buf: inout [UInt8]) {
@@ -9949,7 +9392,6 @@ public struct FfiConverterTypeDocImportProgressProgress: FfiConverterRustBuffer 
     }
 }
 
-
 public func FfiConverterTypeDocImportProgressProgress_lift(_ buf: RustBuffer) throws -> DocImportProgressProgress {
     return try FfiConverterTypeDocImportProgressProgress.lift(buf)
 }
@@ -9957,7 +9399,6 @@ public func FfiConverterTypeDocImportProgressProgress_lift(_ buf: RustBuffer) th
 public func FfiConverterTypeDocImportProgressProgress_lower(_ value: DocImportProgressProgress) -> RustBuffer {
     return FfiConverterTypeDocImportProgressProgress.lower(value)
 }
-
 
 /**
  * A DownloadProgress event indicating we got an error and need to abort
@@ -9972,10 +9413,8 @@ public struct DownloadProgressAbort {
     }
 }
 
-
-
 extension DownloadProgressAbort: Equatable, Hashable {
-    public static func ==(lhs: DownloadProgressAbort, rhs: DownloadProgressAbort) -> Bool {
+    public static func == (lhs: DownloadProgressAbort, rhs: DownloadProgressAbort) -> Bool {
         if lhs.error != rhs.error {
             return false
         }
@@ -9987,20 +9426,18 @@ extension DownloadProgressAbort: Equatable, Hashable {
     }
 }
 
-
 public struct FfiConverterTypeDownloadProgressAbort: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> DownloadProgressAbort {
         return
             try DownloadProgressAbort(
                 error: FfiConverterString.read(from: &buf)
-        )
+            )
     }
 
     public static func write(_ value: DownloadProgressAbort, into buf: inout [UInt8]) {
         FfiConverterString.write(value.error, into: &buf)
     }
 }
-
 
 public func FfiConverterTypeDownloadProgressAbort_lift(_ buf: RustBuffer) throws -> DownloadProgressAbort {
     return try FfiConverterTypeDownloadProgressAbort.lift(buf)
@@ -10009,7 +9446,6 @@ public func FfiConverterTypeDownloadProgressAbort_lift(_ buf: RustBuffer) throws
 public func FfiConverterTypeDownloadProgressAbort_lower(_ value: DownloadProgressAbort) -> RustBuffer {
     return FfiConverterTypeDownloadProgressAbort.lower(value)
 }
-
 
 /**
  * A DownloadProgress event indicating we are done with the whole operation
@@ -10033,23 +9469,22 @@ public struct DownloadProgressAllDone {
     public init(
         /**
          * The number of bytes written
-         */bytesWritten: UInt64, 
+         */ bytesWritten: UInt64,
         /**
-         * The number of bytes read
-         */bytesRead: UInt64, 
+            * The number of bytes read
+            */ bytesRead: UInt64,
         /**
-         * The time it took to transfer the data
-         */elapsed: TimeInterval) {
+            * The time it took to transfer the data
+            */ elapsed: TimeInterval
+    ) {
         self.bytesWritten = bytesWritten
         self.bytesRead = bytesRead
         self.elapsed = elapsed
     }
 }
 
-
-
 extension DownloadProgressAllDone: Equatable, Hashable {
-    public static func ==(lhs: DownloadProgressAllDone, rhs: DownloadProgressAllDone) -> Bool {
+    public static func == (lhs: DownloadProgressAllDone, rhs: DownloadProgressAllDone) -> Bool {
         if lhs.bytesWritten != rhs.bytesWritten {
             return false
         }
@@ -10069,15 +9504,14 @@ extension DownloadProgressAllDone: Equatable, Hashable {
     }
 }
 
-
 public struct FfiConverterTypeDownloadProgressAllDone: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> DownloadProgressAllDone {
         return
             try DownloadProgressAllDone(
-                bytesWritten: FfiConverterUInt64.read(from: &buf), 
-                bytesRead: FfiConverterUInt64.read(from: &buf), 
+                bytesWritten: FfiConverterUInt64.read(from: &buf),
+                bytesRead: FfiConverterUInt64.read(from: &buf),
                 elapsed: FfiConverterDuration.read(from: &buf)
-        )
+            )
     }
 
     public static func write(_ value: DownloadProgressAllDone, into buf: inout [UInt8]) {
@@ -10087,7 +9521,6 @@ public struct FfiConverterTypeDownloadProgressAllDone: FfiConverterRustBuffer {
     }
 }
 
-
 public func FfiConverterTypeDownloadProgressAllDone_lift(_ buf: RustBuffer) throws -> DownloadProgressAllDone {
     return try FfiConverterTypeDownloadProgressAllDone.lift(buf)
 }
@@ -10095,7 +9528,6 @@ public func FfiConverterTypeDownloadProgressAllDone_lift(_ buf: RustBuffer) thro
 public func FfiConverterTypeDownloadProgressAllDone_lower(_ value: DownloadProgressAllDone) -> RustBuffer {
     return FfiConverterTypeDownloadProgressAllDone.lower(value)
 }
-
 
 /**
  * A DownloadProgress event indicated we are done with `id`
@@ -10111,15 +9543,14 @@ public struct DownloadProgressDone {
     public init(
         /**
          * The unique id of the entry.
-         */id: UInt64) {
+         */ id: UInt64
+    ) {
         self.id = id
     }
 }
 
-
-
 extension DownloadProgressDone: Equatable, Hashable {
-    public static func ==(lhs: DownloadProgressDone, rhs: DownloadProgressDone) -> Bool {
+    public static func == (lhs: DownloadProgressDone, rhs: DownloadProgressDone) -> Bool {
         if lhs.id != rhs.id {
             return false
         }
@@ -10131,20 +9562,18 @@ extension DownloadProgressDone: Equatable, Hashable {
     }
 }
 
-
 public struct FfiConverterTypeDownloadProgressDone: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> DownloadProgressDone {
         return
             try DownloadProgressDone(
                 id: FfiConverterUInt64.read(from: &buf)
-        )
+            )
     }
 
     public static func write(_ value: DownloadProgressDone, into buf: inout [UInt8]) {
         FfiConverterUInt64.write(value.id, into: &buf)
     }
 }
-
 
 public func FfiConverterTypeDownloadProgressDone_lift(_ buf: RustBuffer) throws -> DownloadProgressDone {
     return try FfiConverterTypeDownloadProgressDone.lift(buf)
@@ -10153,7 +9582,6 @@ public func FfiConverterTypeDownloadProgressDone_lift(_ buf: RustBuffer) throws 
 public func FfiConverterTypeDownloadProgressDone_lower(_ value: DownloadProgressDone) -> RustBuffer {
     return FfiConverterTypeDownloadProgressDone.lower(value)
 }
-
 
 /**
  * A DownloadProgress event indicating an item was found with hash `hash`, that can be referred to by `id`
@@ -10181,16 +9609,17 @@ public struct DownloadProgressFound {
     public init(
         /**
          * A new unique id for this entry.
-         */id: UInt64, 
+         */ id: UInt64,
         /**
-         * child offset
-         */child: UInt64, 
+            * child offset
+            */ child: UInt64,
         /**
-         * The hash of the entry.
-         */hash: Hash, 
+            * The hash of the entry.
+            */ hash: Hash,
         /**
-         * The size of the entry in bytes.
-         */size: UInt64) {
+            * The size of the entry in bytes.
+            */ size: UInt64
+    ) {
         self.id = id
         self.child = child
         self.hash = hash
@@ -10198,17 +9627,15 @@ public struct DownloadProgressFound {
     }
 }
 
-
-
 public struct FfiConverterTypeDownloadProgressFound: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> DownloadProgressFound {
         return
             try DownloadProgressFound(
-                id: FfiConverterUInt64.read(from: &buf), 
-                child: FfiConverterUInt64.read(from: &buf), 
-                hash: FfiConverterTypeHash.read(from: &buf), 
+                id: FfiConverterUInt64.read(from: &buf),
+                child: FfiConverterUInt64.read(from: &buf),
+                hash: FfiConverterTypeHash.read(from: &buf),
                 size: FfiConverterUInt64.read(from: &buf)
-        )
+            )
     }
 
     public static func write(_ value: DownloadProgressFound, into buf: inout [UInt8]) {
@@ -10219,7 +9646,6 @@ public struct FfiConverterTypeDownloadProgressFound: FfiConverterRustBuffer {
     }
 }
 
-
 public func FfiConverterTypeDownloadProgressFound_lift(_ buf: RustBuffer) throws -> DownloadProgressFound {
     return try FfiConverterTypeDownloadProgressFound.lift(buf)
 }
@@ -10227,7 +9653,6 @@ public func FfiConverterTypeDownloadProgressFound_lift(_ buf: RustBuffer) throws
 public func FfiConverterTypeDownloadProgressFound_lower(_ value: DownloadProgressFound) -> RustBuffer {
     return FfiConverterTypeDownloadProgressFound.lower(value)
 }
-
 
 /**
  * A DownloadProgress event indicating an item was found with hash `hash`, that can be referred to by `id`
@@ -10247,24 +9672,23 @@ public struct DownloadProgressFoundHashSeq {
     public init(
         /**
          * Number of children in the collection, if known.
-         */children: UInt64, 
+         */ children: UInt64,
         /**
-         * The hash of the entry.
-         */hash: Hash) {
+            * The hash of the entry.
+            */ hash: Hash
+    ) {
         self.children = children
         self.hash = hash
     }
 }
 
-
-
 public struct FfiConverterTypeDownloadProgressFoundHashSeq: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> DownloadProgressFoundHashSeq {
         return
             try DownloadProgressFoundHashSeq(
-                children: FfiConverterUInt64.read(from: &buf), 
+                children: FfiConverterUInt64.read(from: &buf),
                 hash: FfiConverterTypeHash.read(from: &buf)
-        )
+            )
     }
 
     public static func write(_ value: DownloadProgressFoundHashSeq, into buf: inout [UInt8]) {
@@ -10273,7 +9697,6 @@ public struct FfiConverterTypeDownloadProgressFoundHashSeq: FfiConverterRustBuff
     }
 }
 
-
 public func FfiConverterTypeDownloadProgressFoundHashSeq_lift(_ buf: RustBuffer) throws -> DownloadProgressFoundHashSeq {
     return try FfiConverterTypeDownloadProgressFoundHashSeq.lift(buf)
 }
@@ -10281,7 +9704,6 @@ public func FfiConverterTypeDownloadProgressFoundHashSeq_lift(_ buf: RustBuffer)
 public func FfiConverterTypeDownloadProgressFoundHashSeq_lower(_ value: DownloadProgressFoundHashSeq) -> RustBuffer {
     return FfiConverterTypeDownloadProgressFoundHashSeq.lower(value)
 }
-
 
 /**
  * A DownloadProgress event indicating an entry was found locally
@@ -10309,16 +9731,17 @@ public struct DownloadProgressFoundLocal {
     public init(
         /**
          * child offset
-         */child: UInt64, 
+         */ child: UInt64,
         /**
-         * The hash of the entry.
-         */hash: Hash, 
+            * The hash of the entry.
+            */ hash: Hash,
         /**
-         * The size of the entry in bytes.
-         */size: UInt64, 
+            * The size of the entry in bytes.
+            */ size: UInt64,
         /**
-         * The ranges that are available locally.
-         */validRanges: RangeSpec) {
+            * The ranges that are available locally.
+            */ validRanges: RangeSpec
+    ) {
         self.child = child
         self.hash = hash
         self.size = size
@@ -10326,17 +9749,15 @@ public struct DownloadProgressFoundLocal {
     }
 }
 
-
-
 public struct FfiConverterTypeDownloadProgressFoundLocal: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> DownloadProgressFoundLocal {
         return
             try DownloadProgressFoundLocal(
-                child: FfiConverterUInt64.read(from: &buf), 
-                hash: FfiConverterTypeHash.read(from: &buf), 
-                size: FfiConverterUInt64.read(from: &buf), 
+                child: FfiConverterUInt64.read(from: &buf),
+                hash: FfiConverterTypeHash.read(from: &buf),
+                size: FfiConverterUInt64.read(from: &buf),
                 validRanges: FfiConverterTypeRangeSpec.read(from: &buf)
-        )
+            )
     }
 
     public static func write(_ value: DownloadProgressFoundLocal, into buf: inout [UInt8]) {
@@ -10347,7 +9768,6 @@ public struct FfiConverterTypeDownloadProgressFoundLocal: FfiConverterRustBuffer
     }
 }
 
-
 public func FfiConverterTypeDownloadProgressFoundLocal_lift(_ buf: RustBuffer) throws -> DownloadProgressFoundLocal {
     return try FfiConverterTypeDownloadProgressFoundLocal.lift(buf)
 }
@@ -10355,7 +9775,6 @@ public func FfiConverterTypeDownloadProgressFoundLocal_lift(_ buf: RustBuffer) t
 public func FfiConverterTypeDownloadProgressFoundLocal_lower(_ value: DownloadProgressFoundLocal) -> RustBuffer {
     return FfiConverterTypeDownloadProgressFoundLocal.lower(value)
 }
-
 
 public struct DownloadProgressInitialState {
     /**
@@ -10368,15 +9787,14 @@ public struct DownloadProgressInitialState {
     public init(
         /**
          * Whether we are connected to a node
-         */connected: Bool) {
+         */ connected: Bool
+    ) {
         self.connected = connected
     }
 }
 
-
-
 extension DownloadProgressInitialState: Equatable, Hashable {
-    public static func ==(lhs: DownloadProgressInitialState, rhs: DownloadProgressInitialState) -> Bool {
+    public static func == (lhs: DownloadProgressInitialState, rhs: DownloadProgressInitialState) -> Bool {
         if lhs.connected != rhs.connected {
             return false
         }
@@ -10388,20 +9806,18 @@ extension DownloadProgressInitialState: Equatable, Hashable {
     }
 }
 
-
 public struct FfiConverterTypeDownloadProgressInitialState: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> DownloadProgressInitialState {
         return
             try DownloadProgressInitialState(
                 connected: FfiConverterBool.read(from: &buf)
-        )
+            )
     }
 
     public static func write(_ value: DownloadProgressInitialState, into buf: inout [UInt8]) {
         FfiConverterBool.write(value.connected, into: &buf)
     }
 }
-
 
 public func FfiConverterTypeDownloadProgressInitialState_lift(_ buf: RustBuffer) throws -> DownloadProgressInitialState {
     return try FfiConverterTypeDownloadProgressInitialState.lift(buf)
@@ -10410,7 +9826,6 @@ public func FfiConverterTypeDownloadProgressInitialState_lift(_ buf: RustBuffer)
 public func FfiConverterTypeDownloadProgressInitialState_lower(_ value: DownloadProgressInitialState) -> RustBuffer {
     return FfiConverterTypeDownloadProgressInitialState.lower(value)
 }
-
 
 /**
  * A DownloadProgress event indicating we got progress ingesting item `id`.
@@ -10430,19 +9845,18 @@ public struct DownloadProgressProgress {
     public init(
         /**
          * The unique id of the entry.
-         */id: UInt64, 
+         */ id: UInt64,
         /**
-         * The offset of the progress, in bytes.
-         */offset: UInt64) {
+            * The offset of the progress, in bytes.
+            */ offset: UInt64
+    ) {
         self.id = id
         self.offset = offset
     }
 }
 
-
-
 extension DownloadProgressProgress: Equatable, Hashable {
-    public static func ==(lhs: DownloadProgressProgress, rhs: DownloadProgressProgress) -> Bool {
+    public static func == (lhs: DownloadProgressProgress, rhs: DownloadProgressProgress) -> Bool {
         if lhs.id != rhs.id {
             return false
         }
@@ -10458,14 +9872,13 @@ extension DownloadProgressProgress: Equatable, Hashable {
     }
 }
 
-
 public struct FfiConverterTypeDownloadProgressProgress: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> DownloadProgressProgress {
         return
             try DownloadProgressProgress(
-                id: FfiConverterUInt64.read(from: &buf), 
+                id: FfiConverterUInt64.read(from: &buf),
                 offset: FfiConverterUInt64.read(from: &buf)
-        )
+            )
     }
 
     public static func write(_ value: DownloadProgressProgress, into buf: inout [UInt8]) {
@@ -10474,7 +9887,6 @@ public struct FfiConverterTypeDownloadProgressProgress: FfiConverterRustBuffer {
     }
 }
 
-
 public func FfiConverterTypeDownloadProgressProgress_lift(_ buf: RustBuffer) throws -> DownloadProgressProgress {
     return try FfiConverterTypeDownloadProgressProgress.lift(buf)
 }
@@ -10482,7 +9894,6 @@ public func FfiConverterTypeDownloadProgressProgress_lift(_ buf: RustBuffer) thr
 public func FfiConverterTypeDownloadProgressProgress_lower(_ value: DownloadProgressProgress) -> RustBuffer {
     return FfiConverterTypeDownloadProgressProgress.lower(value)
 }
-
 
 /**
  * The Hash and associated tag of a newly created collection
@@ -10502,24 +9913,23 @@ public struct HashAndTag {
     public init(
         /**
          * The hash of the collection
-         */hash: Hash, 
+         */ hash: Hash,
         /**
-         * The tag of the collection
-         */tag: Data) {
+            * The tag of the collection
+            */ tag: Data
+    ) {
         self.hash = hash
         self.tag = tag
     }
 }
 
-
-
 public struct FfiConverterTypeHashAndTag: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> HashAndTag {
         return
             try HashAndTag(
-                hash: FfiConverterTypeHash.read(from: &buf), 
+                hash: FfiConverterTypeHash.read(from: &buf),
                 tag: FfiConverterData.read(from: &buf)
-        )
+            )
     }
 
     public static func write(_ value: HashAndTag, into buf: inout [UInt8]) {
@@ -10528,7 +9938,6 @@ public struct FfiConverterTypeHashAndTag: FfiConverterRustBuffer {
     }
 }
 
-
 public func FfiConverterTypeHashAndTag_lift(_ buf: RustBuffer) throws -> HashAndTag {
     return try FfiConverterTypeHashAndTag.lift(buf)
 }
@@ -10536,7 +9945,6 @@ public func FfiConverterTypeHashAndTag_lift(_ buf: RustBuffer) throws -> HashAnd
 public func FfiConverterTypeHashAndTag_lower(_ value: HashAndTag) -> RustBuffer {
     return FfiConverterTypeHashAndTag.lower(value)
 }
-
 
 /**
  * A response to a list blobs request
@@ -10560,29 +9968,28 @@ public struct IncompleteBlobInfo {
     public init(
         /**
          * The size we got
-         */size: UInt64, 
+         */ size: UInt64,
         /**
-         * The size we expect
-         */expectedSize: UInt64, 
+            * The size we expect
+            */ expectedSize: UInt64,
         /**
-         * The hash of the blob
-         */hash: Hash) {
+            * The hash of the blob
+            */ hash: Hash
+    ) {
         self.size = size
         self.expectedSize = expectedSize
         self.hash = hash
     }
 }
 
-
-
 public struct FfiConverterTypeIncompleteBlobInfo: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> IncompleteBlobInfo {
         return
             try IncompleteBlobInfo(
-                size: FfiConverterUInt64.read(from: &buf), 
-                expectedSize: FfiConverterUInt64.read(from: &buf), 
+                size: FfiConverterUInt64.read(from: &buf),
+                expectedSize: FfiConverterUInt64.read(from: &buf),
                 hash: FfiConverterTypeHash.read(from: &buf)
-        )
+            )
     }
 
     public static func write(_ value: IncompleteBlobInfo, into buf: inout [UInt8]) {
@@ -10592,7 +9999,6 @@ public struct FfiConverterTypeIncompleteBlobInfo: FfiConverterRustBuffer {
     }
 }
 
-
 public func FfiConverterTypeIncompleteBlobInfo_lift(_ buf: RustBuffer) throws -> IncompleteBlobInfo {
     return try FfiConverterTypeIncompleteBlobInfo.lift(buf)
 }
@@ -10600,7 +10006,6 @@ public func FfiConverterTypeIncompleteBlobInfo_lift(_ buf: RustBuffer) throws ->
 public func FfiConverterTypeIncompleteBlobInfo_lower(_ value: IncompleteBlobInfo) -> RustBuffer {
     return FfiConverterTypeIncompleteBlobInfo.lower(value)
 }
-
 
 /**
  * Outcome of an InsertRemove event.
@@ -10624,29 +10029,28 @@ public struct InsertRemoteEvent {
     public init(
         /**
          * The peer that sent us the entry.
-         */from: PublicKey, 
+         */ from: PublicKey,
         /**
-         * The inserted entry.
-         */entry: Entry, 
+            * The inserted entry.
+            */ entry: Entry,
         /**
-         * If the content is available at the local node
-         */contentStatus: ContentStatus) {
+            * If the content is available at the local node
+            */ contentStatus: ContentStatus
+    ) {
         self.from = from
         self.entry = entry
         self.contentStatus = contentStatus
     }
 }
 
-
-
 public struct FfiConverterTypeInsertRemoteEvent: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> InsertRemoteEvent {
         return
             try InsertRemoteEvent(
-                from: FfiConverterTypePublicKey.read(from: &buf), 
-                entry: FfiConverterTypeEntry.read(from: &buf), 
+                from: FfiConverterTypePublicKey.read(from: &buf),
+                entry: FfiConverterTypeEntry.read(from: &buf),
                 contentStatus: FfiConverterTypeContentStatus.read(from: &buf)
-        )
+            )
     }
 
     public static func write(_ value: InsertRemoteEvent, into buf: inout [UInt8]) {
@@ -10656,7 +10060,6 @@ public struct FfiConverterTypeInsertRemoteEvent: FfiConverterRustBuffer {
     }
 }
 
-
 public func FfiConverterTypeInsertRemoteEvent_lift(_ buf: RustBuffer) throws -> InsertRemoteEvent {
     return try FfiConverterTypeInsertRemoteEvent.lift(buf)
 }
@@ -10664,7 +10067,6 @@ public func FfiConverterTypeInsertRemoteEvent_lift(_ buf: RustBuffer) throws -> 
 public func FfiConverterTypeInsertRemoteEvent_lower(_ value: InsertRemoteEvent) -> RustBuffer {
     return FfiConverterTypeInsertRemoteEvent.lower(value)
 }
-
 
 /**
  * The latency and type of the control message
@@ -10684,19 +10086,18 @@ public struct LatencyAndControlMsg {
     public init(
         /**
          * The latency of the control message
-         */latency: TimeInterval, 
+         */ latency: TimeInterval,
         /**
-         * The type of control message, represented as a string
-         */controlMsg: String) {
+            * The type of control message, represented as a string
+            */ controlMsg: String
+    ) {
         self.latency = latency
         self.controlMsg = controlMsg
     }
 }
 
-
-
 extension LatencyAndControlMsg: Equatable, Hashable {
-    public static func ==(lhs: LatencyAndControlMsg, rhs: LatencyAndControlMsg) -> Bool {
+    public static func == (lhs: LatencyAndControlMsg, rhs: LatencyAndControlMsg) -> Bool {
         if lhs.latency != rhs.latency {
             return false
         }
@@ -10712,14 +10113,13 @@ extension LatencyAndControlMsg: Equatable, Hashable {
     }
 }
 
-
 public struct FfiConverterTypeLatencyAndControlMsg: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> LatencyAndControlMsg {
         return
             try LatencyAndControlMsg(
-                latency: FfiConverterDuration.read(from: &buf), 
+                latency: FfiConverterDuration.read(from: &buf),
                 controlMsg: FfiConverterString.read(from: &buf)
-        )
+            )
     }
 
     public static func write(_ value: LatencyAndControlMsg, into buf: inout [UInt8]) {
@@ -10728,7 +10128,6 @@ public struct FfiConverterTypeLatencyAndControlMsg: FfiConverterRustBuffer {
     }
 }
 
-
 public func FfiConverterTypeLatencyAndControlMsg_lift(_ buf: RustBuffer) throws -> LatencyAndControlMsg {
     return try FfiConverterTypeLatencyAndControlMsg.lift(buf)
 }
@@ -10736,7 +10135,6 @@ public func FfiConverterTypeLatencyAndControlMsg_lift(_ buf: RustBuffer) throws 
 public func FfiConverterTypeLatencyAndControlMsg_lower(_ value: LatencyAndControlMsg) -> RustBuffer {
     return FfiConverterTypeLatencyAndControlMsg.lower(value)
 }
-
 
 /**
  * `LinkAndName` includes a name and a hash for a blob in a collection
@@ -10756,24 +10154,23 @@ public struct LinkAndName {
     public init(
         /**
          * The name associated with this [`Hash`]
-         */name: String, 
+         */ name: String,
         /**
-         * The [`Hash`] of the blob
-         */link: Hash) {
+            * The [`Hash`] of the blob
+            */ link: Hash
+    ) {
         self.name = name
         self.link = link
     }
 }
 
-
-
 public struct FfiConverterTypeLinkAndName: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> LinkAndName {
         return
             try LinkAndName(
-                name: FfiConverterString.read(from: &buf), 
+                name: FfiConverterString.read(from: &buf),
                 link: FfiConverterTypeHash.read(from: &buf)
-        )
+            )
     }
 
     public static func write(_ value: LinkAndName, into buf: inout [UInt8]) {
@@ -10782,7 +10179,6 @@ public struct FfiConverterTypeLinkAndName: FfiConverterRustBuffer {
     }
 }
 
-
 public func FfiConverterTypeLinkAndName_lift(_ buf: RustBuffer) throws -> LinkAndName {
     return try FfiConverterTypeLinkAndName.lift(buf)
 }
@@ -10790,7 +10186,6 @@ public func FfiConverterTypeLinkAndName_lift(_ buf: RustBuffer) throws -> LinkAn
 public func FfiConverterTypeLinkAndName_lower(_ value: LinkAndName) -> RustBuffer {
     return FfiConverterTypeLinkAndName.lower(value)
 }
-
 
 /**
  * The actual content of a gossip message.
@@ -10810,19 +10205,18 @@ public struct MessageContent {
     public init(
         /**
          * The content of the message
-         */content: Data, 
+         */ content: Data,
         /**
-         * The node that delivered the message. This is not the same as the original author.
-         */deliveredFrom: String) {
+            * The node that delivered the message. This is not the same as the original author.
+            */ deliveredFrom: String
+    ) {
         self.content = content
         self.deliveredFrom = deliveredFrom
     }
 }
 
-
-
 extension MessageContent: Equatable, Hashable {
-    public static func ==(lhs: MessageContent, rhs: MessageContent) -> Bool {
+    public static func == (lhs: MessageContent, rhs: MessageContent) -> Bool {
         if lhs.content != rhs.content {
             return false
         }
@@ -10838,14 +10232,13 @@ extension MessageContent: Equatable, Hashable {
     }
 }
 
-
 public struct FfiConverterTypeMessageContent: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> MessageContent {
         return
             try MessageContent(
-                content: FfiConverterData.read(from: &buf), 
+                content: FfiConverterData.read(from: &buf),
                 deliveredFrom: FfiConverterString.read(from: &buf)
-        )
+            )
     }
 
     public static func write(_ value: MessageContent, into buf: inout [UInt8]) {
@@ -10854,7 +10247,6 @@ public struct FfiConverterTypeMessageContent: FfiConverterRustBuffer {
     }
 }
 
-
 public func FfiConverterTypeMessageContent_lift(_ buf: RustBuffer) throws -> MessageContent {
     return try FfiConverterTypeMessageContent.lift(buf)
 }
@@ -10862,7 +10254,6 @@ public func FfiConverterTypeMessageContent_lift(_ buf: RustBuffer) throws -> Mes
 public func FfiConverterTypeMessageContent_lower(_ value: MessageContent) -> RustBuffer {
     return FfiConverterTypeMessageContent.lower(value)
 }
-
 
 /**
  * The namespace id and CapabilityKind (read/write) of the doc
@@ -10882,19 +10273,18 @@ public struct NamespaceAndCapability {
     public init(
         /**
          * The namespace id of the doc
-         */namespace: String, 
+         */ namespace: String,
         /**
-         * The capability you have for the doc (read/write)
-         */capability: CapabilityKind) {
+            * The capability you have for the doc (read/write)
+            */ capability: CapabilityKind
+    ) {
         self.namespace = namespace
         self.capability = capability
     }
 }
 
-
-
 extension NamespaceAndCapability: Equatable, Hashable {
-    public static func ==(lhs: NamespaceAndCapability, rhs: NamespaceAndCapability) -> Bool {
+    public static func == (lhs: NamespaceAndCapability, rhs: NamespaceAndCapability) -> Bool {
         if lhs.namespace != rhs.namespace {
             return false
         }
@@ -10910,14 +10300,13 @@ extension NamespaceAndCapability: Equatable, Hashable {
     }
 }
 
-
 public struct FfiConverterTypeNamespaceAndCapability: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> NamespaceAndCapability {
         return
             try NamespaceAndCapability(
-                namespace: FfiConverterString.read(from: &buf), 
+                namespace: FfiConverterString.read(from: &buf),
                 capability: FfiConverterTypeCapabilityKind.read(from: &buf)
-        )
+            )
     }
 
     public static func write(_ value: NamespaceAndCapability, into buf: inout [UInt8]) {
@@ -10926,7 +10315,6 @@ public struct FfiConverterTypeNamespaceAndCapability: FfiConverterRustBuffer {
     }
 }
 
-
 public func FfiConverterTypeNamespaceAndCapability_lift(_ buf: RustBuffer) throws -> NamespaceAndCapability {
     return try FfiConverterTypeNamespaceAndCapability.lift(buf)
 }
@@ -10934,7 +10322,6 @@ public func FfiConverterTypeNamespaceAndCapability_lift(_ buf: RustBuffer) throw
 public func FfiConverterTypeNamespaceAndCapability_lower(_ value: NamespaceAndCapability) -> RustBuffer {
     return FfiConverterTypeNamespaceAndCapability.lower(value)
 }
-
 
 /**
  * Options passed to [`IrohNode.new`]. Controls the behaviour of an iroh node.
@@ -10952,15 +10339,14 @@ public struct NodeOptions {
         /**
          * How frequently the blob store should clean up unreferenced blobs, in milliseconds.
          * Set to 0 to disable gc
-         */gcIntervalMillis: UInt64?) {
+         */ gcIntervalMillis: UInt64?
+    ) {
         self.gcIntervalMillis = gcIntervalMillis
     }
 }
 
-
-
 extension NodeOptions: Equatable, Hashable {
-    public static func ==(lhs: NodeOptions, rhs: NodeOptions) -> Bool {
+    public static func == (lhs: NodeOptions, rhs: NodeOptions) -> Bool {
         if lhs.gcIntervalMillis != rhs.gcIntervalMillis {
             return false
         }
@@ -10972,20 +10358,18 @@ extension NodeOptions: Equatable, Hashable {
     }
 }
 
-
 public struct FfiConverterTypeNodeOptions: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> NodeOptions {
         return
             try NodeOptions(
                 gcIntervalMillis: FfiConverterOptionUInt64.read(from: &buf)
-        )
+            )
     }
 
     public static func write(_ value: NodeOptions, into buf: inout [UInt8]) {
         FfiConverterOptionUInt64.write(value.gcIntervalMillis, into: &buf)
     }
 }
-
 
 public func FfiConverterTypeNodeOptions_lift(_ buf: RustBuffer) throws -> NodeOptions {
     return try FfiConverterTypeNodeOptions.lift(buf)
@@ -10994,7 +10378,6 @@ public func FfiConverterTypeNodeOptions_lift(_ buf: RustBuffer) throws -> NodeOp
 public func FfiConverterTypeNodeOptions_lower(_ value: NodeOptions) -> RustBuffer {
     return FfiConverterTypeNodeOptions.lower(value)
 }
-
 
 /**
  * The state for an open replica.
@@ -11018,23 +10401,22 @@ public struct OpenState {
     public init(
         /**
          * Whether to accept sync requests for this replica.
-         */sync: Bool, 
+         */ sync: Bool,
         /**
-         * How many event subscriptions are open
-         */subscribers: UInt64, 
+            * How many event subscriptions are open
+            */ subscribers: UInt64,
         /**
-         * By how many handles the replica is currently held open
-         */handles: UInt64) {
+            * By how many handles the replica is currently held open
+            */ handles: UInt64
+    ) {
         self.sync = sync
         self.subscribers = subscribers
         self.handles = handles
     }
 }
 
-
-
 extension OpenState: Equatable, Hashable {
-    public static func ==(lhs: OpenState, rhs: OpenState) -> Bool {
+    public static func == (lhs: OpenState, rhs: OpenState) -> Bool {
         if lhs.sync != rhs.sync {
             return false
         }
@@ -11054,15 +10436,14 @@ extension OpenState: Equatable, Hashable {
     }
 }
 
-
 public struct FfiConverterTypeOpenState: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> OpenState {
         return
             try OpenState(
-                sync: FfiConverterBool.read(from: &buf), 
-                subscribers: FfiConverterUInt64.read(from: &buf), 
+                sync: FfiConverterBool.read(from: &buf),
+                subscribers: FfiConverterUInt64.read(from: &buf),
                 handles: FfiConverterUInt64.read(from: &buf)
-        )
+            )
     }
 
     public static func write(_ value: OpenState, into buf: inout [UInt8]) {
@@ -11072,7 +10453,6 @@ public struct FfiConverterTypeOpenState: FfiConverterRustBuffer {
     }
 }
 
-
 public func FfiConverterTypeOpenState_lift(_ buf: RustBuffer) throws -> OpenState {
     return try FfiConverterTypeOpenState.lift(buf)
 }
@@ -11080,7 +10460,6 @@ public func FfiConverterTypeOpenState_lift(_ buf: RustBuffer) throws -> OpenStat
 public func FfiConverterTypeOpenState_lower(_ value: OpenState) -> RustBuffer {
     return FfiConverterTypeOpenState.lower(value)
 }
-
 
 /**
  * Options for sorting and pagination for using [`Query`]s.
@@ -11116,20 +10495,21 @@ public struct QueryOptions {
          * Sort by author or key first.
          *
          * Default is [`SortBy::AuthorKey`], so sorting first by author and then by key.
-         */sortBy: SortBy, 
+         */ sortBy: SortBy,
         /**
-         * Direction by which to sort the entries
-         *
-         * Default is [`SortDirection::Asc`]
-         */direction: SortDirection, 
+            * Direction by which to sort the entries
+            *
+            * Default is [`SortDirection::Asc`]
+            */ direction: SortDirection,
         /**
-         * Offset
-         */offset: UInt64, 
+            * Offset
+            */ offset: UInt64,
         /**
-         * Limit to limit the pagination.
-         *
-         * When the limit is 0, the limit does not exist.
-         */limit: UInt64) {
+            * Limit to limit the pagination.
+            *
+            * When the limit is 0, the limit does not exist.
+            */ limit: UInt64
+    ) {
         self.sortBy = sortBy
         self.direction = direction
         self.offset = offset
@@ -11137,10 +10517,8 @@ public struct QueryOptions {
     }
 }
 
-
-
 extension QueryOptions: Equatable, Hashable {
-    public static func ==(lhs: QueryOptions, rhs: QueryOptions) -> Bool {
+    public static func == (lhs: QueryOptions, rhs: QueryOptions) -> Bool {
         if lhs.sortBy != rhs.sortBy {
             return false
         }
@@ -11164,16 +10542,15 @@ extension QueryOptions: Equatable, Hashable {
     }
 }
 
-
 public struct FfiConverterTypeQueryOptions: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> QueryOptions {
         return
             try QueryOptions(
-                sortBy: FfiConverterTypeSortBy.read(from: &buf), 
-                direction: FfiConverterTypeSortDirection.read(from: &buf), 
-                offset: FfiConverterUInt64.read(from: &buf), 
+                sortBy: FfiConverterTypeSortBy.read(from: &buf),
+                direction: FfiConverterTypeSortDirection.read(from: &buf),
+                offset: FfiConverterUInt64.read(from: &buf),
                 limit: FfiConverterUInt64.read(from: &buf)
-        )
+            )
     }
 
     public static func write(_ value: QueryOptions, into buf: inout [UInt8]) {
@@ -11184,7 +10561,6 @@ public struct FfiConverterTypeQueryOptions: FfiConverterRustBuffer {
     }
 }
 
-
 public func FfiConverterTypeQueryOptions_lift(_ buf: RustBuffer) throws -> QueryOptions {
     return try FfiConverterTypeQueryOptions.lift(buf)
 }
@@ -11192,7 +10568,6 @@ public func FfiConverterTypeQueryOptions_lift(_ buf: RustBuffer) throws -> Query
 public func FfiConverterTypeQueryOptions_lower(_ value: QueryOptions) -> RustBuffer {
     return FfiConverterTypeQueryOptions.lower(value)
 }
-
 
 /**
  * Outcome of a sync operation
@@ -11224,19 +10599,20 @@ public struct SyncEvent {
     public init(
         /**
          * Peer we synced with
-         */peer: PublicKey, 
+         */ peer: PublicKey,
         /**
-         * Origin of the sync exchange
-         */origin: Origin, 
+            * Origin of the sync exchange
+            */ origin: Origin,
         /**
-         * Timestamp when the sync finished
-         */finished: Date, 
+            * Timestamp when the sync finished
+            */ finished: Date,
         /**
-         * Timestamp when the sync started
-         */started: Date, 
+            * Timestamp when the sync started
+            */ started: Date,
         /**
-         * Result of the sync operation. `None` if successfull.
-         */result: String?) {
+            * Result of the sync operation. `None` if successfull.
+            */ result: String?
+    ) {
         self.peer = peer
         self.origin = origin
         self.finished = finished
@@ -11245,18 +10621,16 @@ public struct SyncEvent {
     }
 }
 
-
-
 public struct FfiConverterTypeSyncEvent: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SyncEvent {
         return
             try SyncEvent(
-                peer: FfiConverterTypePublicKey.read(from: &buf), 
-                origin: FfiConverterTypeOrigin.read(from: &buf), 
-                finished: FfiConverterTimestamp.read(from: &buf), 
-                started: FfiConverterTimestamp.read(from: &buf), 
+                peer: FfiConverterTypePublicKey.read(from: &buf),
+                origin: FfiConverterTypeOrigin.read(from: &buf),
+                finished: FfiConverterTimestamp.read(from: &buf),
+                started: FfiConverterTimestamp.read(from: &buf),
                 result: FfiConverterOptionString.read(from: &buf)
-        )
+            )
     }
 
     public static func write(_ value: SyncEvent, into buf: inout [UInt8]) {
@@ -11268,7 +10642,6 @@ public struct FfiConverterTypeSyncEvent: FfiConverterRustBuffer {
     }
 }
 
-
 public func FfiConverterTypeSyncEvent_lift(_ buf: RustBuffer) throws -> SyncEvent {
     return try FfiConverterTypeSyncEvent.lift(buf)
 }
@@ -11276,7 +10649,6 @@ public func FfiConverterTypeSyncEvent_lift(_ buf: RustBuffer) throws -> SyncEven
 public func FfiConverterTypeSyncEvent_lower(_ value: SyncEvent) -> RustBuffer {
     return FfiConverterTypeSyncEvent.lower(value)
 }
-
 
 /**
  * A response to a list collections request
@@ -11300,29 +10672,28 @@ public struct TagInfo {
     public init(
         /**
          * The tag
-         */name: Data, 
+         */ name: Data,
         /**
-         * The format of the associated blob
-         */format: BlobFormat, 
+            * The format of the associated blob
+            */ format: BlobFormat,
         /**
-         * The hash of the associated blob
-         */hash: Hash) {
+            * The hash of the associated blob
+            */ hash: Hash
+    ) {
         self.name = name
         self.format = format
         self.hash = hash
     }
 }
 
-
-
 public struct FfiConverterTypeTagInfo: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> TagInfo {
         return
             try TagInfo(
-                name: FfiConverterData.read(from: &buf), 
-                format: FfiConverterTypeBlobFormat.read(from: &buf), 
+                name: FfiConverterData.read(from: &buf),
+                format: FfiConverterTypeBlobFormat.read(from: &buf),
                 hash: FfiConverterTypeHash.read(from: &buf)
-        )
+            )
     }
 
     public static func write(_ value: TagInfo, into buf: inout [UInt8]) {
@@ -11331,7 +10702,6 @@ public struct FfiConverterTypeTagInfo: FfiConverterRustBuffer {
         FfiConverterTypeHash.write(value.hash, into: &buf)
     }
 }
-
 
 public func FfiConverterTypeTagInfo_lift(_ buf: RustBuffer) throws -> TagInfo {
     return try FfiConverterTypeTagInfo.lift(buf)
@@ -11348,7 +10718,6 @@ public func FfiConverterTypeTagInfo_lower(_ value: TagInfo) -> RustBuffer {
  */
 
 public enum AddProgressType {
-    
     /**
      * An item was found with name `name`, from now on referred to via `id`
      */
@@ -11373,55 +10742,45 @@ public enum AddProgressType {
     case abort
 }
 
-
 public struct FfiConverterTypeAddProgressType: FfiConverterRustBuffer {
     typealias SwiftType = AddProgressType
 
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> AddProgressType {
         let variant: Int32 = try readInt(&buf)
         switch variant {
-        
         case 1: return .found
-        
+
         case 2: return .progress
-        
+
         case 3: return .done
-        
+
         case 4: return .allDone
-        
+
         case 5: return .abort
-        
+
         default: throw UniffiInternalError.unexpectedEnumCase
         }
     }
 
     public static func write(_ value: AddProgressType, into buf: inout [UInt8]) {
         switch value {
-        
-        
         case .found:
             writeInt(&buf, Int32(1))
-        
-        
+
         case .progress:
             writeInt(&buf, Int32(2))
-        
-        
+
         case .done:
             writeInt(&buf, Int32(3))
-        
-        
+
         case .allDone:
             writeInt(&buf, Int32(4))
-        
-        
+
         case .abort:
             writeInt(&buf, Int32(5))
-        
         }
     }
 }
-
 
 public func FfiConverterTypeAddProgressType_lift(_ buf: RustBuffer) throws -> AddProgressType {
     return try FfiConverterTypeAddProgressType.lift(buf)
@@ -11431,11 +10790,7 @@ public func FfiConverterTypeAddProgressType_lower(_ value: AddProgressType) -> R
     return FfiConverterTypeAddProgressType.lower(value)
 }
 
-
-
 extension AddProgressType: Equatable, Hashable {}
-
-
 
 // Note that we don't yet support `indirect` for enums.
 // See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
@@ -11444,7 +10799,6 @@ extension AddProgressType: Equatable, Hashable {}
  */
 
 public enum AddrInfoOptions {
-    
     /**
      * Only the Node ID is added.
      *
@@ -11465,49 +10819,40 @@ public enum AddrInfoOptions {
     case addresses
 }
 
-
 public struct FfiConverterTypeAddrInfoOptions: FfiConverterRustBuffer {
     typealias SwiftType = AddrInfoOptions
 
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> AddrInfoOptions {
         let variant: Int32 = try readInt(&buf)
         switch variant {
-        
         case 1: return .id
-        
+
         case 2: return .relayAndAddresses
-        
+
         case 3: return .relay
-        
+
         case 4: return .addresses
-        
+
         default: throw UniffiInternalError.unexpectedEnumCase
         }
     }
 
     public static func write(_ value: AddrInfoOptions, into buf: inout [UInt8]) {
         switch value {
-        
-        
         case .id:
             writeInt(&buf, Int32(1))
-        
-        
+
         case .relayAndAddresses:
             writeInt(&buf, Int32(2))
-        
-        
+
         case .relay:
             writeInt(&buf, Int32(3))
-        
-        
+
         case .addresses:
             writeInt(&buf, Int32(4))
-        
         }
     }
 }
-
 
 public func FfiConverterTypeAddrInfoOptions_lift(_ buf: RustBuffer) throws -> AddrInfoOptions {
     return try FfiConverterTypeAddrInfoOptions.lift(buf)
@@ -11517,11 +10862,7 @@ public func FfiConverterTypeAddrInfoOptions_lower(_ value: AddrInfoOptions) -> R
     return FfiConverterTypeAddrInfoOptions.lower(value)
 }
 
-
-
 extension AddrInfoOptions: Equatable, Hashable {}
-
-
 
 // Note that we don't yet support `indirect` for enums.
 // See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
@@ -11530,7 +10871,6 @@ extension AddrInfoOptions: Equatable, Hashable {}
  */
 
 public enum BlobExportFormat {
-    
     /**
      * The hash refers to any blob and will be exported to a single file.
      */
@@ -11549,37 +10889,30 @@ public enum BlobExportFormat {
     case collection
 }
 
-
 public struct FfiConverterTypeBlobExportFormat: FfiConverterRustBuffer {
     typealias SwiftType = BlobExportFormat
 
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> BlobExportFormat {
         let variant: Int32 = try readInt(&buf)
         switch variant {
-        
         case 1: return .blob
-        
+
         case 2: return .collection
-        
+
         default: throw UniffiInternalError.unexpectedEnumCase
         }
     }
 
     public static func write(_ value: BlobExportFormat, into buf: inout [UInt8]) {
         switch value {
-        
-        
         case .blob:
             writeInt(&buf, Int32(1))
-        
-        
+
         case .collection:
             writeInt(&buf, Int32(2))
-        
         }
     }
 }
-
 
 public func FfiConverterTypeBlobExportFormat_lift(_ buf: RustBuffer) throws -> BlobExportFormat {
     return try FfiConverterTypeBlobExportFormat.lift(buf)
@@ -11589,11 +10922,7 @@ public func FfiConverterTypeBlobExportFormat_lower(_ value: BlobExportFormat) ->
     return FfiConverterTypeBlobExportFormat.lower(value)
 }
 
-
-
 extension BlobExportFormat: Equatable, Hashable {}
-
-
 
 // Note that we don't yet support `indirect` for enums.
 // See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
@@ -11607,7 +10936,6 @@ extension BlobExportFormat: Equatable, Hashable {}
  */
 
 public enum BlobExportMode {
-    
     /**
      * This mode will copy the file to the target directory.
      *
@@ -11628,37 +10956,30 @@ public enum BlobExportMode {
     case tryReference
 }
 
-
 public struct FfiConverterTypeBlobExportMode: FfiConverterRustBuffer {
     typealias SwiftType = BlobExportMode
 
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> BlobExportMode {
         let variant: Int32 = try readInt(&buf)
         switch variant {
-        
         case 1: return .copy
-        
+
         case 2: return .tryReference
-        
+
         default: throw UniffiInternalError.unexpectedEnumCase
         }
     }
 
     public static func write(_ value: BlobExportMode, into buf: inout [UInt8]) {
         switch value {
-        
-        
         case .copy:
             writeInt(&buf, Int32(1))
-        
-        
+
         case .tryReference:
             writeInt(&buf, Int32(2))
-        
         }
     }
 }
-
 
 public func FfiConverterTypeBlobExportMode_lift(_ buf: RustBuffer) throws -> BlobExportMode {
     return try FfiConverterTypeBlobExportMode.lift(buf)
@@ -11668,11 +10989,7 @@ public func FfiConverterTypeBlobExportMode_lower(_ value: BlobExportMode) -> Rus
     return FfiConverterTypeBlobExportMode.lower(value)
 }
 
-
-
 extension BlobExportMode: Equatable, Hashable {}
-
-
 
 // Note that we don't yet support `indirect` for enums.
 // See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
@@ -11681,7 +10998,6 @@ extension BlobExportMode: Equatable, Hashable {}
  */
 
 public enum BlobFormat {
-    
     /**
      * Raw blob
      */
@@ -11692,37 +11008,30 @@ public enum BlobFormat {
     case hashSeq
 }
 
-
 public struct FfiConverterTypeBlobFormat: FfiConverterRustBuffer {
     typealias SwiftType = BlobFormat
 
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> BlobFormat {
         let variant: Int32 = try readInt(&buf)
         switch variant {
-        
         case 1: return .raw
-        
+
         case 2: return .hashSeq
-        
+
         default: throw UniffiInternalError.unexpectedEnumCase
         }
     }
 
     public static func write(_ value: BlobFormat, into buf: inout [UInt8]) {
         switch value {
-        
-        
         case .raw:
             writeInt(&buf, Int32(1))
-        
-        
+
         case .hashSeq:
             writeInt(&buf, Int32(2))
-        
         }
     }
 }
-
 
 public func FfiConverterTypeBlobFormat_lift(_ buf: RustBuffer) throws -> BlobFormat {
     return try FfiConverterTypeBlobFormat.lift(buf)
@@ -11732,20 +11041,11 @@ public func FfiConverterTypeBlobFormat_lower(_ value: BlobFormat) -> RustBuffer 
     return FfiConverterTypeBlobFormat.lower(value)
 }
 
-
-
 extension BlobFormat: Equatable, Hashable {}
 
-
-
-
 public enum CallbackError {
-
-    
-    
     case Error
 }
-
 
 public struct FfiConverterTypeCallbackError: FfiConverterRustBuffer {
     typealias SwiftType = CallbackError
@@ -11753,30 +11053,19 @@ public struct FfiConverterTypeCallbackError: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> CallbackError {
         let variant: Int32 = try readInt(&buf)
         switch variant {
-
-        
-
-        
         case 1: return .Error
 
-         default: throw UniffiInternalError.unexpectedEnumCase
+        default: throw UniffiInternalError.unexpectedEnumCase
         }
     }
 
     public static func write(_ value: CallbackError, into buf: inout [UInt8]) {
         switch value {
-
-        
-
-        
-        
         case .Error:
             writeInt(&buf, Int32(1))
-        
         }
     }
 }
-
 
 extension CallbackError: Equatable, Hashable {}
 
@@ -11790,7 +11079,6 @@ extension CallbackError: Foundation.LocalizedError {
 // See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
 
 public enum CapabilityKind {
-    
     /**
      * A writable replica.
      */
@@ -11801,37 +11089,30 @@ public enum CapabilityKind {
     case read
 }
 
-
 public struct FfiConverterTypeCapabilityKind: FfiConverterRustBuffer {
     typealias SwiftType = CapabilityKind
 
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> CapabilityKind {
         let variant: Int32 = try readInt(&buf)
         switch variant {
-        
         case 1: return .write
-        
+
         case 2: return .read
-        
+
         default: throw UniffiInternalError.unexpectedEnumCase
         }
     }
 
     public static func write(_ value: CapabilityKind, into buf: inout [UInt8]) {
         switch value {
-        
-        
         case .write:
             writeInt(&buf, Int32(1))
-        
-        
+
         case .read:
             writeInt(&buf, Int32(2))
-        
         }
     }
 }
-
 
 public func FfiConverterTypeCapabilityKind_lift(_ buf: RustBuffer) throws -> CapabilityKind {
     return try FfiConverterTypeCapabilityKind.lift(buf)
@@ -11841,11 +11122,7 @@ public func FfiConverterTypeCapabilityKind_lower(_ value: CapabilityKind) -> Rus
     return FfiConverterTypeCapabilityKind.lower(value)
 }
 
-
-
 extension CapabilityKind: Equatable, Hashable {}
-
-
 
 // Note that we don't yet support `indirect` for enums.
 // See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
@@ -11854,7 +11131,6 @@ extension CapabilityKind: Equatable, Hashable {}
  */
 
 public enum ConnType {
-    
     /**
      * Indicates you have a UDP connection.
      */
@@ -11873,49 +11149,40 @@ public enum ConnType {
     case none
 }
 
-
 public struct FfiConverterTypeConnType: FfiConverterRustBuffer {
     typealias SwiftType = ConnType
 
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> ConnType {
         let variant: Int32 = try readInt(&buf)
         switch variant {
-        
         case 1: return .direct
-        
+
         case 2: return .relay
-        
+
         case 3: return .mixed
-        
+
         case 4: return .none
-        
+
         default: throw UniffiInternalError.unexpectedEnumCase
         }
     }
 
     public static func write(_ value: ConnType, into buf: inout [UInt8]) {
         switch value {
-        
-        
         case .direct:
             writeInt(&buf, Int32(1))
-        
-        
+
         case .relay:
             writeInt(&buf, Int32(2))
-        
-        
+
         case .mixed:
             writeInt(&buf, Int32(3))
-        
-        
+
         case .none:
             writeInt(&buf, Int32(4))
-        
         }
     }
 }
-
 
 public func FfiConverterTypeConnType_lift(_ buf: RustBuffer) throws -> ConnType {
     return try FfiConverterTypeConnType.lift(buf)
@@ -11925,11 +11192,7 @@ public func FfiConverterTypeConnType_lower(_ value: ConnType) -> RustBuffer {
     return FfiConverterTypeConnType.lower(value)
 }
 
-
-
 extension ConnType: Equatable, Hashable {}
-
-
 
 // Note that we don't yet support `indirect` for enums.
 // See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
@@ -11938,7 +11201,6 @@ extension ConnType: Equatable, Hashable {}
  */
 
 public enum ContentStatus {
-    
     /**
      * The content is completely available.
      */
@@ -11953,43 +11215,35 @@ public enum ContentStatus {
     case missing
 }
 
-
 public struct FfiConverterTypeContentStatus: FfiConverterRustBuffer {
     typealias SwiftType = ContentStatus
 
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> ContentStatus {
         let variant: Int32 = try readInt(&buf)
         switch variant {
-        
         case 1: return .complete
-        
+
         case 2: return .incomplete
-        
+
         case 3: return .missing
-        
+
         default: throw UniffiInternalError.unexpectedEnumCase
         }
     }
 
     public static func write(_ value: ContentStatus, into buf: inout [UInt8]) {
         switch value {
-        
-        
         case .complete:
             writeInt(&buf, Int32(1))
-        
-        
+
         case .incomplete:
             writeInt(&buf, Int32(2))
-        
-        
+
         case .missing:
             writeInt(&buf, Int32(3))
-        
         }
     }
 }
-
 
 public func FfiConverterTypeContentStatus_lift(_ buf: RustBuffer) throws -> ContentStatus {
     return try FfiConverterTypeContentStatus.lift(buf)
@@ -11999,11 +11253,7 @@ public func FfiConverterTypeContentStatus_lower(_ value: ContentStatus) -> RustB
     return FfiConverterTypeContentStatus.lower(value)
 }
 
-
-
 extension ContentStatus: Equatable, Hashable {}
-
-
 
 // Note that we don't yet support `indirect` for enums.
 // See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
@@ -12012,7 +11262,6 @@ extension ContentStatus: Equatable, Hashable {}
  */
 
 public enum DocExportProgressType {
-    
     /**
      * An item was found with name `name`, from now on referred to via `id`
      */
@@ -12037,55 +11286,45 @@ public enum DocExportProgressType {
     case abort
 }
 
-
 public struct FfiConverterTypeDocExportProgressType: FfiConverterRustBuffer {
     typealias SwiftType = DocExportProgressType
 
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> DocExportProgressType {
         let variant: Int32 = try readInt(&buf)
         switch variant {
-        
         case 1: return .found
-        
+
         case 2: return .progress
-        
+
         case 3: return .done
-        
+
         case 4: return .allDone
-        
+
         case 5: return .abort
-        
+
         default: throw UniffiInternalError.unexpectedEnumCase
         }
     }
 
     public static func write(_ value: DocExportProgressType, into buf: inout [UInt8]) {
         switch value {
-        
-        
         case .found:
             writeInt(&buf, Int32(1))
-        
-        
+
         case .progress:
             writeInt(&buf, Int32(2))
-        
-        
+
         case .done:
             writeInt(&buf, Int32(3))
-        
-        
+
         case .allDone:
             writeInt(&buf, Int32(4))
-        
-        
+
         case .abort:
             writeInt(&buf, Int32(5))
-        
         }
     }
 }
-
 
 public func FfiConverterTypeDocExportProgressType_lift(_ buf: RustBuffer) throws -> DocExportProgressType {
     return try FfiConverterTypeDocExportProgressType.lift(buf)
@@ -12095,11 +11334,7 @@ public func FfiConverterTypeDocExportProgressType_lower(_ value: DocExportProgre
     return FfiConverterTypeDocExportProgressType.lower(value)
 }
 
-
-
 extension DocExportProgressType: Equatable, Hashable {}
-
-
 
 // Note that we don't yet support `indirect` for enums.
 // See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
@@ -12108,7 +11343,6 @@ extension DocExportProgressType: Equatable, Hashable {}
  */
 
 public enum DocImportProgressType {
-    
     /**
      * An item was found with name `name`, from now on referred to via `id`
      */
@@ -12133,55 +11367,45 @@ public enum DocImportProgressType {
     case abort
 }
 
-
 public struct FfiConverterTypeDocImportProgressType: FfiConverterRustBuffer {
     typealias SwiftType = DocImportProgressType
 
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> DocImportProgressType {
         let variant: Int32 = try readInt(&buf)
         switch variant {
-        
         case 1: return .found
-        
+
         case 2: return .progress
-        
+
         case 3: return .ingestDone
-        
+
         case 4: return .allDone
-        
+
         case 5: return .abort
-        
+
         default: throw UniffiInternalError.unexpectedEnumCase
         }
     }
 
     public static func write(_ value: DocImportProgressType, into buf: inout [UInt8]) {
         switch value {
-        
-        
         case .found:
             writeInt(&buf, Int32(1))
-        
-        
+
         case .progress:
             writeInt(&buf, Int32(2))
-        
-        
+
         case .ingestDone:
             writeInt(&buf, Int32(3))
-        
-        
+
         case .allDone:
             writeInt(&buf, Int32(4))
-        
-        
+
         case .abort:
             writeInt(&buf, Int32(5))
-        
         }
     }
 }
-
 
 public func FfiConverterTypeDocImportProgressType_lift(_ buf: RustBuffer) throws -> DocImportProgressType {
     return try FfiConverterTypeDocImportProgressType.lift(buf)
@@ -12191,11 +11415,7 @@ public func FfiConverterTypeDocImportProgressType_lower(_ value: DocImportProgre
     return FfiConverterTypeDocImportProgressType.lower(value)
 }
 
-
-
 extension DocImportProgressType: Equatable, Hashable {}
-
-
 
 // Note that we don't yet support `indirect` for enums.
 // See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
@@ -12204,7 +11424,6 @@ extension DocImportProgressType: Equatable, Hashable {}
  */
 
 public enum DownloadProgressType {
-    
     case initialState
     case foundLocal
     case connected
@@ -12216,79 +11435,65 @@ public enum DownloadProgressType {
     case abort
 }
 
-
 public struct FfiConverterTypeDownloadProgressType: FfiConverterRustBuffer {
     typealias SwiftType = DownloadProgressType
 
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> DownloadProgressType {
         let variant: Int32 = try readInt(&buf)
         switch variant {
-        
         case 1: return .initialState
-        
+
         case 2: return .foundLocal
-        
+
         case 3: return .connected
-        
+
         case 4: return .found
-        
+
         case 5: return .foundHashSeq
-        
+
         case 6: return .progress
-        
+
         case 7: return .done
-        
+
         case 8: return .allDone
-        
+
         case 9: return .abort
-        
+
         default: throw UniffiInternalError.unexpectedEnumCase
         }
     }
 
     public static func write(_ value: DownloadProgressType, into buf: inout [UInt8]) {
         switch value {
-        
-        
         case .initialState:
             writeInt(&buf, Int32(1))
-        
-        
+
         case .foundLocal:
             writeInt(&buf, Int32(2))
-        
-        
+
         case .connected:
             writeInt(&buf, Int32(3))
-        
-        
+
         case .found:
             writeInt(&buf, Int32(4))
-        
-        
+
         case .foundHashSeq:
             writeInt(&buf, Int32(5))
-        
-        
+
         case .progress:
             writeInt(&buf, Int32(6))
-        
-        
+
         case .done:
             writeInt(&buf, Int32(7))
-        
-        
+
         case .allDone:
             writeInt(&buf, Int32(8))
-        
-        
+
         case .abort:
             writeInt(&buf, Int32(9))
-        
         }
     }
 }
-
 
 public func FfiConverterTypeDownloadProgressType_lift(_ buf: RustBuffer) throws -> DownloadProgressType {
     return try FfiConverterTypeDownloadProgressType.lift(buf)
@@ -12298,11 +11503,7 @@ public func FfiConverterTypeDownloadProgressType_lower(_ value: DownloadProgress
     return FfiConverterTypeDownloadProgressType.lower(value)
 }
 
-
-
 extension DownloadProgressType: Equatable, Hashable {}
-
-
 
 // Note that we don't yet support `indirect` for enums.
 // See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
@@ -12311,7 +11512,6 @@ extension DownloadProgressType: Equatable, Hashable {}
  */
 
 public enum LiveEventType {
-    
     /**
      * A local insertion.
      */
@@ -12350,67 +11550,55 @@ public enum LiveEventType {
     case pendingContentReady
 }
 
-
 public struct FfiConverterTypeLiveEventType: FfiConverterRustBuffer {
     typealias SwiftType = LiveEventType
 
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> LiveEventType {
         let variant: Int32 = try readInt(&buf)
         switch variant {
-        
         case 1: return .insertLocal
-        
+
         case 2: return .insertRemote
-        
+
         case 3: return .contentReady
-        
+
         case 4: return .neighborUp
-        
+
         case 5: return .neighborDown
-        
+
         case 6: return .syncFinished
-        
+
         case 7: return .pendingContentReady
-        
+
         default: throw UniffiInternalError.unexpectedEnumCase
         }
     }
 
     public static func write(_ value: LiveEventType, into buf: inout [UInt8]) {
         switch value {
-        
-        
         case .insertLocal:
             writeInt(&buf, Int32(1))
-        
-        
+
         case .insertRemote:
             writeInt(&buf, Int32(2))
-        
-        
+
         case .contentReady:
             writeInt(&buf, Int32(3))
-        
-        
+
         case .neighborUp:
             writeInt(&buf, Int32(4))
-        
-        
+
         case .neighborDown:
             writeInt(&buf, Int32(5))
-        
-        
+
         case .syncFinished:
             writeInt(&buf, Int32(6))
-        
-        
+
         case .pendingContentReady:
             writeInt(&buf, Int32(7))
-        
         }
     }
 }
-
 
 public func FfiConverterTypeLiveEventType_lift(_ buf: RustBuffer) throws -> LiveEventType {
     return try FfiConverterTypeLiveEventType.lift(buf)
@@ -12420,11 +11608,7 @@ public func FfiConverterTypeLiveEventType_lower(_ value: LiveEventType) -> RustB
     return FfiConverterTypeLiveEventType.lower(value)
 }
 
-
-
 extension LiveEventType: Equatable, Hashable {}
-
-
 
 // Note that we don't yet support `indirect` for enums.
 // See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
@@ -12433,7 +11617,6 @@ extension LiveEventType: Equatable, Hashable {}
  */
 
 public enum LogLevel {
-    
     case trace
     case debug
     case info
@@ -12442,61 +11625,50 @@ public enum LogLevel {
     case off
 }
 
-
 public struct FfiConverterTypeLogLevel: FfiConverterRustBuffer {
     typealias SwiftType = LogLevel
 
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> LogLevel {
         let variant: Int32 = try readInt(&buf)
         switch variant {
-        
         case 1: return .trace
-        
+
         case 2: return .debug
-        
+
         case 3: return .info
-        
+
         case 4: return .warn
-        
+
         case 5: return .error
-        
+
         case 6: return .off
-        
+
         default: throw UniffiInternalError.unexpectedEnumCase
         }
     }
 
     public static func write(_ value: LogLevel, into buf: inout [UInt8]) {
         switch value {
-        
-        
         case .trace:
             writeInt(&buf, Int32(1))
-        
-        
+
         case .debug:
             writeInt(&buf, Int32(2))
-        
-        
+
         case .info:
             writeInt(&buf, Int32(3))
-        
-        
+
         case .warn:
             writeInt(&buf, Int32(4))
-        
-        
+
         case .error:
             writeInt(&buf, Int32(5))
-        
-        
+
         case .off:
             writeInt(&buf, Int32(6))
-        
         }
     }
 }
-
 
 public func FfiConverterTypeLogLevel_lift(_ buf: RustBuffer) throws -> LogLevel {
     return try FfiConverterTypeLogLevel.lift(buf)
@@ -12506,17 +11678,12 @@ public func FfiConverterTypeLogLevel_lower(_ value: LogLevel) -> RustBuffer {
     return FfiConverterTypeLogLevel.lower(value)
 }
 
-
-
 extension LogLevel: Equatable, Hashable {}
-
-
 
 // Note that we don't yet support `indirect` for enums.
 // See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
 
 public enum MessageType {
-    
     case neighborUp
     case neighborDown
     case received
@@ -12525,61 +11692,50 @@ public enum MessageType {
     case error
 }
 
-
 public struct FfiConverterTypeMessageType: FfiConverterRustBuffer {
     typealias SwiftType = MessageType
 
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> MessageType {
         let variant: Int32 = try readInt(&buf)
         switch variant {
-        
         case 1: return .neighborUp
-        
+
         case 2: return .neighborDown
-        
+
         case 3: return .received
-        
+
         case 4: return .joined
-        
+
         case 5: return .lagged
-        
+
         case 6: return .error
-        
+
         default: throw UniffiInternalError.unexpectedEnumCase
         }
     }
 
     public static func write(_ value: MessageType, into buf: inout [UInt8]) {
         switch value {
-        
-        
         case .neighborUp:
             writeInt(&buf, Int32(1))
-        
-        
+
         case .neighborDown:
             writeInt(&buf, Int32(2))
-        
-        
+
         case .received:
             writeInt(&buf, Int32(3))
-        
-        
+
         case .joined:
             writeInt(&buf, Int32(4))
-        
-        
+
         case .lagged:
             writeInt(&buf, Int32(5))
-        
-        
+
         case .error:
             writeInt(&buf, Int32(6))
-        
         }
     }
 }
-
 
 public func FfiConverterTypeMessageType_lift(_ buf: RustBuffer) throws -> MessageType {
     return try FfiConverterTypeMessageType.lift(buf)
@@ -12589,11 +11745,7 @@ public func FfiConverterTypeMessageType_lower(_ value: MessageType) -> RustBuffe
     return FfiConverterTypeMessageType.lower(value)
 }
 
-
-
 extension MessageType: Equatable, Hashable {}
-
-
 
 // Note that we don't yet support `indirect` for enums.
 // See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
@@ -12602,7 +11754,6 @@ extension MessageType: Equatable, Hashable {}
  */
 
 public enum Origin {
-    
     /**
      * public, use a unit variant
      */
@@ -12614,39 +11765,32 @@ public enum Origin {
     case accept
 }
 
-
 public struct FfiConverterTypeOrigin: FfiConverterRustBuffer {
     typealias SwiftType = Origin
 
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> Origin {
         let variant: Int32 = try readInt(&buf)
         switch variant {
-        
-        case 1: return .connect(reason: try FfiConverterTypeSyncReason.read(from: &buf)
-        )
-        
+        case 1: return try .connect(reason: FfiConverterTypeSyncReason.read(from: &buf)
+            )
+
         case 2: return .accept
-        
+
         default: throw UniffiInternalError.unexpectedEnumCase
         }
     }
 
     public static func write(_ value: Origin, into buf: inout [UInt8]) {
         switch value {
-        
-        
         case let .connect(reason):
             writeInt(&buf, Int32(1))
             FfiConverterTypeSyncReason.write(reason, into: &buf)
-            
-        
+
         case .accept:
             writeInt(&buf, Int32(2))
-        
         }
     }
 }
-
 
 public func FfiConverterTypeOrigin_lift(_ buf: RustBuffer) throws -> Origin {
     return try FfiConverterTypeOrigin.lift(buf)
@@ -12656,11 +11800,7 @@ public func FfiConverterTypeOrigin_lower(_ value: Origin) -> RustBuffer {
     return FfiConverterTypeOrigin.lower(value)
 }
 
-
-
 extension Origin: Equatable, Hashable {}
-
-
 
 // Note that we don't yet support `indirect` for enums.
 // See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
@@ -12669,7 +11809,6 @@ extension Origin: Equatable, Hashable {}
  */
 
 public enum ShareMode {
-    
     /**
      * Read-only access
      */
@@ -12680,37 +11819,30 @@ public enum ShareMode {
     case write
 }
 
-
 public struct FfiConverterTypeShareMode: FfiConverterRustBuffer {
     typealias SwiftType = ShareMode
 
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> ShareMode {
         let variant: Int32 = try readInt(&buf)
         switch variant {
-        
         case 1: return .read
-        
+
         case 2: return .write
-        
+
         default: throw UniffiInternalError.unexpectedEnumCase
         }
     }
 
     public static func write(_ value: ShareMode, into buf: inout [UInt8]) {
         switch value {
-        
-        
         case .read:
             writeInt(&buf, Int32(1))
-        
-        
+
         case .write:
             writeInt(&buf, Int32(2))
-        
         }
     }
 }
-
 
 public func FfiConverterTypeShareMode_lift(_ buf: RustBuffer) throws -> ShareMode {
     return try FfiConverterTypeShareMode.lift(buf)
@@ -12720,11 +11852,7 @@ public func FfiConverterTypeShareMode_lower(_ value: ShareMode) -> RustBuffer {
     return FfiConverterTypeShareMode.lower(value)
 }
 
-
-
 extension ShareMode: Equatable, Hashable {}
-
-
 
 // Note that we don't yet support `indirect` for enums.
 // See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
@@ -12733,7 +11861,6 @@ extension ShareMode: Equatable, Hashable {}
  */
 
 public enum SortBy {
-    
     /**
      * Sort by key, then author.
      */
@@ -12744,37 +11871,30 @@ public enum SortBy {
     case authorKey
 }
 
-
 public struct FfiConverterTypeSortBy: FfiConverterRustBuffer {
     typealias SwiftType = SortBy
 
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SortBy {
         let variant: Int32 = try readInt(&buf)
         switch variant {
-        
         case 1: return .keyAuthor
-        
+
         case 2: return .authorKey
-        
+
         default: throw UniffiInternalError.unexpectedEnumCase
         }
     }
 
     public static func write(_ value: SortBy, into buf: inout [UInt8]) {
         switch value {
-        
-        
         case .keyAuthor:
             writeInt(&buf, Int32(1))
-        
-        
+
         case .authorKey:
             writeInt(&buf, Int32(2))
-        
         }
     }
 }
-
 
 public func FfiConverterTypeSortBy_lift(_ buf: RustBuffer) throws -> SortBy {
     return try FfiConverterTypeSortBy.lift(buf)
@@ -12784,11 +11904,7 @@ public func FfiConverterTypeSortBy_lower(_ value: SortBy) -> RustBuffer {
     return FfiConverterTypeSortBy.lower(value)
 }
 
-
-
 extension SortBy: Equatable, Hashable {}
-
-
 
 // Note that we don't yet support `indirect` for enums.
 // See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
@@ -12797,7 +11913,6 @@ extension SortBy: Equatable, Hashable {}
  */
 
 public enum SortDirection {
-    
     /**
      * Sort ascending
      */
@@ -12808,37 +11923,30 @@ public enum SortDirection {
     case desc
 }
 
-
 public struct FfiConverterTypeSortDirection: FfiConverterRustBuffer {
     typealias SwiftType = SortDirection
 
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SortDirection {
         let variant: Int32 = try readInt(&buf)
         switch variant {
-        
         case 1: return .asc
-        
+
         case 2: return .desc
-        
+
         default: throw UniffiInternalError.unexpectedEnumCase
         }
     }
 
     public static func write(_ value: SortDirection, into buf: inout [UInt8]) {
         switch value {
-        
-        
         case .asc:
             writeInt(&buf, Int32(1))
-        
-        
+
         case .desc:
             writeInt(&buf, Int32(2))
-        
         }
     }
 }
-
 
 public func FfiConverterTypeSortDirection_lift(_ buf: RustBuffer) throws -> SortDirection {
     return try FfiConverterTypeSortDirection.lift(buf)
@@ -12848,11 +11956,7 @@ public func FfiConverterTypeSortDirection_lower(_ value: SortDirection) -> RustB
     return FfiConverterTypeSortDirection.lower(value)
 }
 
-
-
 extension SortDirection: Equatable, Hashable {}
-
-
 
 // Note that we don't yet support `indirect` for enums.
 // See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
@@ -12861,7 +11965,6 @@ extension SortDirection: Equatable, Hashable {}
  */
 
 public enum SyncReason {
-    
     /**
      * Direct join request via API
      */
@@ -12880,49 +11983,40 @@ public enum SyncReason {
     case resync
 }
 
-
 public struct FfiConverterTypeSyncReason: FfiConverterRustBuffer {
     typealias SwiftType = SyncReason
 
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SyncReason {
         let variant: Int32 = try readInt(&buf)
         switch variant {
-        
         case 1: return .directJoin
-        
+
         case 2: return .newNeighbor
-        
+
         case 3: return .syncReport
-        
+
         case 4: return .resync
-        
+
         default: throw UniffiInternalError.unexpectedEnumCase
         }
     }
 
     public static func write(_ value: SyncReason, into buf: inout [UInt8]) {
         switch value {
-        
-        
         case .directJoin:
             writeInt(&buf, Int32(1))
-        
-        
+
         case .newNeighbor:
             writeInt(&buf, Int32(2))
-        
-        
+
         case .syncReport:
             writeInt(&buf, Int32(3))
-        
-        
+
         case .resync:
             writeInt(&buf, Int32(4))
-        
         }
     }
 }
-
 
 public func FfiConverterTypeSyncReason_lift(_ buf: RustBuffer) throws -> SyncReason {
     return try FfiConverterTypeSyncReason.lift(buf)
@@ -12932,13 +12026,9 @@ public func FfiConverterTypeSyncReason_lower(_ value: SyncReason) -> RustBuffer 
     return FfiConverterTypeSyncReason.lower(value)
 }
 
-
-
 extension SyncReason: Equatable, Hashable {}
 
-
-
-fileprivate struct FfiConverterOptionUInt64: FfiConverterRustBuffer {
+private struct FfiConverterOptionUInt64: FfiConverterRustBuffer {
     typealias SwiftType = UInt64?
 
     public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
@@ -12959,7 +12049,7 @@ fileprivate struct FfiConverterOptionUInt64: FfiConverterRustBuffer {
     }
 }
 
-fileprivate struct FfiConverterOptionString: FfiConverterRustBuffer {
+private struct FfiConverterOptionString: FfiConverterRustBuffer {
     typealias SwiftType = String?
 
     public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
@@ -12980,7 +12070,7 @@ fileprivate struct FfiConverterOptionString: FfiConverterRustBuffer {
     }
 }
 
-fileprivate struct FfiConverterOptionDuration: FfiConverterRustBuffer {
+private struct FfiConverterOptionDuration: FfiConverterRustBuffer {
     typealias SwiftType = TimeInterval?
 
     public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
@@ -13001,7 +12091,7 @@ fileprivate struct FfiConverterOptionDuration: FfiConverterRustBuffer {
     }
 }
 
-fileprivate struct FfiConverterOptionTypeDoc: FfiConverterRustBuffer {
+private struct FfiConverterOptionTypeDoc: FfiConverterRustBuffer {
     typealias SwiftType = Doc?
 
     public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
@@ -13022,7 +12112,7 @@ fileprivate struct FfiConverterOptionTypeDoc: FfiConverterRustBuffer {
     }
 }
 
-fileprivate struct FfiConverterOptionTypeDocExportFileCallback: FfiConverterRustBuffer {
+private struct FfiConverterOptionTypeDocExportFileCallback: FfiConverterRustBuffer {
     typealias SwiftType = DocExportFileCallback?
 
     public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
@@ -13043,7 +12133,7 @@ fileprivate struct FfiConverterOptionTypeDocExportFileCallback: FfiConverterRust
     }
 }
 
-fileprivate struct FfiConverterOptionTypeDocImportFileCallback: FfiConverterRustBuffer {
+private struct FfiConverterOptionTypeDocImportFileCallback: FfiConverterRustBuffer {
     typealias SwiftType = DocImportFileCallback?
 
     public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
@@ -13064,7 +12154,7 @@ fileprivate struct FfiConverterOptionTypeDocImportFileCallback: FfiConverterRust
     }
 }
 
-fileprivate struct FfiConverterOptionTypeEntry: FfiConverterRustBuffer {
+private struct FfiConverterOptionTypeEntry: FfiConverterRustBuffer {
     typealias SwiftType = Entry?
 
     public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
@@ -13085,7 +12175,7 @@ fileprivate struct FfiConverterOptionTypeEntry: FfiConverterRustBuffer {
     }
 }
 
-fileprivate struct FfiConverterOptionTypeConnectionInfo: FfiConverterRustBuffer {
+private struct FfiConverterOptionTypeConnectionInfo: FfiConverterRustBuffer {
     typealias SwiftType = ConnectionInfo?
 
     public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
@@ -13106,7 +12196,7 @@ fileprivate struct FfiConverterOptionTypeConnectionInfo: FfiConverterRustBuffer 
     }
 }
 
-fileprivate struct FfiConverterOptionTypeLatencyAndControlMsg: FfiConverterRustBuffer {
+private struct FfiConverterOptionTypeLatencyAndControlMsg: FfiConverterRustBuffer {
     typealias SwiftType = LatencyAndControlMsg?
 
     public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
@@ -13127,7 +12217,7 @@ fileprivate struct FfiConverterOptionTypeLatencyAndControlMsg: FfiConverterRustB
     }
 }
 
-fileprivate struct FfiConverterOptionTypeQueryOptions: FfiConverterRustBuffer {
+private struct FfiConverterOptionTypeQueryOptions: FfiConverterRustBuffer {
     typealias SwiftType = QueryOptions?
 
     public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
@@ -13148,7 +12238,7 @@ fileprivate struct FfiConverterOptionTypeQueryOptions: FfiConverterRustBuffer {
     }
 }
 
-fileprivate struct FfiConverterOptionSequenceData: FfiConverterRustBuffer {
+private struct FfiConverterOptionSequenceData: FfiConverterRustBuffer {
     typealias SwiftType = [Data]?
 
     public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
@@ -13169,7 +12259,7 @@ fileprivate struct FfiConverterOptionSequenceData: FfiConverterRustBuffer {
     }
 }
 
-fileprivate struct FfiConverterSequenceString: FfiConverterRustBuffer {
+private struct FfiConverterSequenceString: FfiConverterRustBuffer {
     typealias SwiftType = [String]
 
     public static func write(_ value: [String], into buf: inout [UInt8]) {
@@ -13185,13 +12275,13 @@ fileprivate struct FfiConverterSequenceString: FfiConverterRustBuffer {
         var seq = [String]()
         seq.reserveCapacity(Int(len))
         for _ in 0 ..< len {
-            seq.append(try FfiConverterString.read(from: &buf))
+            try seq.append(FfiConverterString.read(from: &buf))
         }
         return seq
     }
 }
 
-fileprivate struct FfiConverterSequenceData: FfiConverterRustBuffer {
+private struct FfiConverterSequenceData: FfiConverterRustBuffer {
     typealias SwiftType = [Data]
 
     public static func write(_ value: [Data], into buf: inout [UInt8]) {
@@ -13207,13 +12297,13 @@ fileprivate struct FfiConverterSequenceData: FfiConverterRustBuffer {
         var seq = [Data]()
         seq.reserveCapacity(Int(len))
         for _ in 0 ..< len {
-            seq.append(try FfiConverterData.read(from: &buf))
+            try seq.append(FfiConverterData.read(from: &buf))
         }
         return seq
     }
 }
 
-fileprivate struct FfiConverterSequenceTypeAuthorId: FfiConverterRustBuffer {
+private struct FfiConverterSequenceTypeAuthorId: FfiConverterRustBuffer {
     typealias SwiftType = [AuthorId]
 
     public static func write(_ value: [AuthorId], into buf: inout [UInt8]) {
@@ -13229,13 +12319,13 @@ fileprivate struct FfiConverterSequenceTypeAuthorId: FfiConverterRustBuffer {
         var seq = [AuthorId]()
         seq.reserveCapacity(Int(len))
         for _ in 0 ..< len {
-            seq.append(try FfiConverterTypeAuthorId.read(from: &buf))
+            try seq.append(FfiConverterTypeAuthorId.read(from: &buf))
         }
         return seq
     }
 }
 
-fileprivate struct FfiConverterSequenceTypeDirectAddrInfo: FfiConverterRustBuffer {
+private struct FfiConverterSequenceTypeDirectAddrInfo: FfiConverterRustBuffer {
     typealias SwiftType = [DirectAddrInfo]
 
     public static func write(_ value: [DirectAddrInfo], into buf: inout [UInt8]) {
@@ -13251,13 +12341,13 @@ fileprivate struct FfiConverterSequenceTypeDirectAddrInfo: FfiConverterRustBuffe
         var seq = [DirectAddrInfo]()
         seq.reserveCapacity(Int(len))
         for _ in 0 ..< len {
-            seq.append(try FfiConverterTypeDirectAddrInfo.read(from: &buf))
+            try seq.append(FfiConverterTypeDirectAddrInfo.read(from: &buf))
         }
         return seq
     }
 }
 
-fileprivate struct FfiConverterSequenceTypeEntry: FfiConverterRustBuffer {
+private struct FfiConverterSequenceTypeEntry: FfiConverterRustBuffer {
     typealias SwiftType = [Entry]
 
     public static func write(_ value: [Entry], into buf: inout [UInt8]) {
@@ -13273,13 +12363,13 @@ fileprivate struct FfiConverterSequenceTypeEntry: FfiConverterRustBuffer {
         var seq = [Entry]()
         seq.reserveCapacity(Int(len))
         for _ in 0 ..< len {
-            seq.append(try FfiConverterTypeEntry.read(from: &buf))
+            try seq.append(FfiConverterTypeEntry.read(from: &buf))
         }
         return seq
     }
 }
 
-fileprivate struct FfiConverterSequenceTypeFilterKind: FfiConverterRustBuffer {
+private struct FfiConverterSequenceTypeFilterKind: FfiConverterRustBuffer {
     typealias SwiftType = [FilterKind]
 
     public static func write(_ value: [FilterKind], into buf: inout [UInt8]) {
@@ -13295,13 +12385,13 @@ fileprivate struct FfiConverterSequenceTypeFilterKind: FfiConverterRustBuffer {
         var seq = [FilterKind]()
         seq.reserveCapacity(Int(len))
         for _ in 0 ..< len {
-            seq.append(try FfiConverterTypeFilterKind.read(from: &buf))
+            try seq.append(FfiConverterTypeFilterKind.read(from: &buf))
         }
         return seq
     }
 }
 
-fileprivate struct FfiConverterSequenceTypeHash: FfiConverterRustBuffer {
+private struct FfiConverterSequenceTypeHash: FfiConverterRustBuffer {
     typealias SwiftType = [Hash]
 
     public static func write(_ value: [Hash], into buf: inout [UInt8]) {
@@ -13317,13 +12407,13 @@ fileprivate struct FfiConverterSequenceTypeHash: FfiConverterRustBuffer {
         var seq = [Hash]()
         seq.reserveCapacity(Int(len))
         for _ in 0 ..< len {
-            seq.append(try FfiConverterTypeHash.read(from: &buf))
+            try seq.append(FfiConverterTypeHash.read(from: &buf))
         }
         return seq
     }
 }
 
-fileprivate struct FfiConverterSequenceTypeNodeAddr: FfiConverterRustBuffer {
+private struct FfiConverterSequenceTypeNodeAddr: FfiConverterRustBuffer {
     typealias SwiftType = [NodeAddr]
 
     public static func write(_ value: [NodeAddr], into buf: inout [UInt8]) {
@@ -13339,13 +12429,13 @@ fileprivate struct FfiConverterSequenceTypeNodeAddr: FfiConverterRustBuffer {
         var seq = [NodeAddr]()
         seq.reserveCapacity(Int(len))
         for _ in 0 ..< len {
-            seq.append(try FfiConverterTypeNodeAddr.read(from: &buf))
+            try seq.append(FfiConverterTypeNodeAddr.read(from: &buf))
         }
         return seq
     }
 }
 
-fileprivate struct FfiConverterSequenceTypeCollectionInfo: FfiConverterRustBuffer {
+private struct FfiConverterSequenceTypeCollectionInfo: FfiConverterRustBuffer {
     typealias SwiftType = [CollectionInfo]
 
     public static func write(_ value: [CollectionInfo], into buf: inout [UInt8]) {
@@ -13361,13 +12451,13 @@ fileprivate struct FfiConverterSequenceTypeCollectionInfo: FfiConverterRustBuffe
         var seq = [CollectionInfo]()
         seq.reserveCapacity(Int(len))
         for _ in 0 ..< len {
-            seq.append(try FfiConverterTypeCollectionInfo.read(from: &buf))
+            try seq.append(FfiConverterTypeCollectionInfo.read(from: &buf))
         }
         return seq
     }
 }
 
-fileprivate struct FfiConverterSequenceTypeConnectionInfo: FfiConverterRustBuffer {
+private struct FfiConverterSequenceTypeConnectionInfo: FfiConverterRustBuffer {
     typealias SwiftType = [ConnectionInfo]
 
     public static func write(_ value: [ConnectionInfo], into buf: inout [UInt8]) {
@@ -13383,13 +12473,13 @@ fileprivate struct FfiConverterSequenceTypeConnectionInfo: FfiConverterRustBuffe
         var seq = [ConnectionInfo]()
         seq.reserveCapacity(Int(len))
         for _ in 0 ..< len {
-            seq.append(try FfiConverterTypeConnectionInfo.read(from: &buf))
+            try seq.append(FfiConverterTypeConnectionInfo.read(from: &buf))
         }
         return seq
     }
 }
 
-fileprivate struct FfiConverterSequenceTypeIncompleteBlobInfo: FfiConverterRustBuffer {
+private struct FfiConverterSequenceTypeIncompleteBlobInfo: FfiConverterRustBuffer {
     typealias SwiftType = [IncompleteBlobInfo]
 
     public static func write(_ value: [IncompleteBlobInfo], into buf: inout [UInt8]) {
@@ -13405,13 +12495,13 @@ fileprivate struct FfiConverterSequenceTypeIncompleteBlobInfo: FfiConverterRustB
         var seq = [IncompleteBlobInfo]()
         seq.reserveCapacity(Int(len))
         for _ in 0 ..< len {
-            seq.append(try FfiConverterTypeIncompleteBlobInfo.read(from: &buf))
+            try seq.append(FfiConverterTypeIncompleteBlobInfo.read(from: &buf))
         }
         return seq
     }
 }
 
-fileprivate struct FfiConverterSequenceTypeLinkAndName: FfiConverterRustBuffer {
+private struct FfiConverterSequenceTypeLinkAndName: FfiConverterRustBuffer {
     typealias SwiftType = [LinkAndName]
 
     public static func write(_ value: [LinkAndName], into buf: inout [UInt8]) {
@@ -13427,13 +12517,13 @@ fileprivate struct FfiConverterSequenceTypeLinkAndName: FfiConverterRustBuffer {
         var seq = [LinkAndName]()
         seq.reserveCapacity(Int(len))
         for _ in 0 ..< len {
-            seq.append(try FfiConverterTypeLinkAndName.read(from: &buf))
+            try seq.append(FfiConverterTypeLinkAndName.read(from: &buf))
         }
         return seq
     }
 }
 
-fileprivate struct FfiConverterSequenceTypeNamespaceAndCapability: FfiConverterRustBuffer {
+private struct FfiConverterSequenceTypeNamespaceAndCapability: FfiConverterRustBuffer {
     typealias SwiftType = [NamespaceAndCapability]
 
     public static func write(_ value: [NamespaceAndCapability], into buf: inout [UInt8]) {
@@ -13449,13 +12539,13 @@ fileprivate struct FfiConverterSequenceTypeNamespaceAndCapability: FfiConverterR
         var seq = [NamespaceAndCapability]()
         seq.reserveCapacity(Int(len))
         for _ in 0 ..< len {
-            seq.append(try FfiConverterTypeNamespaceAndCapability.read(from: &buf))
+            try seq.append(FfiConverterTypeNamespaceAndCapability.read(from: &buf))
         }
         return seq
     }
 }
 
-fileprivate struct FfiConverterSequenceTypeTagInfo: FfiConverterRustBuffer {
+private struct FfiConverterSequenceTypeTagInfo: FfiConverterRustBuffer {
     typealias SwiftType = [TagInfo]
 
     public static func write(_ value: [TagInfo], into buf: inout [UInt8]) {
@@ -13471,13 +12561,13 @@ fileprivate struct FfiConverterSequenceTypeTagInfo: FfiConverterRustBuffer {
         var seq = [TagInfo]()
         seq.reserveCapacity(Int(len))
         for _ in 0 ..< len {
-            seq.append(try FfiConverterTypeTagInfo.read(from: &buf))
+            try seq.append(FfiConverterTypeTagInfo.read(from: &buf))
         }
         return seq
     }
 }
 
-fileprivate struct FfiConverterDictionaryStringTypeCounterStats: FfiConverterRustBuffer {
+private struct FfiConverterDictionaryStringTypeCounterStats: FfiConverterRustBuffer {
     public static func write(_ value: [String: CounterStats], into buf: inout [UInt8]) {
         let len = Int32(value.count)
         writeInt(&buf, len)
@@ -13491,7 +12581,7 @@ fileprivate struct FfiConverterDictionaryStringTypeCounterStats: FfiConverterRus
         let len: Int32 = try readInt(&buf)
         var dict = [String: CounterStats]()
         dict.reserveCapacity(Int(len))
-        for _ in 0..<len {
+        for _ in 0 ..< len {
             let key = try FfiConverterString.read(from: &buf)
             let value = try FfiConverterTypeCounterStats.read(from: &buf)
             dict[key] = value
@@ -13499,16 +12589,17 @@ fileprivate struct FfiConverterDictionaryStringTypeCounterStats: FfiConverterRus
         return dict
     }
 }
+
 private let UNIFFI_RUST_FUTURE_POLL_READY: Int8 = 0
 private let UNIFFI_RUST_FUTURE_POLL_MAYBE_READY: Int8 = 1
 
-fileprivate let uniffiContinuationHandleMap = UniffiHandleMap<UnsafeContinuation<Int8, Never>>()
+private let uniffiContinuationHandleMap = UniffiHandleMap<UnsafeContinuation<Int8, Never>>()
 
-fileprivate func uniffiRustCallAsync<F, T>(
+private func uniffiRustCallAsync<F, T>(
     rustFutureFunc: () -> UInt64,
-    pollFunc: (UInt64, @escaping UniffiRustFutureContinuationCallback, UInt64) -> (),
+    pollFunc: (UInt64, @escaping UniffiRustFutureContinuationCallback, UInt64) -> Void,
     completeFunc: (UInt64, UnsafeMutablePointer<RustCallStatus>) -> F,
-    freeFunc: (UInt64) -> (),
+    freeFunc: (UInt64) -> Void,
     liftFunc: (F) throws -> T,
     errorHandler: ((RustBuffer) throws -> Swift.Error)?
 ) async throws -> T {
@@ -13519,7 +12610,7 @@ fileprivate func uniffiRustCallAsync<F, T>(
     defer {
         freeFunc(rustFuture)
     }
-    var pollResult: Int8;
+    var pollResult: Int8
     repeat {
         pollResult = await withUnsafeContinuation {
             pollFunc(
@@ -13538,39 +12629,39 @@ fileprivate func uniffiRustCallAsync<F, T>(
 
 // Callback handlers for an async calls.  These are invoked by Rust when the future is ready.  They
 // lift the return value or error and resume the suspended function.
-fileprivate func uniffiFutureContinuationCallback(handle: UInt64, pollResult: Int8) {
+private func uniffiFutureContinuationCallback(handle: UInt64, pollResult: Int8) {
     if let continuation = try? uniffiContinuationHandleMap.remove(handle: handle) {
         continuation.resume(returning: pollResult)
     } else {
         print("uniffiFutureContinuationCallback invalid handle")
     }
 }
+
 private func uniffiTraitInterfaceCallAsync<T>(
     makeCall: @escaping () async throws -> T,
-    handleSuccess: @escaping (T) -> (),
-    handleError: @escaping (Int8, RustBuffer) -> ()
+    handleSuccess: @escaping (T) -> Void,
+    handleError: @escaping (Int8, RustBuffer) -> Void
 ) -> UniffiForeignFuture {
     let task = Task {
         do {
-            handleSuccess(try await makeCall())
+            try handleSuccess(await makeCall())
         } catch {
             handleError(CALL_UNEXPECTED_ERROR, FfiConverterString.lower(String(describing: error)))
         }
     }
     let handle = UNIFFI_FOREIGN_FUTURE_HANDLE_MAP.insert(obj: task)
     return UniffiForeignFuture(handle: handle, free: uniffiForeignFutureFree)
-
 }
 
 private func uniffiTraitInterfaceCallAsyncWithError<T, E>(
     makeCall: @escaping () async throws -> T,
-    handleSuccess: @escaping (T) -> (),
-    handleError: @escaping (Int8, RustBuffer) -> (),
+    handleSuccess: @escaping (T) -> Void,
+    handleError: @escaping (Int8, RustBuffer) -> Void,
     lowerError: @escaping (E) -> RustBuffer
 ) -> UniffiForeignFuture {
     let task = Task {
         do {
-            handleSuccess(try await makeCall())
+            try handleSuccess(await makeCall())
         } catch let error as E {
             handleError(CALL_ERROR, lowerError(error))
         } catch {
@@ -13583,7 +12674,7 @@ private func uniffiTraitInterfaceCallAsyncWithError<T, E>(
 
 // Borrow the callback handle map implementation to store foreign future handles
 // TODO: consolidate the handle-map code (https://github.com/mozilla/uniffi-rs/pull/1823)
-fileprivate var UNIFFI_FOREIGN_FUTURE_HANDLE_MAP = UniffiHandleMap<UniffiForeignFutureTask>()
+private var UNIFFI_FOREIGN_FUTURE_HANDLE_MAP = UniffiHandleMap<UniffiForeignFutureTask>()
 
 // Protocol for tasks that handle foreign futures.
 //
@@ -13611,6 +12702,7 @@ private func uniffiForeignFutureFree(handle: UInt64) {
 public func uniffiForeignFutureHandleCountIrohFfi() -> Int {
     UNIFFI_FOREIGN_FUTURE_HANDLE_MAP.count
 }
+
 /**
  * Helper function that translates a key that was derived from the [`path_to_key`] function back
  * into a path.
@@ -13619,42 +12711,45 @@ public func uniffiForeignFutureHandleCountIrohFfi() -> Int {
  * If `root` exists, will add the root as a parent to the created path
  * Removes any null byte that has been appened to the key
  */
-public func keyToPath(key: Data, prefix: String?, root: String?)throws  -> String {
-    return try  FfiConverterString.lift(try rustCallWithError(FfiConverterTypeIrohError__as_error.lift) {
-    uniffi_iroh_ffi_fn_func_key_to_path(
-        FfiConverterData.lower(key),
-        FfiConverterOptionString.lower(prefix),
-        FfiConverterOptionString.lower(root),$0
-    )
-})
+public func keyToPath(key: Data, prefix: String?, root: String?) throws -> String {
+    return try FfiConverterString.lift(rustCallWithError(FfiConverterTypeIrohError__as_error.lift) {
+        uniffi_iroh_ffi_fn_func_key_to_path(
+            FfiConverterData.lower(key),
+            FfiConverterOptionString.lower(prefix),
+            FfiConverterOptionString.lower(root), $0
+        )
+    })
 }
+
 /**
  * Helper function that creates a document key from a canonicalized path, removing the `root` and adding the `prefix`, if they exist
  *
  * Appends the null byte to the end of the key.
  */
-public func pathToKey(path: String, prefix: String?, root: String?)throws  -> Data {
-    return try  FfiConverterData.lift(try rustCallWithError(FfiConverterTypeIrohError__as_error.lift) {
-    uniffi_iroh_ffi_fn_func_path_to_key(
-        FfiConverterString.lower(path),
-        FfiConverterOptionString.lower(prefix),
-        FfiConverterOptionString.lower(root),$0
-    )
-})
+public func pathToKey(path: String, prefix: String?, root: String?) throws -> Data {
+    return try FfiConverterData.lift(rustCallWithError(FfiConverterTypeIrohError__as_error.lift) {
+        uniffi_iroh_ffi_fn_func_path_to_key(
+            FfiConverterString.lower(path),
+            FfiConverterOptionString.lower(prefix),
+            FfiConverterOptionString.lower(root), $0
+        )
+    })
 }
+
 /**
  * Set the logging level.
  */
-public func setLogLevel(level: LogLevel) {try! rustCall() {
+public func setLogLevel(level: LogLevel) { try! rustCall {
     uniffi_iroh_ffi_fn_func_set_log_level(
-        FfiConverterTypeLogLevel.lower(level),$0
+        FfiConverterTypeLogLevel.lower(level), $0
     )
 }
 }
+
 /**
  * Initialize the global metrics collection.
  */
-public func startMetricsCollection()throws  {try rustCallWithError(FfiConverterTypeIrohError__as_error.lift) {
+public func startMetricsCollection() throws { try rustCallWithError(FfiConverterTypeIrohError__as_error.lift) {
     uniffi_iroh_ffi_fn_func_start_metrics_collection($0
     )
 }
@@ -13665,6 +12760,7 @@ private enum InitializationResult {
     case contractVersionMismatch
     case apiChecksumMismatch
 }
+
 // Use a global variable to perform the versioning checks. Swift ensures that
 // the code inside is only computed once.
 private var initializationResult: InitializationResult = {
@@ -13675,592 +12771,595 @@ private var initializationResult: InitializationResult = {
     if bindings_contract_version != scaffolding_contract_version {
         return InitializationResult.contractVersionMismatch
     }
-    if (uniffi_iroh_ffi_checksum_func_key_to_path() != 28001) {
+    if uniffi_iroh_ffi_checksum_func_key_to_path() != 28001 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_func_path_to_key() != 4438) {
+    if uniffi_iroh_ffi_checksum_func_path_to_key() != 4438 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_func_set_log_level() != 52619) {
+    if uniffi_iroh_ffi_checksum_func_set_log_level() != 52619 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_func_start_metrics_collection() != 23413) {
+    if uniffi_iroh_ffi_checksum_func_start_metrics_collection() != 23413 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_addcallback_progress() != 62116) {
+    if uniffi_iroh_ffi_checksum_method_addcallback_progress() != 62116 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_addprogress_as_abort() != 44667) {
+    if uniffi_iroh_ffi_checksum_method_addprogress_as_abort() != 44667 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_addprogress_as_all_done() != 62551) {
+    if uniffi_iroh_ffi_checksum_method_addprogress_as_all_done() != 62551 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_addprogress_as_done() != 58505) {
+    if uniffi_iroh_ffi_checksum_method_addprogress_as_done() != 58505 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_addprogress_as_found() != 8172) {
+    if uniffi_iroh_ffi_checksum_method_addprogress_as_found() != 8172 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_addprogress_as_progress() != 36155) {
+    if uniffi_iroh_ffi_checksum_method_addprogress_as_progress() != 36155 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_addprogress_type() != 46221) {
+    if uniffi_iroh_ffi_checksum_method_addprogress_type() != 46221 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_author_id() != 39022) {
+    if uniffi_iroh_ffi_checksum_method_author_id() != 39022 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_authorid_equal() != 56356) {
+    if uniffi_iroh_ffi_checksum_method_authorid_equal() != 56356 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_authors_create() != 47692) {
+    if uniffi_iroh_ffi_checksum_method_authors_create() != 47692 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_authors_default() != 6795) {
+    if uniffi_iroh_ffi_checksum_method_authors_default() != 6795 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_authors_delete() != 51040) {
+    if uniffi_iroh_ffi_checksum_method_authors_delete() != 51040 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_authors_export() != 17391) {
+    if uniffi_iroh_ffi_checksum_method_authors_export() != 17391 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_authors_import() != 11067) {
+    if uniffi_iroh_ffi_checksum_method_authors_import() != 11067 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_authors_import_author() != 56460) {
+    if uniffi_iroh_ffi_checksum_method_authors_import_author() != 56460 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_authors_list() != 33930) {
+    if uniffi_iroh_ffi_checksum_method_authors_list() != 33930 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_blobticket_as_download_options() != 18713) {
+    if uniffi_iroh_ffi_checksum_method_blobticket_as_download_options() != 18713 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_blobticket_format() != 35808) {
+    if uniffi_iroh_ffi_checksum_method_blobticket_format() != 35808 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_blobticket_hash() != 54061) {
+    if uniffi_iroh_ffi_checksum_method_blobticket_hash() != 54061 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_blobticket_node_addr() != 30662) {
+    if uniffi_iroh_ffi_checksum_method_blobticket_node_addr() != 30662 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_blobticket_recursive() != 53797) {
+    if uniffi_iroh_ffi_checksum_method_blobticket_recursive() != 53797 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_blobs_add_bytes() != 16525) {
+    if uniffi_iroh_ffi_checksum_method_blobs_add_bytes() != 16525 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_blobs_add_bytes_named() != 4623) {
+    if uniffi_iroh_ffi_checksum_method_blobs_add_bytes_named() != 4623 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_blobs_add_from_path() != 12412) {
+    if uniffi_iroh_ffi_checksum_method_blobs_add_from_path() != 12412 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_blobs_create_collection() != 63440) {
+    if uniffi_iroh_ffi_checksum_method_blobs_create_collection() != 63440 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_blobs_delete_blob() != 24901) {
+    if uniffi_iroh_ffi_checksum_method_blobs_delete_blob() != 24901 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_blobs_download() != 14779) {
+    if uniffi_iroh_ffi_checksum_method_blobs_download() != 14779 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_blobs_export() != 23697) {
+    if uniffi_iroh_ffi_checksum_method_blobs_export() != 23697 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_blobs_get_collection() != 57130) {
+    if uniffi_iroh_ffi_checksum_method_blobs_get_collection() != 57130 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_blobs_list() != 9714) {
+    if uniffi_iroh_ffi_checksum_method_blobs_list() != 9714 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_blobs_list_collections() != 22274) {
+    if uniffi_iroh_ffi_checksum_method_blobs_list_collections() != 22274 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_blobs_list_incomplete() != 31740) {
+    if uniffi_iroh_ffi_checksum_method_blobs_list_incomplete() != 31740 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_blobs_read_at_to_bytes() != 29675) {
+    if uniffi_iroh_ffi_checksum_method_blobs_read_at_to_bytes() != 29675 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_blobs_read_to_bytes() != 13624) {
+    if uniffi_iroh_ffi_checksum_method_blobs_read_to_bytes() != 13624 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_blobs_share() != 55307) {
+    if uniffi_iroh_ffi_checksum_method_blobs_share() != 35831 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_blobs_size() != 20254) {
+    if uniffi_iroh_ffi_checksum_method_blobs_size() != 20254 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_blobs_write_to_path() != 47517) {
+    if uniffi_iroh_ffi_checksum_method_blobs_write_to_path() != 47517 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_collection_blobs() != 52509) {
+    if uniffi_iroh_ffi_checksum_method_collection_blobs() != 52509 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_collection_is_empty() != 40621) {
+    if uniffi_iroh_ffi_checksum_method_collection_is_empty() != 40621 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_collection_len() != 10206) {
+    if uniffi_iroh_ffi_checksum_method_collection_len() != 10206 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_collection_links() != 56034) {
+    if uniffi_iroh_ffi_checksum_method_collection_links() != 56034 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_collection_names() != 28871) {
+    if uniffi_iroh_ffi_checksum_method_collection_names() != 28871 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_collection_push() != 22031) {
+    if uniffi_iroh_ffi_checksum_method_collection_push() != 22031 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_connectiontype_as_direct() != 47530) {
+    if uniffi_iroh_ffi_checksum_method_connectiontype_as_direct() != 47530 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_connectiontype_as_mixed() != 49068) {
+    if uniffi_iroh_ffi_checksum_method_connectiontype_as_mixed() != 49068 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_connectiontype_as_relay() != 6121) {
+    if uniffi_iroh_ffi_checksum_method_connectiontype_as_relay() != 6121 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_connectiontype_type() != 54998) {
+    if uniffi_iroh_ffi_checksum_method_connectiontype_type() != 54998 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_directaddrinfo_addr() != 20100) {
+    if uniffi_iroh_ffi_checksum_method_directaddrinfo_addr() != 20100 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_directaddrinfo_last_control() != 35048) {
+    if uniffi_iroh_ffi_checksum_method_directaddrinfo_last_control() != 35048 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_directaddrinfo_last_payload() != 12406) {
+    if uniffi_iroh_ffi_checksum_method_directaddrinfo_last_payload() != 12406 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_directaddrinfo_latency() != 7414) {
+    if uniffi_iroh_ffi_checksum_method_directaddrinfo_latency() != 7414 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_doc_close_me() != 13449) {
+    if uniffi_iroh_ffi_checksum_method_doc_close_me() != 13449 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_doc_delete() != 54552) {
+    if uniffi_iroh_ffi_checksum_method_doc_delete() != 54552 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_doc_export_file() != 16067) {
+    if uniffi_iroh_ffi_checksum_method_doc_export_file() != 16067 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_doc_get_download_policy() != 44884) {
+    if uniffi_iroh_ffi_checksum_method_doc_get_download_policy() != 44884 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_doc_get_exact() != 20423) {
+    if uniffi_iroh_ffi_checksum_method_doc_get_exact() != 20423 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_doc_get_many() != 53909) {
+    if uniffi_iroh_ffi_checksum_method_doc_get_many() != 53909 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_doc_get_one() != 18797) {
+    if uniffi_iroh_ffi_checksum_method_doc_get_one() != 18797 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_doc_get_sync_peers() != 59505) {
+    if uniffi_iroh_ffi_checksum_method_doc_get_sync_peers() != 59505 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_doc_id() != 53450) {
+    if uniffi_iroh_ffi_checksum_method_doc_id() != 53450 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_doc_import_file() != 52327) {
+    if uniffi_iroh_ffi_checksum_method_doc_import_file() != 52327 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_doc_leave() != 40204) {
+    if uniffi_iroh_ffi_checksum_method_doc_leave() != 40204 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_doc_set_bytes() != 32483) {
+    if uniffi_iroh_ffi_checksum_method_doc_set_bytes() != 32483 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_doc_set_download_policy() != 18200) {
+    if uniffi_iroh_ffi_checksum_method_doc_set_download_policy() != 18200 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_doc_set_hash() != 30875) {
+    if uniffi_iroh_ffi_checksum_method_doc_set_hash() != 30875 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_doc_share() != 30398) {
+    if uniffi_iroh_ffi_checksum_method_doc_share() != 59706 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_doc_start_sync() != 54450) {
+    if uniffi_iroh_ffi_checksum_method_doc_start_sync() != 54450 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_doc_status() != 30558) {
+    if uniffi_iroh_ffi_checksum_method_doc_status() != 30558 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_doc_subscribe() != 59807) {
+    if uniffi_iroh_ffi_checksum_method_doc_subscribe() != 59807 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_docexportfilecallback_progress() != 53186) {
+    if uniffi_iroh_ffi_checksum_method_docexportfilecallback_progress() != 53186 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_docexportprogress_as_abort() != 34476) {
+    if uniffi_iroh_ffi_checksum_method_docexportprogress_as_abort() != 34476 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_docexportprogress_as_found() != 23982) {
+    if uniffi_iroh_ffi_checksum_method_docexportprogress_as_found() != 23982 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_docexportprogress_as_progress() != 44802) {
+    if uniffi_iroh_ffi_checksum_method_docexportprogress_as_progress() != 44802 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_docexportprogress_type() != 11215) {
+    if uniffi_iroh_ffi_checksum_method_docexportprogress_type() != 11215 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_docimportfilecallback_progress() != 55347) {
+    if uniffi_iroh_ffi_checksum_method_docimportfilecallback_progress() != 55347 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_docimportprogress_as_abort() != 35952) {
+    if uniffi_iroh_ffi_checksum_method_docimportprogress_as_abort() != 35952 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_docimportprogress_as_all_done() != 35787) {
+    if uniffi_iroh_ffi_checksum_method_docimportprogress_as_all_done() != 35787 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_docimportprogress_as_found() != 6030) {
+    if uniffi_iroh_ffi_checksum_method_docimportprogress_as_found() != 6030 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_docimportprogress_as_ingest_done() != 36) {
+    if uniffi_iroh_ffi_checksum_method_docimportprogress_as_ingest_done() != 36 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_docimportprogress_as_progress() != 19927) {
+    if uniffi_iroh_ffi_checksum_method_docimportprogress_as_progress() != 19927 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_docimportprogress_type() != 48401) {
+    if uniffi_iroh_ffi_checksum_method_docimportprogress_type() != 48401 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_docs_create() != 54486) {
+    if uniffi_iroh_ffi_checksum_method_docs_create() != 54486 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_docs_drop_doc() != 5864) {
+    if uniffi_iroh_ffi_checksum_method_docs_drop_doc() != 5864 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_docs_join() != 29064) {
+    if uniffi_iroh_ffi_checksum_method_docs_join() != 38489 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_docs_join_and_subscribe() != 30619) {
+    if uniffi_iroh_ffi_checksum_method_docs_join_and_subscribe() != 41379 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_docs_list() != 23866) {
+    if uniffi_iroh_ffi_checksum_method_docs_list() != 23866 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_docs_open() != 45928) {
+    if uniffi_iroh_ffi_checksum_method_docs_open() != 45928 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_downloadcallback_progress() != 21881) {
+    if uniffi_iroh_ffi_checksum_method_downloadcallback_progress() != 21881 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_downloadprogress_as_abort() != 6879) {
+    if uniffi_iroh_ffi_checksum_method_downloadprogress_as_abort() != 6879 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_downloadprogress_as_all_done() != 4219) {
+    if uniffi_iroh_ffi_checksum_method_downloadprogress_as_all_done() != 4219 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_downloadprogress_as_done() != 21859) {
+    if uniffi_iroh_ffi_checksum_method_downloadprogress_as_done() != 21859 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_downloadprogress_as_found() != 47836) {
+    if uniffi_iroh_ffi_checksum_method_downloadprogress_as_found() != 47836 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_downloadprogress_as_found_hash_seq() != 14451) {
+    if uniffi_iroh_ffi_checksum_method_downloadprogress_as_found_hash_seq() != 14451 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_downloadprogress_as_found_local() != 47262) {
+    if uniffi_iroh_ffi_checksum_method_downloadprogress_as_found_local() != 47262 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_downloadprogress_as_progress() != 16155) {
+    if uniffi_iroh_ffi_checksum_method_downloadprogress_as_progress() != 16155 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_downloadprogress_type() != 60534) {
+    if uniffi_iroh_ffi_checksum_method_downloadprogress_type() != 60534 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_entry_author() != 39787) {
+    if uniffi_iroh_ffi_checksum_method_entry_author() != 39787 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_entry_content_bytes() != 18583) {
+    if uniffi_iroh_ffi_checksum_method_entry_content_bytes() != 18583 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_entry_content_hash() != 26949) {
+    if uniffi_iroh_ffi_checksum_method_entry_content_hash() != 26949 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_entry_content_len() != 40073) {
+    if uniffi_iroh_ffi_checksum_method_entry_content_len() != 40073 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_entry_key() != 10200) {
+    if uniffi_iroh_ffi_checksum_method_entry_key() != 10200 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_entry_namespace() != 25213) {
+    if uniffi_iroh_ffi_checksum_method_entry_namespace() != 25213 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_entry_timestamp() != 38377) {
+    if uniffi_iroh_ffi_checksum_method_entry_timestamp() != 38377 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_filterkind_matches() != 24522) {
+    if uniffi_iroh_ffi_checksum_method_filterkind_matches() != 24522 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_gossip_subscribe() != 6414) {
+    if uniffi_iroh_ffi_checksum_method_gossip_subscribe() != 6414 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_gossipmessagecallback_on_message() != 49150) {
+    if uniffi_iroh_ffi_checksum_method_gossipmessagecallback_on_message() != 49150 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_hash_equal() != 28210) {
+    if uniffi_iroh_ffi_checksum_method_hash_equal() != 28210 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_hash_to_bytes() != 26394) {
+    if uniffi_iroh_ffi_checksum_method_hash_to_bytes() != 26394 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_hash_to_hex() != 52108) {
+    if uniffi_iroh_ffi_checksum_method_hash_to_hex() != 52108 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_iroh_authors() != 25106) {
+    if uniffi_iroh_ffi_checksum_method_iroh_authors() != 25106 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_iroh_blobs() != 50340) {
+    if uniffi_iroh_ffi_checksum_method_iroh_blobs() != 50340 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_iroh_docs() != 17607) {
+    if uniffi_iroh_ffi_checksum_method_iroh_docs() != 17607 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_iroh_gossip() != 58884) {
+    if uniffi_iroh_ffi_checksum_method_iroh_gossip() != 58884 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_iroh_node() != 12499) {
+    if uniffi_iroh_ffi_checksum_method_iroh_node() != 12499 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_iroh_tags() != 59606) {
+    if uniffi_iroh_ffi_checksum_method_iroh_tags() != 59606 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_iroherror_message() != 31085) {
+    if uniffi_iroh_ffi_checksum_method_iroherror_message() != 31085 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_liveevent_as_content_ready() != 6578) {
+    if uniffi_iroh_ffi_checksum_method_liveevent_as_content_ready() != 6578 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_liveevent_as_insert_local() != 27496) {
+    if uniffi_iroh_ffi_checksum_method_liveevent_as_insert_local() != 27496 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_liveevent_as_insert_remote() != 38454) {
+    if uniffi_iroh_ffi_checksum_method_liveevent_as_insert_remote() != 38454 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_liveevent_as_neighbor_down() != 27752) {
+    if uniffi_iroh_ffi_checksum_method_liveevent_as_neighbor_down() != 27752 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_liveevent_as_neighbor_up() != 44203) {
+    if uniffi_iroh_ffi_checksum_method_liveevent_as_neighbor_up() != 44203 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_liveevent_as_sync_finished() != 27893) {
+    if uniffi_iroh_ffi_checksum_method_liveevent_as_sync_finished() != 27893 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_liveevent_type() != 30099) {
+    if uniffi_iroh_ffi_checksum_method_liveevent_type() != 30099 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_message_as_error() != 9059) {
+    if uniffi_iroh_ffi_checksum_method_message_as_error() != 9059 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_message_as_joined() != 39463) {
+    if uniffi_iroh_ffi_checksum_method_message_as_joined() != 39463 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_message_as_neighbor_down() != 19092) {
+    if uniffi_iroh_ffi_checksum_method_message_as_neighbor_down() != 19092 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_message_as_neighbor_up() != 3541) {
+    if uniffi_iroh_ffi_checksum_method_message_as_neighbor_up() != 3541 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_message_as_received() != 6044) {
+    if uniffi_iroh_ffi_checksum_method_message_as_received() != 6044 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_message_type() != 75) {
+    if uniffi_iroh_ffi_checksum_method_message_type() != 75 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_node_add_node_addr() != 48772) {
+    if uniffi_iroh_ffi_checksum_method_node_add_node_addr() != 48772 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_node_connection_info() != 19420) {
+    if uniffi_iroh_ffi_checksum_method_node_connection_info() != 19420 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_node_connections() != 60971) {
+    if uniffi_iroh_ffi_checksum_method_node_connections() != 60971 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_node_home_relay() != 39435) {
+    if uniffi_iroh_ffi_checksum_method_node_home_relay() != 39435 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_node_my_rpc_addr() != 34751) {
+    if uniffi_iroh_ffi_checksum_method_node_my_rpc_addr() != 34751 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_node_node_addr() != 55077) {
+    if uniffi_iroh_ffi_checksum_method_node_node_addr() != 55077 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_node_node_id() != 50937) {
+    if uniffi_iroh_ffi_checksum_method_node_node_id() != 50937 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_node_shutdown() != 21075) {
+    if uniffi_iroh_ffi_checksum_method_node_shutdown() != 21075 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_node_stats() != 13439) {
+    if uniffi_iroh_ffi_checksum_method_node_stats() != 13439 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_node_status() != 21889) {
+    if uniffi_iroh_ffi_checksum_method_node_status() != 21889 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_nodeaddr_direct_addresses() != 23787) {
+    if uniffi_iroh_ffi_checksum_method_nodeaddr_direct_addresses() != 23787 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_nodeaddr_equal() != 19664) {
+    if uniffi_iroh_ffi_checksum_method_nodeaddr_equal() != 19664 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_nodeaddr_relay_url() != 34772) {
+    if uniffi_iroh_ffi_checksum_method_nodeaddr_relay_url() != 34772 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_nodestatus_listen_addrs() != 54436) {
+    if uniffi_iroh_ffi_checksum_method_nodestatus_listen_addrs() != 54436 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_nodestatus_node_addr() != 12507) {
+    if uniffi_iroh_ffi_checksum_method_nodestatus_node_addr() != 12507 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_nodestatus_rpc_addr() != 20002) {
+    if uniffi_iroh_ffi_checksum_method_nodestatus_rpc_addr() != 20002 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_nodestatus_version() != 3183) {
+    if uniffi_iroh_ffi_checksum_method_nodestatus_version() != 3183 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_publickey_equal() != 8690) {
+    if uniffi_iroh_ffi_checksum_method_publickey_equal() != 8690 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_publickey_fmt_short() != 31871) {
+    if uniffi_iroh_ffi_checksum_method_publickey_fmt_short() != 31871 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_publickey_to_bytes() != 22449) {
+    if uniffi_iroh_ffi_checksum_method_publickey_to_bytes() != 22449 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_query_limit() != 23235) {
+    if uniffi_iroh_ffi_checksum_method_query_limit() != 23235 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_query_offset() != 14460) {
+    if uniffi_iroh_ffi_checksum_method_query_offset() != 14460 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_rangespec_is_all() != 51737) {
+    if uniffi_iroh_ffi_checksum_method_rangespec_is_all() != 51737 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_rangespec_is_empty() != 38175) {
+    if uniffi_iroh_ffi_checksum_method_rangespec_is_empty() != 38175 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_sender_broadcast() != 42694) {
+    if uniffi_iroh_ffi_checksum_method_sender_broadcast() != 42694 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_sender_broadcast_neighbors() != 14000) {
+    if uniffi_iroh_ffi_checksum_method_sender_broadcast_neighbors() != 14000 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_subscribecallback_event() != 35520) {
+    if uniffi_iroh_ffi_checksum_method_subscribecallback_event() != 35520 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_tags_delete() != 17755) {
+    if uniffi_iroh_ffi_checksum_method_tags_delete() != 17755 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_method_tags_list() != 16151) {
+    if uniffi_iroh_ffi_checksum_method_tags_list() != 16151 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_constructor_author_from_string() != 63158) {
+    if uniffi_iroh_ffi_checksum_constructor_author_from_string() != 63158 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_constructor_authorid_from_string() != 47849) {
+    if uniffi_iroh_ffi_checksum_constructor_authorid_from_string() != 47849 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_constructor_blobdownloadoptions_new() != 19425) {
+    if uniffi_iroh_ffi_checksum_constructor_blobdownloadoptions_new() != 19425 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_constructor_blobticket_new() != 29763) {
+    if uniffi_iroh_ffi_checksum_constructor_blobticket_new() != 29763 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_constructor_collection_new() != 3798) {
+    if uniffi_iroh_ffi_checksum_constructor_collection_new() != 3798 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_constructor_downloadpolicy_everything() != 35143) {
+    if uniffi_iroh_ffi_checksum_constructor_docticket_new() != 29537 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_constructor_downloadpolicy_everything_except() != 21211) {
+    if uniffi_iroh_ffi_checksum_constructor_downloadpolicy_everything() != 35143 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_constructor_downloadpolicy_nothing() != 16928) {
+    if uniffi_iroh_ffi_checksum_constructor_downloadpolicy_everything_except() != 21211 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_constructor_downloadpolicy_nothing_except() != 12041) {
+    if uniffi_iroh_ffi_checksum_constructor_downloadpolicy_nothing() != 16928 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_constructor_filterkind_exact() != 13432) {
+    if uniffi_iroh_ffi_checksum_constructor_downloadpolicy_nothing_except() != 12041 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_constructor_filterkind_prefix() != 42338) {
+    if uniffi_iroh_ffi_checksum_constructor_filterkind_exact() != 13432 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_constructor_hash_from_bytes() != 13104) {
+    if uniffi_iroh_ffi_checksum_constructor_filterkind_prefix() != 42338 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_constructor_hash_from_string() != 23453) {
+    if uniffi_iroh_ffi_checksum_constructor_hash_from_bytes() != 13104 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_constructor_hash_new() != 30613) {
+    if uniffi_iroh_ffi_checksum_constructor_hash_from_string() != 23453 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_constructor_iroh_memory() != 49939) {
+    if uniffi_iroh_ffi_checksum_constructor_hash_new() != 30613 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_constructor_iroh_memory_with_options() != 60437) {
+    if uniffi_iroh_ffi_checksum_constructor_iroh_memory() != 49939 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_constructor_iroh_persistent() != 42623) {
+    if uniffi_iroh_ffi_checksum_constructor_iroh_memory_with_options() != 60437 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_constructor_iroh_persistent_with_options() != 60788) {
+    if uniffi_iroh_ffi_checksum_constructor_iroh_persistent() != 42623 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_constructor_nodeaddr_new() != 5759) {
+    if uniffi_iroh_ffi_checksum_constructor_iroh_persistent_with_options() != 60788 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_constructor_publickey_from_bytes() != 64011) {
+    if uniffi_iroh_ffi_checksum_constructor_nodeaddr_new() != 5759 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_constructor_publickey_from_string() != 42207) {
+    if uniffi_iroh_ffi_checksum_constructor_publickey_from_bytes() != 64011 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_constructor_query_all() != 34328) {
+    if uniffi_iroh_ffi_checksum_constructor_publickey_from_string() != 42207 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_constructor_query_author() != 17803) {
+    if uniffi_iroh_ffi_checksum_constructor_query_all() != 34328 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_constructor_query_author_key_exact() != 38571) {
+    if uniffi_iroh_ffi_checksum_constructor_query_author() != 17803 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_constructor_query_author_key_prefix() != 48731) {
+    if uniffi_iroh_ffi_checksum_constructor_query_author_key_exact() != 38571 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_constructor_query_key_exact() != 17481) {
+    if uniffi_iroh_ffi_checksum_constructor_query_author_key_prefix() != 48731 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_constructor_query_key_prefix() != 35279) {
+    if uniffi_iroh_ffi_checksum_constructor_query_key_exact() != 17481 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_constructor_query_single_latest_per_key() != 58221) {
+    if uniffi_iroh_ffi_checksum_constructor_query_key_prefix() != 35279 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_constructor_query_single_latest_per_key_exact() != 6734) {
+    if uniffi_iroh_ffi_checksum_constructor_query_single_latest_per_key() != 58221 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_constructor_query_single_latest_per_key_prefix() != 8914) {
+    if uniffi_iroh_ffi_checksum_constructor_query_single_latest_per_key_exact() != 6734 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_constructor_settagoption_auto() != 50496) {
+    if uniffi_iroh_ffi_checksum_constructor_query_single_latest_per_key_prefix() != 8914 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_constructor_settagoption_named() != 33009) {
+    if uniffi_iroh_ffi_checksum_constructor_settagoption_auto() != 50496 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_constructor_wrapoption_no_wrap() != 59800) {
+    if uniffi_iroh_ffi_checksum_constructor_settagoption_named() != 33009 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iroh_ffi_checksum_constructor_wrapoption_wrap() != 6667) {
+    if uniffi_iroh_ffi_checksum_constructor_wrapoption_no_wrap() != 59800 {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if uniffi_iroh_ffi_checksum_constructor_wrapoption_wrap() != 6667 {
         return InitializationResult.apiChecksumMismatch
     }
 

--- a/iroh-js/__test__/blob.spec.mjs
+++ b/iroh-js/__test__/blob.spec.mjs
@@ -102,3 +102,18 @@ test('collections', async (t) => {
   t.is(collectionList[0].hash, res.hash)
   t.is(collectionList[0].totalBlobsCount, BigInt(numFiles + 1))
 })
+
+test('share', async (t) => {
+  const node = await Iroh.memory()
+
+  const res = await node.blobs.addBytes(Array.from(Buffer.from('hello')))
+  const ticket = await node.blobs.share(res.hash, res.format, 'RelayAndAddresses')
+
+  const nodeAddr = await node.node.nodeAddr()
+
+  console.log(res, ticket)
+
+  t.is(ticket.format, res.format)
+  t.is(ticket.hash, res.hash)
+  t.deepEqual(ticket.nodeAddr, nodeAddr)
+})

--- a/iroh-js/index.d.ts
+++ b/iroh-js/index.d.ts
@@ -134,7 +134,7 @@ export declare class Blobs {
    */
   export(hash: string, destination: string, format: BlobExportFormat, mode: BlobExportMode): Promise<void>
   /** Create a ticket for sharing a blob from this node. */
-  share(hash: string, blobFormat: BlobFormat, ticketOptions: AddrInfoOptions): Promise<string>
+  share(hash: string, blobFormat: BlobFormat, ticketOptions: AddrInfoOptions): Promise<BlobTicket>
   /**
    * List all incomplete (partial) blobs.
    *

--- a/iroh-js/src/blob.rs
+++ b/iroh-js/src/blob.rs
@@ -5,7 +5,7 @@ use napi::bindgen_prelude::*;
 use napi::threadsafe_function::ThreadsafeFunction;
 use napi_derive::napi;
 
-use crate::{node::Iroh, AddrInfoOptions, NodeAddr};
+use crate::{node::Iroh, AddrInfoOptions, BlobTicket, NodeAddr};
 
 /// Iroh blobs client.
 #[napi]
@@ -240,7 +240,7 @@ impl Blobs {
         hash: String,
         blob_format: BlobFormat,
         ticket_options: AddrInfoOptions,
-    ) -> Result<String> {
+    ) -> Result<BlobTicket> {
         let ticket = self
             .client()
             .blobs()
@@ -250,7 +250,7 @@ impl Blobs {
                 ticket_options.into(),
             )
             .await?;
-        Ok(ticket.to_string())
+        Ok(ticket.into())
     }
 
     /// List all incomplete (partial) blobs.

--- a/kotlin/iroh/iroh_ffi.kt
+++ b/kotlin/iroh/iroh_ffi.kt
@@ -1124,6 +1124,11 @@ internal interface UniffiLib : Library {
         uniffi_out_err: UniffiRustCallStatus,
     ): Byte
 
+    fun uniffi_iroh_ffi_fn_method_blobticket_uniffi_trait_display(
+        `ptr`: Pointer,
+        uniffi_out_err: UniffiRustCallStatus,
+    ): RustBuffer.ByValue
+
     fun uniffi_iroh_ffi_fn_clone_blobs(
         `ptr`: Pointer,
         uniffi_out_err: UniffiRustCallStatus,
@@ -1530,6 +1535,26 @@ internal interface UniffiLib : Library {
         uniffi_out_err: UniffiRustCallStatus,
     ): RustBuffer.ByValue
 
+    fun uniffi_iroh_ffi_fn_clone_docticket(
+        `ptr`: Pointer,
+        uniffi_out_err: UniffiRustCallStatus,
+    ): Pointer
+
+    fun uniffi_iroh_ffi_fn_free_docticket(
+        `ptr`: Pointer,
+        uniffi_out_err: UniffiRustCallStatus,
+    ): Unit
+
+    fun uniffi_iroh_ffi_fn_constructor_docticket_new(
+        `str`: RustBuffer.ByValue,
+        uniffi_out_err: UniffiRustCallStatus,
+    ): Pointer
+
+    fun uniffi_iroh_ffi_fn_method_docticket_uniffi_trait_display(
+        `ptr`: Pointer,
+        uniffi_out_err: UniffiRustCallStatus,
+    ): RustBuffer.ByValue
+
     fun uniffi_iroh_ffi_fn_clone_docs(
         `ptr`: Pointer,
         uniffi_out_err: UniffiRustCallStatus,
@@ -1549,12 +1574,12 @@ internal interface UniffiLib : Library {
 
     fun uniffi_iroh_ffi_fn_method_docs_join(
         `ptr`: Pointer,
-        `ticket`: RustBuffer.ByValue,
+        `ticket`: Pointer,
     ): Long
 
     fun uniffi_iroh_ffi_fn_method_docs_join_and_subscribe(
         `ptr`: Pointer,
-        `ticket`: RustBuffer.ByValue,
+        `ticket`: Pointer,
         `cb`: Pointer,
     ): Long
 
@@ -2860,6 +2885,8 @@ internal interface UniffiLib : Library {
 
     fun uniffi_iroh_ffi_checksum_constructor_collection_new(): Short
 
+    fun uniffi_iroh_ffi_checksum_constructor_docticket_new(): Short
+
     fun uniffi_iroh_ffi_checksum_constructor_downloadpolicy_everything(): Short
 
     fun uniffi_iroh_ffi_checksum_constructor_downloadpolicy_everything_except(): Short
@@ -3047,7 +3074,7 @@ private fun uniffiCheckApiChecksums(lib: UniffiLib) {
     if (lib.uniffi_iroh_ffi_checksum_method_blobs_read_to_bytes() != 13624.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_iroh_ffi_checksum_method_blobs_share() != 55307.toShort()) {
+    if (lib.uniffi_iroh_ffi_checksum_method_blobs_share() != 35831.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_iroh_ffi_checksum_method_blobs_size() != 20254.toShort()) {
@@ -3140,7 +3167,7 @@ private fun uniffiCheckApiChecksums(lib: UniffiLib) {
     if (lib.uniffi_iroh_ffi_checksum_method_doc_set_hash() != 30875.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_iroh_ffi_checksum_method_doc_share() != 30398.toShort()) {
+    if (lib.uniffi_iroh_ffi_checksum_method_doc_share() != 59706.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_iroh_ffi_checksum_method_doc_start_sync() != 54450.toShort()) {
@@ -3194,10 +3221,10 @@ private fun uniffiCheckApiChecksums(lib: UniffiLib) {
     if (lib.uniffi_iroh_ffi_checksum_method_docs_drop_doc() != 5864.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_iroh_ffi_checksum_method_docs_join() != 29064.toShort()) {
+    if (lib.uniffi_iroh_ffi_checksum_method_docs_join() != 38489.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_iroh_ffi_checksum_method_docs_join_and_subscribe() != 30619.toShort()) {
+    if (lib.uniffi_iroh_ffi_checksum_method_docs_join_and_subscribe() != 41379.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_iroh_ffi_checksum_method_docs_list() != 23866.toShort()) {
@@ -3432,6 +3459,9 @@ private fun uniffiCheckApiChecksums(lib: UniffiLib) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_iroh_ffi_checksum_constructor_collection_new() != 3798.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_iroh_ffi_checksum_constructor_docticket_new() != 29537.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_iroh_ffi_checksum_constructor_downloadpolicy_everything() != 35143.toShort()) {
@@ -6154,6 +6184,18 @@ open class BlobTicket :
             },
         )
 
+    override fun toString(): String =
+        FfiConverterString.lift(
+            callWithPointer {
+                uniffiRustCall { _status ->
+                    UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_blobticket_uniffi_trait_display(
+                        it,
+                        _status,
+                    )
+                }
+            },
+        )
+
     companion object
 }
 
@@ -6412,7 +6454,7 @@ public interface BlobsInterface {
         `hash`: Hash,
         `blobFormat`: BlobFormat,
         `ticketOptions`: AddrInfoOptions,
-    ): kotlin.String
+    ): BlobTicket
 
     /**
      * Get the size information on a single blob.
@@ -6930,7 +6972,7 @@ open class Blobs :
         `hash`: Hash,
         `blobFormat`: BlobFormat,
         `ticketOptions`: AddrInfoOptions,
-    ): kotlin.String =
+    ): BlobTicket =
         uniffiRustCallAsync(
             callWithPointer { thisPtr ->
                 UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_blobs_share(
@@ -6940,17 +6982,11 @@ open class Blobs :
                     FfiConverterTypeAddrInfoOptions.lower(`ticketOptions`),
                 )
             },
-            {
-                    future,
-                    callback,
-                    continuation,
-                ->
-                UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_rust_buffer(future, callback, continuation)
-            },
-            { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_rust_buffer(future, continuation) },
-            { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_rust_buffer(future) },
+            { future, callback, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_pointer(future, callback, continuation) },
+            { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_pointer(future, continuation) },
+            { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_pointer(future) },
             // lift function
-            { FfiConverterString.lift(it) },
+            { FfiConverterTypeBlobTicket.lift(it) },
             // Error FFI converter
             IrohException.ErrorHandler,
         )
@@ -7270,9 +7306,7 @@ open class Collection :
     /**
      * Get the blobs associated with this collection
      */
-    @Throws(
-        IrohException::class,
-        )
+    @Throws(IrohException::class)
     override fun `blobs`(): List<LinkAndName> =
         FfiConverterSequenceTypeLinkAndName.lift(
             callWithPointer {
@@ -7288,9 +7322,7 @@ open class Collection :
     /**
      * Check if the collection is empty
      */
-    @Throws(
-        IrohException::class,
-        )
+    @Throws(IrohException::class)
     override fun `isEmpty`(): kotlin.Boolean =
         FfiConverterBoolean.lift(
             callWithPointer {
@@ -7306,9 +7338,7 @@ open class Collection :
     /**
      * Returns the number of blobs in this collection
      */
-    @Throws(
-        IrohException::class,
-        )
+    @Throws(IrohException::class)
     override fun `len`(): kotlin.ULong =
         FfiConverterULong.lift(
             callWithPointer {
@@ -7324,9 +7354,7 @@ open class Collection :
     /**
      * Get the links to the blobs in this collection
      */
-    @Throws(
-        IrohException::class,
-        )
+    @Throws(IrohException::class)
     override fun `links`(): List<Hash> =
         FfiConverterSequenceTypeHash.lift(
             callWithPointer {
@@ -7342,9 +7370,7 @@ open class Collection :
     /**
      * Get the names of the blobs in this collection
      */
-    @Throws(
-        IrohException::class,
-        )
+    @Throws(IrohException::class)
     override fun `names`(): List<kotlin.String> =
         FfiConverterSequenceString.lift(
             callWithPointer {
@@ -7360,9 +7386,7 @@ open class Collection :
     /**
      * Add the given blob to the collection
      */
-    @Throws(
-        IrohException::class,
-        )
+    @Throws(IrohException::class)
     override fun `push`(
         `name`: kotlin.String,
         `hash`: Hash,
@@ -8208,7 +8232,7 @@ public interface DocInterface {
     suspend fun `share`(
         `mode`: ShareMode,
         `addrOptions`: AddrInfoOptions,
-    ): kotlin.String
+    ): DocTicket
 
     /**
      * Start to sync this document with a list of peers.
@@ -8689,7 +8713,7 @@ open class Doc :
     override suspend fun `share`(
         `mode`: ShareMode,
         `addrOptions`: AddrInfoOptions,
-    ): kotlin.String =
+    ): DocTicket =
         uniffiRustCallAsync(
             callWithPointer { thisPtr ->
                 UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_doc_share(
@@ -8698,17 +8722,11 @@ open class Doc :
                     FfiConverterTypeAddrInfoOptions.lower(`addrOptions`),
                 )
             },
-            {
-                    future,
-                    callback,
-                    continuation,
-                ->
-                UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_rust_buffer(future, callback, continuation)
-            },
-            { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_rust_buffer(future, continuation) },
-            { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_rust_buffer(future) },
+            { future, callback, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_pointer(future, callback, continuation) },
+            { future, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_complete_pointer(future, continuation) },
+            { future -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_free_pointer(future) },
             // lift function
-            { FfiConverterString.lift(it) },
+            { FfiConverterTypeDocTicket.lift(it) },
             // Error FFI converter
             IrohException.ErrorHandler,
         )
@@ -10156,6 +10174,244 @@ public object FfiConverterTypeDocImportProgress : FfiConverter<DocImportProgress
 //
 
 /**
+ * Contains both a key (either secret or public) to a document, and a list of peers to join.
+ */
+public interface DocTicketInterface {
+    companion object
+}
+
+/**
+ * Contains both a key (either secret or public) to a document, and a list of peers to join.
+ */
+open class DocTicket :
+    Disposable,
+    AutoCloseable,
+    DocTicketInterface {
+    constructor(pointer: Pointer) {
+        this.pointer = pointer
+        this.cleanable = UniffiLib.CLEANER.register(this, UniffiCleanAction(pointer))
+    }
+
+    /**
+     * This constructor can be used to instantiate a fake object. Only used for tests. Any
+     * attempt to actually use an object constructed this way will fail as there is no
+     * connected Rust object.
+     */
+    @Suppress("UNUSED_PARAMETER")
+    constructor(noPointer: NoPointer) {
+        this.pointer = null
+        this.cleanable = UniffiLib.CLEANER.register(this, UniffiCleanAction(pointer))
+    }
+    constructor(`str`: kotlin.String) :
+        this(
+            uniffiRustCallWithError(IrohException) { _status ->
+                UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_constructor_docticket_new(
+                    FfiConverterString.lower(`str`),
+                    _status,
+                )
+            },
+        )
+
+    protected val pointer: Pointer?
+    protected val cleanable: UniffiCleaner.Cleanable
+
+    private val wasDestroyed = AtomicBoolean(false)
+    private val callCounter = AtomicLong(1)
+
+    override fun destroy() {
+        // Only allow a single call to this method.
+        // TODO: maybe we should log a warning if called more than once?
+        if (this.wasDestroyed.compareAndSet(false, true)) {
+            // This decrement always matches the initial count of 1 given at creation time.
+            if (this.callCounter.decrementAndGet() == 0L) {
+                cleanable.clean()
+            }
+        }
+    }
+
+    @Synchronized
+    override fun close() {
+        this.destroy()
+    }
+
+    internal inline fun <R> callWithPointer(block: (ptr: Pointer) -> R): R {
+        // Check and increment the call counter, to keep the object alive.
+        // This needs a compare-and-set retry loop in case of concurrent updates.
+        do {
+            val c = this.callCounter.get()
+            if (c == 0L) {
+                throw IllegalStateException("${this.javaClass.simpleName} object has already been destroyed")
+            }
+            if (c == Long.MAX_VALUE) {
+                throw IllegalStateException("${this.javaClass.simpleName} call counter would overflow")
+            }
+        } while (!this.callCounter.compareAndSet(c, c + 1L))
+        // Now we can safely do the method call without the pointer being freed concurrently.
+        try {
+            return block(this.uniffiClonePointer())
+        } finally {
+            // This decrement always matches the increment we performed above.
+            if (this.callCounter.decrementAndGet() == 0L) {
+                cleanable.clean()
+            }
+        }
+    }
+
+    // Use a static inner class instead of a closure so as not to accidentally
+    // capture `this` as part of the cleanable's action.
+    private class UniffiCleanAction(
+        private val pointer: Pointer?,
+    ) : Runnable {
+        override fun run() {
+            pointer?.let { ptr ->
+                uniffiRustCall { status ->
+                    UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_free_docticket(ptr, status)
+                }
+            }
+        }
+    }
+
+    fun uniffiClonePointer(): Pointer =
+        uniffiRustCall { status ->
+            UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_clone_docticket(pointer!!, status)
+        }
+
+    override fun toString(): String =
+        FfiConverterString.lift(
+            callWithPointer {
+                uniffiRustCall { _status ->
+                    UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_docticket_uniffi_trait_display(
+                        it,
+                        _status,
+                    )
+                }
+            },
+        )
+
+    companion object
+}
+
+public object FfiConverterTypeDocTicket : FfiConverter<DocTicket, Pointer> {
+    override fun lower(value: DocTicket): Pointer = value.uniffiClonePointer()
+
+    override fun lift(value: Pointer): DocTicket = DocTicket(value)
+
+    override fun read(buf: ByteBuffer): DocTicket {
+        // The Rust code always writes pointers as 8 bytes, and will
+        // fail to compile if they don't fit.
+        return lift(Pointer(buf.getLong()))
+    }
+
+    override fun allocationSize(value: DocTicket) = 8UL
+
+    override fun write(
+        value: DocTicket,
+        buf: ByteBuffer,
+    ) {
+        // The Rust code always expects pointers written as 8 bytes,
+        // and will fail to compile if they don't fit.
+        buf.putLong(Pointer.nativeValue(lower(value)))
+    }
+}
+
+// This template implements a class for working with a Rust struct via a Pointer/Arc<T>
+// to the live Rust struct on the other side of the FFI.
+//
+// Each instance implements core operations for working with the Rust `Arc<T>` and the
+// Kotlin Pointer to work with the live Rust struct on the other side of the FFI.
+//
+// There's some subtlety here, because we have to be careful not to operate on a Rust
+// struct after it has been dropped, and because we must expose a public API for freeing
+// theq Kotlin wrapper object in lieu of reliable finalizers. The core requirements are:
+//
+//   * Each instance holds an opaque pointer to the underlying Rust struct.
+//     Method calls need to read this pointer from the object's state and pass it in to
+//     the Rust FFI.
+//
+//   * When an instance is no longer needed, its pointer should be passed to a
+//     special destructor function provided by the Rust FFI, which will drop the
+//     underlying Rust struct.
+//
+//   * Given an instance, calling code is expected to call the special
+//     `destroy` method in order to free it after use, either by calling it explicitly
+//     or by using a higher-level helper like the `use` method. Failing to do so risks
+//     leaking the underlying Rust struct.
+//
+//   * We can't assume that calling code will do the right thing, and must be prepared
+//     to handle Kotlin method calls executing concurrently with or even after a call to
+//     `destroy`, and to handle multiple (possibly concurrent!) calls to `destroy`.
+//
+//   * We must never allow Rust code to operate on the underlying Rust struct after
+//     the destructor has been called, and must never call the destructor more than once.
+//     Doing so may trigger memory unsafety.
+//
+//   * To mitigate many of the risks of leaking memory and use-after-free unsafety, a `Cleaner`
+//     is implemented to call the destructor when the Kotlin object becomes unreachable.
+//     This is done in a background thread. This is not a panacea, and client code should be aware that
+//      1. the thread may starve if some there are objects that have poorly performing
+//     `drop` methods or do significant work in their `drop` methods.
+//      2. the thread is shared across the whole library. This can be tuned by using `android_cleaner = true`,
+//         or `android = true` in the [`kotlin` section of the `uniffi.toml` file](https://mozilla.github.io/uniffi-rs/kotlin/configuration.html).
+//
+// If we try to implement this with mutual exclusion on access to the pointer, there is the
+// possibility of a race between a method call and a concurrent call to `destroy`:
+//
+//    * Thread A starts a method call, reads the value of the pointer, but is interrupted
+//      before it can pass the pointer over the FFI to Rust.
+//    * Thread B calls `destroy` and frees the underlying Rust struct.
+//    * Thread A resumes, passing the already-read pointer value to Rust and triggering
+//      a use-after-free.
+//
+// One possible solution would be to use a `ReadWriteLock`, with each method call taking
+// a read lock (and thus allowed to run concurrently) and the special `destroy` method
+// taking a write lock (and thus blocking on live method calls). However, we aim not to
+// generate methods with any hidden blocking semantics, and a `destroy` method that might
+// block if called incorrectly seems to meet that bar.
+//
+// So, we achieve our goals by giving each instance an associated `AtomicLong` counter to track
+// the number of in-flight method calls, and an `AtomicBoolean` flag to indicate whether `destroy`
+// has been called. These are updated according to the following rules:
+//
+//    * The initial value of the counter is 1, indicating a live object with no in-flight calls.
+//      The initial value for the flag is false.
+//
+//    * At the start of each method call, we atomically check the counter.
+//      If it is 0 then the underlying Rust struct has already been destroyed and the call is aborted.
+//      If it is nonzero them we atomically increment it by 1 and proceed with the method call.
+//
+//    * At the end of each method call, we atomically decrement and check the counter.
+//      If it has reached zero then we destroy the underlying Rust struct.
+//
+//    * When `destroy` is called, we atomically flip the flag from false to true.
+//      If the flag was already true we silently fail.
+//      Otherwise we atomically decrement and check the counter.
+//      If it has reached zero then we destroy the underlying Rust struct.
+//
+// Astute readers may observe that this all sounds very similar to the way that Rust's `Arc<T>` works,
+// and indeed it is, with the addition of a flag to guard against multiple calls to `destroy`.
+//
+// The overall effect is that the underlying Rust struct is destroyed only when `destroy` has been
+// called *and* all in-flight method calls have completed, avoiding violating any of the expectations
+// of the underlying Rust code.
+//
+// This makes a cleaner a better alternative to _not_ calling `destroy()` as
+// and when the object is finished with, but the abstraction is not perfect: if the Rust object's `drop`
+// method is slow, and/or there are many objects to cleanup, and it's on a low end Android device, then the cleaner
+// thread may be starved, and the app will leak memory.
+//
+// In this case, `destroy`ing manually may be a better solution.
+//
+// The cleaner can live side by side with the manual calling of `destroy`. In the order of responsiveness, uniffi objects
+// with Rust peers are reclaimed:
+//
+// 1. By calling the `destroy` method of the object, which calls `rustObject.free()`. If that doesn't happen:
+// 2. When the object becomes unreachable, AND the Cleaner thread gets to call `rustObject.free()`. If the thread is starved then:
+// 3. The memory is reclaimed when the process terminates.
+//
+// [1] https://stackoverflow.com/questions/24376768/can-java-finalize-an-object-when-it-is-still-in-scope/24380219
+//
+
+/**
  * Iroh docs client.
  */
 public interface DocsInterface {
@@ -10176,13 +10432,13 @@ public interface DocsInterface {
     /**
      * Join and sync with an already existing document.
      */
-    suspend fun `join`(`ticket`: kotlin.String): Doc
+    suspend fun `join`(`ticket`: DocTicket): Doc
 
     /**
      * Join and sync with an already existing document and subscribe to events on that document.
      */
     suspend fun `joinAndSubscribe`(
-        `ticket`: kotlin.String,
+        `ticket`: DocTicket,
         `cb`: SubscribeCallback,
     ): Doc
 
@@ -10340,12 +10596,12 @@ open class Docs :
      */
     @Throws(IrohException::class)
     @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
-    override suspend fun `join`(`ticket`: kotlin.String): Doc =
+    override suspend fun `join`(`ticket`: DocTicket): Doc =
         uniffiRustCallAsync(
             callWithPointer { thisPtr ->
                 UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_docs_join(
                     thisPtr,
-                    FfiConverterString.lower(`ticket`),
+                    FfiConverterTypeDocTicket.lower(`ticket`),
                 )
             },
             { future, callback, continuation -> UniffiLib.INSTANCE.ffi_iroh_ffi_rust_future_poll_pointer(future, callback, continuation) },
@@ -10363,14 +10619,14 @@ open class Docs :
     @Throws(IrohException::class)
     @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
     override suspend fun `joinAndSubscribe`(
-        `ticket`: kotlin.String,
+        `ticket`: DocTicket,
         `cb`: SubscribeCallback,
     ): Doc =
         uniffiRustCallAsync(
             callWithPointer { thisPtr ->
                 UniffiLib.INSTANCE.uniffi_iroh_ffi_fn_method_docs_join_and_subscribe(
                     thisPtr,
-                    FfiConverterString.lower(`ticket`),
+                    FfiConverterTypeDocTicket.lower(`ticket`),
                     FfiConverterTypeSubscribeCallback.lower(`cb`),
                 )
             },

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -8,8 +8,8 @@ use std::{
 use futures::{StreamExt, TryStreamExt};
 use serde::{Deserialize, Serialize};
 
-use crate::ticket::AddrInfoOptions;
 use crate::{node::Iroh, CallbackError};
+use crate::{ticket::AddrInfoOptions, BlobTicket};
 use crate::{IrohError, NodeAddr};
 
 /// Iroh blobs client.
@@ -236,13 +236,13 @@ impl Blobs {
         hash: Arc<Hash>,
         blob_format: BlobFormat,
         ticket_options: AddrInfoOptions,
-    ) -> Result<String, IrohError> {
+    ) -> Result<Arc<BlobTicket>, IrohError> {
         let ticket = self
             .client()
             .blobs()
             .share(hash.0, blob_format.into(), ticket_options.into())
             .await?;
-        Ok(ticket.to_string())
+        Ok(Arc::new(ticket.into()))
     }
 
     /// List all incomplete (partial) blobs.

--- a/src/ticket.rs
+++ b/src/ticket.rs
@@ -1,8 +1,6 @@
 use std::str::FromStr;
 use std::sync::Arc;
 
-use iroh::base::ticket::Ticket;
-
 use crate::blob::{BlobDownloadOptions, BlobFormat, Hash};
 use crate::doc::NodeAddr;
 use crate::error::IrohError;
@@ -22,7 +20,7 @@ impl From<iroh::base::ticket::BlobTicket> for BlobTicket {
 
 impl std::fmt::Display for BlobTicket {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{}", Ticket::serialize(&self.0))
+        write!(f, "{}", self.0)
     }
 }
 
@@ -32,11 +30,6 @@ impl BlobTicket {
     pub fn new(str: String) -> Result<Self, IrohError> {
         let ticket = iroh::base::ticket::BlobTicket::from_str(&str).map_err(anyhow::Error::from)?;
         Ok(BlobTicket(ticket))
-    }
-
-    /// Convert this ticket into a string.
-    pub fn serialize(&self) -> String {
-        self.0.to_string()
     }
 
     /// The hash of the item this ticket can retrieve.
@@ -98,5 +91,37 @@ impl From<AddrInfoOptions> for iroh::base::node_addr::AddrInfoOptions {
             AddrInfoOptions::Relay => iroh::base::node_addr::AddrInfoOptions::Relay,
             AddrInfoOptions::Addresses => iroh::base::node_addr::AddrInfoOptions::Addresses,
         }
+    }
+}
+
+/// Contains both a key (either secret or public) to a document, and a list of peers to join.
+#[derive(Debug, Clone, uniffi::Object)]
+#[uniffi::export(Display)]
+pub struct DocTicket(iroh::docs::DocTicket);
+
+impl From<iroh::docs::DocTicket> for DocTicket {
+    fn from(value: iroh::docs::DocTicket) -> Self {
+        Self(value)
+    }
+}
+
+impl From<DocTicket> for iroh::docs::DocTicket {
+    fn from(value: DocTicket) -> Self {
+        value.0
+    }
+}
+
+#[uniffi::export]
+impl DocTicket {
+    #[uniffi::constructor]
+    pub fn new(str: String) -> Result<Self, IrohError> {
+        let ticket = iroh::docs::DocTicket::from_str(&str).map_err(anyhow::Error::from)?;
+        Ok(ticket.into())
+    }
+}
+
+impl std::fmt::Display for DocTicket {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.0)
     }
 }

--- a/src/ticket.rs
+++ b/src/ticket.rs
@@ -1,6 +1,8 @@
 use std::str::FromStr;
 use std::sync::Arc;
 
+use iroh::base::ticket::Ticket;
+
 use crate::blob::{BlobDownloadOptions, BlobFormat, Hash};
 use crate::doc::NodeAddr;
 use crate::error::IrohError;
@@ -9,7 +11,20 @@ use crate::error::IrohError;
 ///
 /// It is a single item which can be easily serialized and deserialized.
 #[derive(Debug, uniffi::Object)]
+#[uniffi::export(Display)]
 pub struct BlobTicket(iroh::base::ticket::BlobTicket);
+
+impl From<iroh::base::ticket::BlobTicket> for BlobTicket {
+    fn from(ticket: iroh::base::ticket::BlobTicket) -> Self {
+        BlobTicket(ticket)
+    }
+}
+
+impl std::fmt::Display for BlobTicket {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", Ticket::serialize(&self.0))
+    }
+}
 
 #[uniffi::export]
 impl BlobTicket {
@@ -17,6 +32,11 @@ impl BlobTicket {
     pub fn new(str: String) -> Result<Self, IrohError> {
         let ticket = iroh::base::ticket::BlobTicket::from_str(&str).map_err(anyhow::Error::from)?;
         Ok(BlobTicket(ticket))
+    }
+
+    /// Convert this ticket into a string.
+    pub fn serialize(&self) -> String {
+        self.0.to_string()
     }
 
     /// The hash of the item this ticket can retrieve.


### PR DESCRIPTION
share should return a `BlobTicket` instead of the string directly, no? maybe?

I've also added a `serialize` method to `BlobTicket`, _and_ the `#[uniffi::export(Display)]` derive used by `AuthorId`. My reason for having both is `#[uniffi::export(Display)]` converts to a `description` method in swift, and it's extremely strange to use `.description` as the main "purpose" of the `BlobTicket` struct when serializing