### PR TITLE
fix: maturin & release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,8 @@ on:
     - "v*"
 
 env:
-  LIB_NAME: libiroh
+  LIB_NAME: libiroh_ffi
+  PACKAGE_NAME: libiroh
   IROH_FORCE_STAGING_RELAYS: "1"
 
 jobs:
@@ -96,7 +97,7 @@ jobs:
       shell: bash
       run: |
         outdir="./target/release"
-        staging="${{ env.LIB_NAME }}-${{ matrix.target }}"
+        staging="${{ env.PACKAGE_NAME }}-${{ matrix.target }}"
         mkdir -p "$staging"
         if [ "${{ matrix.os }}" = "windows-latest" ]; then
           cp "target/release/iroh.lib" "$staging/"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,6 @@ tokio = { version = "1", features = ["full"] }
 [build-dependencies]
 uniffi = { version = "0.28.0", features = ["build"] }
 
-[profile.release]
-lto = true
-strip = "symbols"
+# [profile.release]
+# lto = true
+# strip = "symbols"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,3 @@ uniffi = { version = "0.28.0", features = ["build"] }
 
 [profile.release]
 lto = true
-strip = "symbols"
-
-[target.'cfg(not(target_env = "maturin"))'.profile.release]
-strip = "none"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,9 @@ tokio = { version = "1", features = ["full"] }
 [build-dependencies]
 uniffi = { version = "0.28.0", features = ["build"] }
 
-# [profile.release]
-# lto = true
-# strip = "symbols"
+[profile.release]
+lto = true
+strip = "symbols"
+
+[target.'cfg(not(target_env = "maturin"))'.profile.release]
+strip = "none"


### PR DESCRIPTION
Stripping symbols messes with maturin. Maturin has it's own `--strip` but I first need to figure out how to remove symbols of other targets and keep them only on the maturin builds.

Release builds broke when we moved the lib name from `libiroh` to `libiroh_ffi`. IIRC that was when we did the swift setup.