### PR TITLE
Add NodeTicket FFI variant

### DIFF
--- a/src/ticket.rs
+++ b/src/ticket.rs
@@ -29,8 +29,19 @@ impl std::fmt::Display for NodeTicket {
 
 #[uniffi::export]
 impl NodeTicket {
+    /// Wrap the given [`NodeAddr`] as a [`NodeTicket`].
+    ///
+    /// The returned ticket can easily be deserialized using its string presentation, and
+    /// later parsed again using [`Self::parse`].
     #[uniffi::constructor]
-    pub fn new(str: String) -> Result<Self, IrohError> {
+    pub fn new(addr: &NodeAddr) -> Result<Self, IrohError> {
+        let inner = TryInto::<iroh::base::node_addr::NodeAddr>::try_into(addr.clone())?;
+        Ok(iroh::base::ticket::NodeTicket::new(inner).into())
+    }
+
+    /// Parse back a [`NodeTicket`] from its string presentation.
+    #[uniffi::constructor]
+    pub fn parse(str: String) -> Result<Self, IrohError> {
         let ticket = iroh::base::ticket::NodeTicket::from_str(&str).map_err(anyhow::Error::from)?;
         Ok(NodeTicket(ticket))
     }

--- a/src/ticket.rs
+++ b/src/ticket.rs
@@ -5,6 +5,43 @@ use crate::blob::{BlobDownloadOptions, BlobFormat, Hash};
 use crate::doc::NodeAddr;
 use crate::error::IrohError;
 
+/// A token containing information for establishing a connection to a node.
+///
+/// This allows establishing a connection to the node in most circumstances where it is
+/// possible to do so.
+///
+/// It is a single item which can be easily serialized and deserialized.
+#[derive(Debug, uniffi::Object)]
+#[uniffi::export(Display)]
+pub struct NodeTicket(iroh::base::ticket::NodeTicket);
+
+impl From<iroh::base::ticket::NodeTicket> for NodeTicket {
+    fn from(ticket: iroh::base::ticket::NodeTicket) -> Self {
+        NodeTicket(ticket)
+    }
+}
+
+impl std::fmt::Display for NodeTicket {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+#[uniffi::export]
+impl NodeTicket {
+    #[uniffi::constructor]
+    pub fn new(str: String) -> Result<Self, IrohError> {
+        let ticket = iroh::base::ticket::NodeTicket::from_str(&str).map_err(anyhow::Error::from)?;
+        Ok(NodeTicket(ticket))
+    }
+
+    /// The [`NodeAddr`] of the provider for this ticket.
+    pub fn node_addr(&self) -> Arc<NodeAddr> {
+        let addr = self.0.node_addr().clone();
+        Arc::new(addr.into())
+    }
+}
+
 /// A token containing everything to get a file from the provider.
 ///
 /// It is a single item which can be easily serialized and deserialized.


### PR DESCRIPTION
Adds the `NodeTicket` to the FFI crate. Basically a copy of the already existing `BlobTicket` and `DocTicket`.

I use this in an Android application of mine and it works as expected. I played with the idea of adding `from_bytes` and `to_bytes`, but ultimately decided to instead just do this small change for now as it is all I need right now.

Not sure if I need to generate any new files? Please let me know.