### PR TITLE
Expose node_id on Endpoint

### DIFF
--- a/iroh-js/__test__/node.spec.mjs
+++ b/iroh-js/__test__/node.spec.mjs
@@ -88,6 +88,8 @@ test('custom protocol', async (t) => {
   const endpoint = node2.node.endpoint()
   // console.log(`connecting to ${nodeAddr.nodeId}`)
 
+  t.is(endpoint.nodeId(), await node2.net.nodeId())
+
   const conn = await endpoint.connect(nodeAddr, alpn)
   const remote = await conn.getRemoteNodeId()
   // console.log(`connected to ${remote.toString()}`)

--- a/iroh-js/index.d.ts
+++ b/iroh-js/index.d.ts
@@ -341,6 +341,8 @@ export declare class DownloadPolicy {
 }
 
 export declare class Endpoint {
+  /** The string representation of this endpoint's NodeId. */
+  nodeId(): string
   connect(nodeAddr: NodeAddr, alpn: Uint8Array): Promise<Connection>
 }
 

--- a/iroh-js/src/endpoint.rs
+++ b/iroh-js/src/endpoint.rs
@@ -19,6 +19,13 @@ impl Endpoint {
     }
 
     #[napi]
+    /// The string representation of this endpoint's NodeId.
+    pub fn node_id(&self) -> Result<String> {
+        let id = self.0.node_id();
+        Ok(id.to_string())
+    }
+
+    #[napi]
     pub async fn connect(&self, node_addr: NodeAddr, alpn: Uint8Array) -> Result<Connection> {
         let node_addr: iroh::net::NodeAddr = node_addr.try_into()?;
         let conn = self.0.connect(node_addr, &alpn).await?;

--- a/iroh.pyi
+++ b/iroh.pyi
@@ -1,0 +1,1 @@
+from .iroh_ffi import *  # NOQA

--- a/python/node_test.py
+++ b/python/node_test.py
@@ -1,10 +1,11 @@
 # tests that correspond to the `src/doc.rs` rust api
 import tempfile
+import iroh.iroh_ffi
 import pytest
 import asyncio
-import iroh
 
-from iroh import Iroh, ShareMode, LiveEventType, AddrInfoOptions, NodeOptions, NodeOptions, NodeAddr, PublicKey
+from iroh import Iroh, ShareMode, LiveEventType, AddrInfoOptions, NodeOptions
+
 
 @pytest.mark.asyncio
 async def test_basic_sync():
@@ -45,9 +46,9 @@ async def test_basic_sync():
     doc_1 = await node_1.docs().join_and_subscribe(ticket, cb1)
 
     # wait for initial sync
-    while (True):
+    while True:
         event = await found_s_1.get()
-        if (event.type() == LiveEventType.SYNC_FINISHED):
+        if event.type() == LiveEventType.SYNC_FINISHED:
             break
 
     # Create author on node_1
@@ -55,15 +56,16 @@ async def test_basic_sync():
     await doc_1.set_bytes(author, b"hello", b"world")
 
     # Wait for the content ready event
-    while (True):
+    while True:
         event = await found_s_0.get()
-        if (event.type() == LiveEventType.CONTENT_READY):
+        if event.type() == LiveEventType.CONTENT_READY:
             hash = event.as_content_ready()
 
             # Get content from hash
             val = await node_1.blobs().read_to_bytes(hash)
             assert b"world" == val
             break
+
 
 @pytest.mark.asyncio
 async def test_custom_protocol():
@@ -107,6 +109,8 @@ async def test_custom_protocol():
     node_addr = await node_1.net().node_addr()
 
     endpoint = node_2.node().endpoint()
+
+    assert endpoint.node_id() == await node_2.net().node_id()
 
     conn = await endpoint.connect(node_addr, alpn)
     remote = conn.get_remote_node_id()

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -16,6 +16,7 @@ impl Endpoint {
 
 #[uniffi::export]
 impl Endpoint {
+    #[uniffi::method]
     /// The string representation of this endpoint's NodeId.
     pub fn node_id(&self) -> Result<String, IrohError> {
         let id = self.0.node_id();

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -16,6 +16,12 @@ impl Endpoint {
 
 #[uniffi::export]
 impl Endpoint {
+    /// The string representation of this endpoint's NodeId.
+    pub fn node_id(&self) -> Result<String, IrohError> {
+        let id = self.0.node_id();
+        Ok(id.to_string())
+    }
+
     #[uniffi::method(async_runtime = "tokio")]
     pub async fn connect(
         &self,

--- a/src/node.rs
+++ b/src/node.rs
@@ -58,7 +58,7 @@ pub struct LatencyAndControlMsg {
 }
 
 // TODO: enable and use for `LatencyAndControlMsg.control_msg` field when iroh core makes this public
-/// The kinds of control messages that can be sent
+// The kinds of control messages that can be sent
 // pub use iroh::net::magicsock::ControlMsg;
 
 /// Information about a remote node


### PR DESCRIPTION
I needed this information, where I only have a reference to the Endpoint, rather than the `net` API. Question, should I then also add this to the other languages?

While I was at it, I also added the py.typed functionality to make static type checkers happy.

Fixes #200 