### PR TITLE
fix(swift): add macOS Info.plist to xcframework slice

### DIFF
--- a/Iroh.xcframework/macos-arm64/Iroh.framework/Info.plist
+++ b/Iroh.xcframework/macos-arm64/Iroh.framework/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>CFBundleDevelopmentRegion</key>
+        <string>en</string>
+        <key>CFBundleExecutable</key>
+        <string>Iroh</string>
+        <key>CFBundleIdentifier</key>
+        <string>com.user.Iroh</string>
+        <key>CFBundleInfoDictionaryVersion</key>
+        <string>6.0</string>
+        <key>CFBundleName</key>
+        <string>Iroh</string>
+        <key>CFBundlePackageType</key>
+        <string>FMWK</string>
+        <key>CFBundleShortVersionString</key>
+        <string>1.0</string>
+        <key>CFBundleVersion</key>
+        <string>0.0.1</string>
+        <key>NSPrincipalClass</key>
+        <string></string>
+    </dict>
+</plist>


### PR DESCRIPTION
## Summary

The macos-arm64 slice of the prebuilt xcframework shipped in `v1.0.0-rc.1`'s release zip is missing `Iroh.framework/Info.plist`. Both iOS slices include one; the macOS slice never did.

macOS app validation refuses to ship an app that embeds a framework without an Info.plist:

```
error: Framework .../HelloIroh.app/Contents/Frameworks/Iroh.framework did not contain an Info.plist
```

Repro: any downstream consumer that points at the v1.0.0-rc.1 SPM ref and builds for `platform=macOS`. iOS Simulator builds work today; macOS does not.

The `.gitignore` already unignores `!/Iroh.xcframework/*/Iroh.framework/Info.plist` for every slice; the file just wasn't checked in for macOS. Copied byte-for-byte from `ios-arm64/Iroh.framework/Info.plist`. Build scripts unchanged — `make_swift.sh` only writes the binary and the FFI header into the slice, so adding a tracked Info.plist is the right knob.

## Test plan

- [x] `cargo make swift-xcframework` + `bash scripts/release/zip_xcframework.sh` produces a zip whose macos-arm64 slice contains `Iroh.framework/Info.plist`.
- [x] A downstream Swift app consuming this branch via local SPM ref builds clean for `platform=macOS,arch=arm64`. (see https://github.com/n0-computer/mobile-pong-demo)
- [ ] iOS Simulator build still succeeds (unchanged path).
