### PR TITLE
feat: add preset_n0_with_mdns for local-network discovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 4
 
 [[package]]
+name = "acto"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598381761ee991bf2f1455f700380e2191fb370dc9df1ee764f348b7f089d8b6"
+dependencies = [
+ "parking_lot",
+ "pin-project-lite",
+ "rustc_version",
+ "smol_str",
+ "sync_wrapper",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "aead"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1756,9 +1771,9 @@ dependencies = [
  "iroh-dns",
  "iroh-metrics",
  "iroh-relay",
- "n0-error",
+ "n0-error 1.0.0-rc.0",
  "n0-future",
- "n0-watcher",
+ "n0-watcher 1.0.0-rc.0",
  "netwatch",
  "noq",
  "noq-proto",
@@ -1799,7 +1814,7 @@ dependencies = [
  "digest",
  "ed25519-dalek",
  "getrandom 0.4.2",
- "n0-error",
+ "n0-error 1.0.0-rc.0",
  "rand",
  "serde",
  "sha2",
@@ -1819,7 +1834,7 @@ dependencies = [
  "derive_more",
  "hickory-resolver",
  "iroh-base",
- "n0-error",
+ "n0-error 1.0.0-rc.0",
  "n0-future",
  "ndk-context",
  "rand",
@@ -1841,12 +1856,13 @@ dependencies = [
  "derive_more",
  "iroh",
  "iroh-base",
+ "iroh-mdns-address-lookup",
  "iroh-metrics",
  "iroh-relay",
  "iroh-services",
  "iroh-tickets",
  "jni 0.21.1",
- "n0-error",
+ "n0-error 1.0.0-rc.0",
  "n0-future",
  "ndk-context",
  "serde",
@@ -1860,6 +1876,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "iroh-mdns-address-lookup"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a68d7e131dd029cb533a4e79d819a2f0271b4af9a268d8ef25fd398c1191d83"
+dependencies = [
+ "data-encoding",
+ "derive_more",
+ "futures-util",
+ "iroh",
+ "iroh-base",
+ "n0-error 1.0.0-rc.0",
+ "n0-future",
+ "n0-watcher 0.6.1",
+ "swarm-discovery",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+]
+
+[[package]]
 name = "iroh-metrics"
 version = "1.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1867,7 +1903,7 @@ checksum = "d102597d0ee523f17fdb672c532395e634dbe945429284c811430d63bacc0d8a"
 dependencies = [
  "iroh-metrics-derive",
  "itoa",
- "n0-error",
+ "n0-error 1.0.0-rc.0",
  "portable-atomic",
  "ryu",
  "serde",
@@ -1907,7 +1943,7 @@ dependencies = [
  "iroh-dns",
  "iroh-metrics",
  "lru",
- "n0-error",
+ "n0-error 1.0.0-rc.0",
  "n0-future",
  "noq",
  "noq-proto",
@@ -1952,7 +1988,7 @@ dependencies = [
  "iroh-tickets",
  "irpc",
  "irpc-iroh",
- "n0-error",
+ "n0-error 1.0.0-rc.0",
  "n0-future",
  "portmapper",
  "postcard",
@@ -1977,7 +2013,7 @@ dependencies = [
  "data-encoding",
  "derive_more",
  "iroh-base",
- "n0-error",
+ "n0-error 1.0.0-rc.0",
  "postcard",
  "serde",
 ]
@@ -1991,7 +2027,7 @@ dependencies = [
  "futures-buffered",
  "futures-util",
  "irpc-derive",
- "n0-error",
+ "n0-error 1.0.0-rc.0",
  "n0-future",
  "noq",
  "postcard",
@@ -2025,7 +2061,7 @@ dependencies = [
  "iroh",
  "iroh-base",
  "irpc",
- "n0-error",
+ "n0-error 1.0.0-rc.0",
  "n0-future",
  "postcard",
  "serde",
@@ -2265,12 +2301,33 @@ dependencies = [
 
 [[package]]
 name = "n0-error"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af4782b4baf92d686d161c15460c83d16ebcfd215918763903e9619842665cae"
+dependencies = [
+ "n0-error-macros 0.1.3",
+ "spez",
+]
+
+[[package]]
+name = "n0-error"
 version = "1.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "223e946a84aa91644507a6b7865cfebbb9a231ace499041c747ab0fd30408212"
 dependencies = [
- "n0-error-macros",
+ "n0-error-macros 1.0.0-rc.0",
  "spez",
+]
+
+[[package]]
+name = "n0-error-macros"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03755949235714b2b307e5ae89dd8c1c2531fb127d9b8b7b4adf9c876cd3ed18"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2307,12 +2364,23 @@ dependencies = [
 
 [[package]]
 name = "n0-watcher"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38795f7932e6e9d1c6e989270ef5b3ff24ebb910e2c9d4bed2d28d8bae3007dc"
+dependencies = [
+ "derive_more",
+ "n0-error 0.1.3",
+ "n0-future",
+]
+
+[[package]]
+name = "n0-watcher"
 version = "1.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "928d8039a66cce5efcfd35e88b32d3defc8eba630b3ac451522997f563956a52"
 dependencies = [
  "derive_more",
- "n0-error",
+ "n0-error 1.0.0-rc.0",
  "n0-future",
 ]
 
@@ -2477,9 +2545,9 @@ dependencies = [
  "derive_more",
  "js-sys",
  "libc",
- "n0-error",
+ "n0-error 1.0.0-rc.0",
  "n0-future",
- "n0-watcher",
+ "n0-watcher 1.0.0-rc.0",
  "netdev",
  "netlink-packet-core",
  "netlink-packet-route 0.30.0",
@@ -2964,7 +3032,7 @@ dependencies = [
  "igd-next",
  "iroh-metrics",
  "libc",
- "n0-error",
+ "n0-error 1.0.0-rc.0",
  "n0-future",
  "netwatch",
  "num_enum",
@@ -3621,6 +3689,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 
 [[package]]
+name = "smol_str"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fad6c857cbab2627dcf01ec85a623ca4e7dcb5691cbaa3d7fb7653671f0d09c9"
+
+[[package]]
 name = "socket2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3716,6 +3790,21 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "swarm-discovery"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36ae41d2d4ad85250007d0f061fddeec5212a15d5c4abad52c475265775572ac"
+dependencies = [
+ "acto",
+ "hickory-proto",
+ "rand",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ anyhow = "1.0.69"
 async-trait = "0.1.80"
 iroh = { version = "=1.0.0-rc.1" }
 iroh-base = { version = "=1.0.0-rc.1" }
+iroh-mdns-address-lookup = "=0.3.0"
 iroh-metrics = { version = "=1.0.0-rc.0" }
 iroh-relay = { version = "=1.0.0-rc.1", default-features = false }
 iroh-services = { version = "=1.0.0-rc.2", default-features = false }

--- a/Iroh.xcframework/ios-arm64/Iroh.framework/Headers/iroh_ffiFFI.h
+++ b/Iroh.xcframework/ios-arm64/Iroh.framework/Headers/iroh_ffiFFI.h
@@ -742,6 +742,11 @@ void uniffi_iroh_ffi_fn_free_endpointbuilder(uint64_t handle, RustCallStatus *_N
 void uniffi_iroh_ffi_fn_method_endpointbuilder_alpns(uint64_t ptr, RustBuffer alpns, RustCallStatus *_Nonnull out_status
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_ENDPOINTBUILDER_APPLY_MDNS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_ENDPOINTBUILDER_APPLY_MDNS
+void uniffi_iroh_ffi_fn_method_endpointbuilder_apply_mdns(uint64_t ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_ENDPOINTBUILDER_APPLY_MINIMAL
 #define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_ENDPOINTBUILDER_APPLY_MINIMAL
 void uniffi_iroh_ffi_fn_method_endpointbuilder_apply_minimal(uint64_t ptr, RustCallStatus *_Nonnull out_status
@@ -1450,6 +1455,12 @@ uint64_t uniffi_iroh_ffi_fn_func_preset_n0_disable_relay(RustCallStatus *_Nonnul
     
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_FUNC_PRESET_N0_WITH_MDNS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_FUNC_PRESET_N0_WITH_MDNS
+uint64_t uniffi_iroh_ffi_fn_func_preset_n0_with_mdns(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
 #ifndef UNIFFI_FFIDEF_FFI_IROH_FFI_RUSTBUFFER_ALLOC
 #define UNIFFI_FFIDEF_FFI_IROH_FFI_RUSTBUFFER_ALLOC
 RustBuffer ffi_iroh_ffi_rustbuffer_alloc(uint64_t size, RustCallStatus *_Nonnull out_status
@@ -1731,6 +1742,12 @@ uint16_t uniffi_iroh_ffi_checksum_func_preset_n0(void
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_FUNC_PRESET_N0_DISABLE_RELAY
 #define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_FUNC_PRESET_N0_DISABLE_RELAY
 uint16_t uniffi_iroh_ffi_checksum_func_preset_n0_disable_relay(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_FUNC_PRESET_N0_WITH_MDNS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_FUNC_PRESET_N0_WITH_MDNS
+uint16_t uniffi_iroh_ffi_checksum_func_preset_n0_with_mdns(void
     
 );
 #endif
@@ -2085,6 +2102,12 @@ uint16_t uniffi_iroh_ffi_checksum_method_endpoint_watch_network_change(void
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_ENDPOINTBUILDER_ALPNS
 #define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_ENDPOINTBUILDER_ALPNS
 uint16_t uniffi_iroh_ffi_checksum_method_endpointbuilder_alpns(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_ENDPOINTBUILDER_APPLY_MDNS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_ENDPOINTBUILDER_APPLY_MDNS
+uint16_t uniffi_iroh_ffi_checksum_method_endpointbuilder_apply_mdns(void
     
 );
 #endif

--- a/Iroh.xcframework/ios-arm64_x86_64-simulator/Iroh.framework/Headers/iroh_ffiFFI.h
+++ b/Iroh.xcframework/ios-arm64_x86_64-simulator/Iroh.framework/Headers/iroh_ffiFFI.h
@@ -742,6 +742,11 @@ void uniffi_iroh_ffi_fn_free_endpointbuilder(uint64_t handle, RustCallStatus *_N
 void uniffi_iroh_ffi_fn_method_endpointbuilder_alpns(uint64_t ptr, RustBuffer alpns, RustCallStatus *_Nonnull out_status
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_ENDPOINTBUILDER_APPLY_MDNS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_ENDPOINTBUILDER_APPLY_MDNS
+void uniffi_iroh_ffi_fn_method_endpointbuilder_apply_mdns(uint64_t ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_ENDPOINTBUILDER_APPLY_MINIMAL
 #define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_ENDPOINTBUILDER_APPLY_MINIMAL
 void uniffi_iroh_ffi_fn_method_endpointbuilder_apply_minimal(uint64_t ptr, RustCallStatus *_Nonnull out_status
@@ -1450,6 +1455,12 @@ uint64_t uniffi_iroh_ffi_fn_func_preset_n0_disable_relay(RustCallStatus *_Nonnul
     
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_FUNC_PRESET_N0_WITH_MDNS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_FUNC_PRESET_N0_WITH_MDNS
+uint64_t uniffi_iroh_ffi_fn_func_preset_n0_with_mdns(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
 #ifndef UNIFFI_FFIDEF_FFI_IROH_FFI_RUSTBUFFER_ALLOC
 #define UNIFFI_FFIDEF_FFI_IROH_FFI_RUSTBUFFER_ALLOC
 RustBuffer ffi_iroh_ffi_rustbuffer_alloc(uint64_t size, RustCallStatus *_Nonnull out_status
@@ -1731,6 +1742,12 @@ uint16_t uniffi_iroh_ffi_checksum_func_preset_n0(void
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_FUNC_PRESET_N0_DISABLE_RELAY
 #define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_FUNC_PRESET_N0_DISABLE_RELAY
 uint16_t uniffi_iroh_ffi_checksum_func_preset_n0_disable_relay(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_FUNC_PRESET_N0_WITH_MDNS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_FUNC_PRESET_N0_WITH_MDNS
+uint16_t uniffi_iroh_ffi_checksum_func_preset_n0_with_mdns(void
     
 );
 #endif
@@ -2085,6 +2102,12 @@ uint16_t uniffi_iroh_ffi_checksum_method_endpoint_watch_network_change(void
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_ENDPOINTBUILDER_ALPNS
 #define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_ENDPOINTBUILDER_ALPNS
 uint16_t uniffi_iroh_ffi_checksum_method_endpointbuilder_alpns(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_ENDPOINTBUILDER_APPLY_MDNS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_ENDPOINTBUILDER_APPLY_MDNS
+uint16_t uniffi_iroh_ffi_checksum_method_endpointbuilder_apply_mdns(void
     
 );
 #endif

--- a/Iroh.xcframework/macos-arm64/Iroh.framework/Headers/iroh_ffiFFI.h
+++ b/Iroh.xcframework/macos-arm64/Iroh.framework/Headers/iroh_ffiFFI.h
@@ -742,6 +742,11 @@ void uniffi_iroh_ffi_fn_free_endpointbuilder(uint64_t handle, RustCallStatus *_N
 void uniffi_iroh_ffi_fn_method_endpointbuilder_alpns(uint64_t ptr, RustBuffer alpns, RustCallStatus *_Nonnull out_status
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_ENDPOINTBUILDER_APPLY_MDNS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_ENDPOINTBUILDER_APPLY_MDNS
+void uniffi_iroh_ffi_fn_method_endpointbuilder_apply_mdns(uint64_t ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_ENDPOINTBUILDER_APPLY_MINIMAL
 #define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_METHOD_ENDPOINTBUILDER_APPLY_MINIMAL
 void uniffi_iroh_ffi_fn_method_endpointbuilder_apply_minimal(uint64_t ptr, RustCallStatus *_Nonnull out_status
@@ -1450,6 +1455,12 @@ uint64_t uniffi_iroh_ffi_fn_func_preset_n0_disable_relay(RustCallStatus *_Nonnul
     
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_FUNC_PRESET_N0_WITH_MDNS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_FN_FUNC_PRESET_N0_WITH_MDNS
+uint64_t uniffi_iroh_ffi_fn_func_preset_n0_with_mdns(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
 #ifndef UNIFFI_FFIDEF_FFI_IROH_FFI_RUSTBUFFER_ALLOC
 #define UNIFFI_FFIDEF_FFI_IROH_FFI_RUSTBUFFER_ALLOC
 RustBuffer ffi_iroh_ffi_rustbuffer_alloc(uint64_t size, RustCallStatus *_Nonnull out_status
@@ -1731,6 +1742,12 @@ uint16_t uniffi_iroh_ffi_checksum_func_preset_n0(void
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_FUNC_PRESET_N0_DISABLE_RELAY
 #define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_FUNC_PRESET_N0_DISABLE_RELAY
 uint16_t uniffi_iroh_ffi_checksum_func_preset_n0_disable_relay(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_FUNC_PRESET_N0_WITH_MDNS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_FUNC_PRESET_N0_WITH_MDNS
+uint16_t uniffi_iroh_ffi_checksum_func_preset_n0_with_mdns(void
     
 );
 #endif
@@ -2085,6 +2102,12 @@ uint16_t uniffi_iroh_ffi_checksum_method_endpoint_watch_network_change(void
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_ENDPOINTBUILDER_ALPNS
 #define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_ENDPOINTBUILDER_ALPNS
 uint16_t uniffi_iroh_ffi_checksum_method_endpointbuilder_alpns(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_ENDPOINTBUILDER_APPLY_MDNS
+#define UNIFFI_FFIDEF_UNIFFI_IROH_FFI_CHECKSUM_METHOD_ENDPOINTBUILDER_APPLY_MDNS
+uint16_t uniffi_iroh_ffi_checksum_method_endpointbuilder_apply_mdns(void
     
 );
 #endif

--- a/IrohLib/Sources/IrohLib/IrohLib.swift
+++ b/IrohLib/Sources/IrohLib/IrohLib.swift
@@ -2691,6 +2691,18 @@ public protocol EndpointBuilderProtocol: AnyObject, Sendable {
     func alpns(alpns: [Data]) 
     
     /**
+     * Add mDNS address lookup to the builder.
+     *
+     * Stacks on top of any previously configured address lookups (most
+     * commonly the n0 DNS lookup installed by [`apply_n0`]); it does not
+     * replace them. Use [`preset_n0_with_mdns`] for the typical
+     * "n0 defaults plus same-WiFi discovery" combination.
+     *
+     * [`apply_n0`]: EndpointBuilder::apply_n0
+     */
+    func applyMdns() 
+    
+    /**
      * Replay the minimal preset (crypto provider only, no external deps).
      */
     func applyMinimal() 
@@ -2790,6 +2802,23 @@ open func alpns(alpns: [Data])  {try! rustCall() {
     uniffi_iroh_ffi_fn_method_endpointbuilder_alpns(
             self.uniffiCloneHandle(),
         FfiConverterSequenceData.lower(alpns),$0
+    )
+}
+}
+    
+    /**
+     * Add mDNS address lookup to the builder.
+     *
+     * Stacks on top of any previously configured address lookups (most
+     * commonly the n0 DNS lookup installed by [`apply_n0`]); it does not
+     * replace them. Use [`preset_n0_with_mdns`] for the typical
+     * "n0 defaults plus same-WiFi discovery" combination.
+     *
+     * [`apply_n0`]: EndpointBuilder::apply_n0
+     */
+open func applyMdns()  {try! rustCall() {
+    uniffi_iroh_ffi_fn_method_endpointbuilder_apply_mdns(
+            self.uniffiCloneHandle(),$0
     )
 }
 }
@@ -9168,6 +9197,19 @@ public func presetN0DisableRelay() -> Preset  {
     )
 })
 }
+/**
+ * The n0 production preset with mDNS-based local address lookup added.
+ *
+ * Same as [`preset_n0`] plus an [`MdnsAddressLookup`] that publishes and
+ * resolves addresses over the local network. Useful when peers share a
+ * WiFi and the public DNS-based lookup is slow or unreachable.
+ */
+public func presetN0WithMdns() -> Preset  {
+    return try!  FfiConverterTypePreset_lift(try! rustCall() {
+    uniffi_iroh_ffi_fn_func_preset_n0_with_mdns($0
+    )
+})
+}
 
 private enum InitializationResult {
     case ok
@@ -9194,6 +9236,9 @@ private let initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_iroh_ffi_checksum_func_preset_n0_disable_relay() != 45395) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iroh_ffi_checksum_func_preset_n0_with_mdns() != 41224) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_iroh_ffi_checksum_method_accepting_alpn() != 1935) {
@@ -9371,6 +9416,9 @@ private let initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_iroh_ffi_checksum_method_endpointbuilder_alpns() != 55626) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iroh_ffi_checksum_method_endpointbuilder_apply_mdns() != 60588) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_iroh_ffi_checksum_method_endpointbuilder_apply_minimal() != 3398) {

--- a/kotlin/lib/src/main/kotlin/computer/iroh/iroh_ffi.kt
+++ b/kotlin/lib/src/main/kotlin/computer/iroh/iroh_ffi.kt
@@ -1006,6 +1006,8 @@ internal object IntegrityCheckingUniffiLib {
 
     external fun uniffi_iroh_ffi_checksum_func_preset_n0_disable_relay(): Short
 
+    external fun uniffi_iroh_ffi_checksum_func_preset_n0_with_mdns(): Short
+
     external fun uniffi_iroh_ffi_checksum_method_accepting_alpn(): Short
 
     external fun uniffi_iroh_ffi_checksum_method_accepting_connect(): Short
@@ -1123,6 +1125,8 @@ internal object IntegrityCheckingUniffiLib {
     external fun uniffi_iroh_ffi_checksum_method_endpoint_watch_network_change(): Short
 
     external fun uniffi_iroh_ffi_checksum_method_endpointbuilder_alpns(): Short
+
+    external fun uniffi_iroh_ffi_checksum_method_endpointbuilder_apply_mdns(): Short
 
     external fun uniffi_iroh_ffi_checksum_method_endpointbuilder_apply_minimal(): Short
 
@@ -1607,6 +1611,11 @@ internal object UniffiLib {
     external fun uniffi_iroh_ffi_fn_method_endpointbuilder_alpns(
         `ptr`: Long,
         `alpns`: RustBuffer.ByValue,
+        uniffi_out_err: UniffiRustCallStatus,
+    ): Unit
+
+    external fun uniffi_iroh_ffi_fn_method_endpointbuilder_apply_mdns(
+        `ptr`: Long,
         uniffi_out_err: UniffiRustCallStatus,
     ): Unit
 
@@ -2245,6 +2254,8 @@ internal object UniffiLib {
 
     external fun uniffi_iroh_ffi_fn_func_preset_n0_disable_relay(uniffi_out_err: UniffiRustCallStatus): Long
 
+    external fun uniffi_iroh_ffi_fn_func_preset_n0_with_mdns(uniffi_out_err: UniffiRustCallStatus): Long
+
     external fun ffi_iroh_ffi_rustbuffer_alloc(
         `size`: Long,
         uniffi_out_err: UniffiRustCallStatus,
@@ -2471,6 +2482,9 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
     if (lib.uniffi_iroh_ffi_checksum_func_preset_n0_disable_relay() != 45395.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
+    if (lib.uniffi_iroh_ffi_checksum_func_preset_n0_with_mdns() != 41224.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
     if (lib.uniffi_iroh_ffi_checksum_method_accepting_alpn() != 1935.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
@@ -2646,6 +2660,9 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_iroh_ffi_checksum_method_endpointbuilder_alpns() != 55626.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_iroh_ffi_checksum_method_endpointbuilder_apply_mdns() != 60588.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_iroh_ffi_checksum_method_endpointbuilder_apply_minimal() != 3398.toShort()) {
@@ -6600,6 +6617,18 @@ public interface EndpointBuilderInterface {
     fun `alpns`(`alpns`: List<kotlin.ByteArray>)
 
     /**
+     * Add mDNS address lookup to the builder.
+     *
+     * Stacks on top of any previously configured address lookups (most
+     * commonly the n0 DNS lookup installed by [`apply_n0`]); it does not
+     * replace them. Use [`preset_n0_with_mdns`] for the typical
+     * "n0 defaults plus same-WiFi discovery" combination.
+     *
+     * [`apply_n0`]: EndpointBuilder::apply_n0
+     */
+    fun `applyMdns`()
+
+    /**
      * Replay the minimal preset (crypto provider only, no external deps).
      */
     fun `applyMinimal`()
@@ -6749,6 +6778,26 @@ open class EndpointBuilder :
                 UniffiLib.uniffi_iroh_ffi_fn_method_endpointbuilder_alpns(
                     it,
                     FfiConverterSequenceByteArray.lower(`alpns`),
+                    _status,
+                )
+            }
+        }
+
+    /**
+     * Add mDNS address lookup to the builder.
+     *
+     * Stacks on top of any previously configured address lookups (most
+     * commonly the n0 DNS lookup installed by [`apply_n0`]); it does not
+     * replace them. Use [`preset_n0_with_mdns`] for the typical
+     * "n0 defaults plus same-WiFi discovery" combination.
+     *
+     * [`apply_n0`]: EndpointBuilder::apply_n0
+     */
+    override fun `applyMdns`() =
+        callWithHandle {
+            uniffiRustCall { _status ->
+                UniffiLib.uniffi_iroh_ffi_fn_method_endpointbuilder_apply_mdns(
+                    it,
                     _status,
                 )
             }
@@ -15067,5 +15116,19 @@ fun `presetN0DisableRelay`(): Preset =
     FfiConverterTypePreset.lift(
         uniffiRustCall { _status ->
             UniffiLib.uniffi_iroh_ffi_fn_func_preset_n0_disable_relay(_status)
+        },
+    )
+
+/**
+ * The n0 production preset with mDNS-based local address lookup added.
+ *
+ * Same as [`preset_n0`] plus an [`MdnsAddressLookup`] that publishes and
+ * resolves addresses over the local network. Useful when peers share a
+ * WiFi and the public DNS-based lookup is slow or unreachable.
+ */
+fun `presetN0WithMdns`(): Preset =
+    FfiConverterTypePreset.lift(
+        uniffiRustCall { _status ->
+            UniffiLib.uniffi_iroh_ffi_fn_func_preset_n0_with_mdns(_status)
         },
     )

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -4,6 +4,7 @@ use iroh::{
     endpoint::{self, presets, presets::Preset as _},
     protocol::AcceptError,
 };
+use iroh_mdns_address_lookup::MdnsAddressLookup;
 use tokio::sync::Mutex;
 
 use crate::{
@@ -64,6 +65,18 @@ impl EndpointBuilder {
     /// Replay the n0 preset with relays disabled.
     pub fn apply_n0_disable_relay(&self) {
         self.map(|b| presets::N0DisableRelay.apply(b));
+    }
+
+    /// Add mDNS address lookup to the builder.
+    ///
+    /// Stacks on top of any previously configured address lookups (most
+    /// commonly the n0 DNS lookup installed by [`apply_n0`]); it does not
+    /// replace them. Use [`preset_n0_with_mdns`] for the typical
+    /// "n0 defaults plus same-WiFi discovery" combination.
+    ///
+    /// [`apply_n0`]: EndpointBuilder::apply_n0
+    pub fn apply_mdns(&self) {
+        self.map(|b| b.address_lookup(MdnsAddressLookup::builder()));
     }
 
     /// Set the endpoint secret key (32 bytes).
@@ -132,6 +145,14 @@ impl Preset for N0DisableRelayPreset {
     }
 }
 
+struct N0WithMdnsPreset;
+impl Preset for N0WithMdnsPreset {
+    fn apply(&self, builder: Arc<EndpointBuilder>) {
+        builder.apply_n0();
+        builder.apply_mdns();
+    }
+}
+
 /// The n0 production preset (relays + discovery).
 #[uniffi::export]
 pub fn preset_n0() -> Arc<dyn Preset> {
@@ -148,6 +169,16 @@ pub fn preset_minimal() -> Arc<dyn Preset> {
 #[uniffi::export]
 pub fn preset_n0_disable_relay() -> Arc<dyn Preset> {
     Arc::new(N0DisableRelayPreset)
+}
+
+/// The n0 production preset with mDNS-based local address lookup added.
+///
+/// Same as [`preset_n0`] plus an [`MdnsAddressLookup`] that publishes and
+/// resolves addresses over the local network. Useful when peers share a
+/// WiFi and the public DNS-based lookup is slow or unreachable.
+#[uniffi::export]
+pub fn preset_n0_with_mdns() -> Arc<dyn Preset> {
+    Arc::new(N0WithMdnsPreset)
 }
 
 /// Options passed to [`Endpoint::bind`].
@@ -862,6 +893,19 @@ mod tests {
     async fn test_custom_preset() {
         let ep = Endpoint::bind(EndpointOptions {
             preset: Some(Arc::new(CustomPreset)),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+        assert!(!ep.bound_sockets().is_empty());
+        ep.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_bind_with_mdns_preset() {
+        let ep = Endpoint::bind(EndpointOptions {
+            preset: Some(crate::preset_n0_with_mdns()),
+            relay_mode: Some(Arc::new(RelayMode::disabled())),
             ..Default::default()
         })
         .await


### PR DESCRIPTION
The n0 preset wires up DNS-based discovery via iroh.link, which fails on networks where the system resolver is uninitialised or the zone is filtered, even when both peers share a WiFi. This adds `preset_n0_with_mdns()` (surfaced as `presetN0WithMdns()` in Swift and Kotlin), which layers the mDNS address lookup from `iroh-mdns-address-lookup` on top of the n0 defaults so same-LAN peers can find each other without the public DNS path. A matching `apply_mdns()` builder method lets callers composing their own presets opt in individually.

The second commit is regenerated bindings only (`cargo make bindgen-kotlin` plus the uniffi-bindgen swift steps from `make_swift.sh`); the xcframework binaries stay gitignored.

Note for app developers: enabling mDNS on iOS requires `NSLocalNetworkUsageDescription` in Info.plist and the `com.apple.developer.networking.multicast` entitlement. Plain unicast iroh traffic needs neither; docs covering this are in [n0-computer/docs.iroh.computer#64.](https://github.com/n0-computer/docs.iroh.computer/pull/64)
