### PR TITLE
feat: serve remote network diagnostics from the FFI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1845,6 +1845,8 @@ dependencies = [
  "iroh-relay",
  "iroh-services",
  "iroh-tickets",
+ "irpc",
+ "irpc-iroh",
  "jni 0.21.1",
  "n0-error",
  "n0-future",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,8 @@ n0-future = "0.3"
 
 
 [dev-dependencies]
+irpc = "0.16"
+irpc-iroh = "0.16"
 tempfile = "3.4"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 tokio = { version = "1", features = ["full"] }

--- a/iroh-js/index.d.ts
+++ b/iroh-js/index.d.ts
@@ -12,6 +12,38 @@ export declare class BiStream {
   get recv(): RecvStream
 }
 
+/**
+ * Serves the iroh-services dial-back protocol on an endpoint.
+ *
+ * The platform connects on `clientHostAlpn()` to run network diagnostics on
+ * demand (the dashboard's Run Diagnostics button). Incoming requests must
+ * present a capability token issued by this endpoint; pair with
+ * `ServicesOptions.remoteDiagnostics`, which grants that token to the
+ * platform.
+ *
+ * Construct one `ClientHost` and, in the accept loop, call
+ * `handleConnection` for each connection whose ALPN equals
+ * `clientHostAlpn()`.
+ *
+ * Like any served protocol, the ALPN is an open accept surface: anyone can
+ * connect, but requests without a capability token issued by this endpoint
+ * are rejected before diagnostics run.
+ */
+export declare class ClientHost {
+  /** Create a host serving diagnostics for the given endpoint. */
+  constructor(endpoint: Endpoint)
+  /**
+   * Serve one accepted dial-back connection to completion.
+   *
+   * The returned promise resolves only once the remote closes the
+   * connection, which can take tens of seconds while diagnostics run. Do
+   * not await it inline in an accept loop; let it run concurrently
+   * (`host.handleConnection(conn).catch(...)`) so the loop keeps
+   * accepting.
+   */
+  handleConnection(conn: Connection): Promise<void>
+}
+
 /** A client-side handshake in progress. */
 export declare class Connecting {
   connect(): Promise<Connection>
@@ -303,6 +335,9 @@ export declare class WatchHandle {
   stop(): Promise<void>
 }
 
+/** The ALPN of the iroh-services dial-back protocol served by `ClientHost`. */
+export declare function clientHostAlpn(): Array<number>
+
 /** Flat snapshot of headline connection statistics. */
 export interface ConnectionStats {
   udpTxDatagrams: number
@@ -444,6 +479,21 @@ export interface ServicesOptions {
   name?: string
   /** Metrics push interval (ms). `0` disables interval pushes. */
   metricsIntervalMs?: number
+  /**
+   * When true, let the iroh-services platform run network diagnostics
+   * against this endpoint on demand: `create` grants the net-diagnostics
+   * capability to the platform endpoint named in the API secret. Requires
+   * an api-secret credential. The endpoint must also serve the dial-back
+   * protocol; see `ClientHost`.
+   *
+   * The grant is best-effort: it runs in the background and is retried
+   * until it succeeds or the client is dropped; failures are logged, not
+   * surfaced. Each grant is valid for 30 days and re-issued on every
+   * client creation. A diagnostics run shares the endpoint's network
+   * details (direct addresses, NAT characteristics, relay latencies) with
+   * the platform.
+   */
+  remoteDiagnostics?: boolean
 }
 
 /** Set the logging level. */

--- a/iroh-js/index.js
+++ b/iroh-js/index.js
@@ -77,8 +77,8 @@ function requireNative() {
       try {
         const binding = require('@number0/iroh-android-arm64')
         const bindingPackageVersion = require('@number0/iroh-android-arm64/package.json').version
-        if (bindingPackageVersion !== '0.35.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.35.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.0-rc.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.0-rc.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -93,8 +93,8 @@ function requireNative() {
       try {
         const binding = require('@number0/iroh-android-arm-eabi')
         const bindingPackageVersion = require('@number0/iroh-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '0.35.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.35.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.0-rc.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.0-rc.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -114,8 +114,8 @@ function requireNative() {
       try {
         const binding = require('@number0/iroh-win32-x64-gnu')
         const bindingPackageVersion = require('@number0/iroh-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.35.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.35.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.0-rc.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.0-rc.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -130,8 +130,8 @@ function requireNative() {
       try {
         const binding = require('@number0/iroh-win32-x64-msvc')
         const bindingPackageVersion = require('@number0/iroh-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.35.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.35.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.0-rc.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.0-rc.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -147,8 +147,8 @@ function requireNative() {
       try {
         const binding = require('@number0/iroh-win32-ia32-msvc')
         const bindingPackageVersion = require('@number0/iroh-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '0.35.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.35.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.0-rc.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.0-rc.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -163,8 +163,8 @@ function requireNative() {
       try {
         const binding = require('@number0/iroh-win32-arm64-msvc')
         const bindingPackageVersion = require('@number0/iroh-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.35.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.35.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.0-rc.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.0-rc.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -182,8 +182,8 @@ function requireNative() {
     try {
       const binding = require('@number0/iroh-darwin-universal')
       const bindingPackageVersion = require('@number0/iroh-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '0.35.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 0.35.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '1.0.0-rc.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 1.0.0-rc.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -198,8 +198,8 @@ function requireNative() {
       try {
         const binding = require('@number0/iroh-darwin-x64')
         const bindingPackageVersion = require('@number0/iroh-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '0.35.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.35.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.0-rc.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.0-rc.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -214,8 +214,8 @@ function requireNative() {
       try {
         const binding = require('@number0/iroh-darwin-arm64')
         const bindingPackageVersion = require('@number0/iroh-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '0.35.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.35.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.0-rc.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.0-rc.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -234,8 +234,8 @@ function requireNative() {
       try {
         const binding = require('@number0/iroh-freebsd-x64')
         const bindingPackageVersion = require('@number0/iroh-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '0.35.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.35.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.0-rc.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.0-rc.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -250,8 +250,8 @@ function requireNative() {
       try {
         const binding = require('@number0/iroh-freebsd-arm64')
         const bindingPackageVersion = require('@number0/iroh-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '0.35.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.35.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.0-rc.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.0-rc.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -271,8 +271,8 @@ function requireNative() {
         try {
           const binding = require('@number0/iroh-linux-x64-musl')
           const bindingPackageVersion = require('@number0/iroh-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '0.35.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.35.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.0.0-rc.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.0.0-rc.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -287,8 +287,8 @@ function requireNative() {
         try {
           const binding = require('@number0/iroh-linux-x64-gnu')
           const bindingPackageVersion = require('@number0/iroh-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.35.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.35.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.0.0-rc.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.0.0-rc.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -305,8 +305,8 @@ function requireNative() {
         try {
           const binding = require('@number0/iroh-linux-arm64-musl')
           const bindingPackageVersion = require('@number0/iroh-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '0.35.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.35.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.0.0-rc.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.0.0-rc.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -321,8 +321,8 @@ function requireNative() {
         try {
           const binding = require('@number0/iroh-linux-arm64-gnu')
           const bindingPackageVersion = require('@number0/iroh-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.35.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.35.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.0.0-rc.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.0.0-rc.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -339,8 +339,8 @@ function requireNative() {
         try {
           const binding = require('@number0/iroh-linux-arm-musleabihf')
           const bindingPackageVersion = require('@number0/iroh-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '0.35.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.35.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.0.0-rc.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.0.0-rc.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -355,8 +355,8 @@ function requireNative() {
         try {
           const binding = require('@number0/iroh-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@number0/iroh-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '0.35.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.35.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.0.0-rc.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.0.0-rc.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -373,8 +373,8 @@ function requireNative() {
         try {
           const binding = require('@number0/iroh-linux-loong64-musl')
           const bindingPackageVersion = require('@number0/iroh-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '0.35.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.35.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.0.0-rc.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.0.0-rc.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -389,8 +389,8 @@ function requireNative() {
         try {
           const binding = require('@number0/iroh-linux-loong64-gnu')
           const bindingPackageVersion = require('@number0/iroh-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.35.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.35.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.0.0-rc.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.0.0-rc.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -407,8 +407,8 @@ function requireNative() {
         try {
           const binding = require('@number0/iroh-linux-riscv64-musl')
           const bindingPackageVersion = require('@number0/iroh-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '0.35.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.35.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.0.0-rc.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.0.0-rc.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -423,8 +423,8 @@ function requireNative() {
         try {
           const binding = require('@number0/iroh-linux-riscv64-gnu')
           const bindingPackageVersion = require('@number0/iroh-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.35.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.35.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.0.0-rc.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.0.0-rc.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -440,8 +440,8 @@ function requireNative() {
       try {
         const binding = require('@number0/iroh-linux-ppc64-gnu')
         const bindingPackageVersion = require('@number0/iroh-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.35.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.35.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.0-rc.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.0-rc.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -456,8 +456,8 @@ function requireNative() {
       try {
         const binding = require('@number0/iroh-linux-s390x-gnu')
         const bindingPackageVersion = require('@number0/iroh-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '0.35.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.35.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.0-rc.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.0-rc.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -476,8 +476,8 @@ function requireNative() {
       try {
         const binding = require('@number0/iroh-openharmony-arm64')
         const bindingPackageVersion = require('@number0/iroh-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '0.35.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.35.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.0-rc.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.0-rc.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -492,8 +492,8 @@ function requireNative() {
       try {
         const binding = require('@number0/iroh-openharmony-x64')
         const bindingPackageVersion = require('@number0/iroh-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '0.35.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.35.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.0-rc.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.0-rc.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -508,8 +508,8 @@ function requireNative() {
       try {
         const binding = require('@number0/iroh-openharmony-arm')
         const bindingPackageVersion = require('@number0/iroh-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '0.35.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.35.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.0-rc.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.0-rc.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -525,23 +525,33 @@ function requireNative() {
 
 nativeBinding = requireNative()
 
-if (!nativeBinding || process.env.NAPI_RS_FORCE_WASI) {
+// NAPI_RS_FORCE_WASI is a tri-state flag:
+//   unset / any other value → native binding preferred, WASI is only a fallback
+//   'true'                   → force WASI fallback even if native loaded
+//   'error'                  → force WASI and throw if no WASI binding is found
+// Treating any non-empty string as truthy (the historical behavior) meant
+// NAPI_RS_FORCE_WASI=false, NAPI_RS_FORCE_WASI=0, etc. inadvertently triggered
+// the WASI path, causing ENOENT for packages shipped without a .wasi.cjs file.
+const forceWasi =
+  process.env.NAPI_RS_FORCE_WASI === 'true' || process.env.NAPI_RS_FORCE_WASI === 'error'
+
+if (!nativeBinding || forceWasi) {
   let wasiBinding = null
   let wasiBindingError = null
   try {
     wasiBinding = require('./iroh.wasi.cjs')
     nativeBinding = wasiBinding
   } catch (err) {
-    if (process.env.NAPI_RS_FORCE_WASI) {
+    if (forceWasi) {
       wasiBindingError = err
     }
   }
-  if (!nativeBinding || process.env.NAPI_RS_FORCE_WASI) {
+  if (!nativeBinding || forceWasi) {
     try {
       wasiBinding = require('@number0/iroh-wasm32-wasi')
       nativeBinding = wasiBinding
     } catch (err) {
-      if (process.env.NAPI_RS_FORCE_WASI) {
+      if (forceWasi) {
         if (!wasiBindingError) {
           wasiBindingError = err
         } else {
@@ -578,6 +588,7 @@ if (!nativeBinding) {
 module.exports = nativeBinding
 module.exports.Accepting = nativeBinding.Accepting
 module.exports.BiStream = nativeBinding.BiStream
+module.exports.ClientHost = nativeBinding.ClientHost
 module.exports.Connecting = nativeBinding.Connecting
 module.exports.Connection = nativeBinding.Connection
 module.exports.Endpoint = nativeBinding.Endpoint
@@ -594,6 +605,7 @@ module.exports.SendStream = nativeBinding.SendStream
 module.exports.ServicesClient = nativeBinding.ServicesClient
 module.exports.Signature = nativeBinding.Signature
 module.exports.WatchHandle = nativeBinding.WatchHandle
+module.exports.clientHostAlpn = nativeBinding.clientHostAlpn
 module.exports.LogLevel = nativeBinding.LogLevel
 module.exports.PathEventKind = nativeBinding.PathEventKind
 module.exports.presetMinimal = nativeBinding.presetMinimal

--- a/iroh-js/src/endpoint.rs
+++ b/iroh-js/src/endpoint.rs
@@ -634,6 +634,12 @@ impl Connecting {
 #[napi]
 pub struct Connection(Arc<endpoint::Connection>);
 
+impl Connection {
+    pub(crate) fn raw(&self) -> &endpoint::Connection {
+        &self.0
+    }
+}
+
 #[napi]
 impl Connection {
     #[napi]

--- a/iroh-js/src/services.rs
+++ b/iroh-js/src/services.rs
@@ -1,10 +1,13 @@
-use std::time::Duration;
+use std::{str::FromStr, time::Duration};
 
-use iroh_services::{Client, ClientBuilder};
+use iroh::protocol::ProtocolHandler as _;
+use iroh_services::{ApiSecret, Client, ClientBuilder, caps::NetDiagnosticsCap};
+use n0_future::task::AbortOnDropHandle;
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
+use tracing::warn;
 
-use crate::Endpoint;
+use crate::{Connection, Endpoint};
 
 /// Build options for [`ServicesClient`].
 #[derive(Debug, Default)]
@@ -20,6 +23,19 @@ pub struct ServicesOptions {
     pub name: Option<String>,
     /// Metrics push interval (ms). `0` disables interval pushes.
     pub metrics_interval_ms: Option<i64>,
+    /// When true, let the iroh-services platform run network diagnostics
+    /// against this endpoint on demand: `create` grants the net-diagnostics
+    /// capability to the platform endpoint named in the API secret. Requires
+    /// an api-secret credential. The endpoint must also serve the dial-back
+    /// protocol; see `ClientHost`.
+    ///
+    /// The grant is best-effort: it runs in the background and is retried
+    /// until it succeeds or the client is dropped; failures are logged, not
+    /// surfaced. Each grant is valid for 30 days and re-issued on every
+    /// client creation. A diagnostics run shares the endpoint's network
+    /// details (direct addresses, NAT characteristics, relay latencies) with
+    /// the platform.
+    pub remote_diagnostics: Option<bool>,
 }
 
 /// Flattened summary of an `iroh_services` diagnostics report.
@@ -59,6 +75,9 @@ impl From<iroh_services::net_diagnostics::DiagnosticsReport> for DiagnosticsSumm
 #[napi]
 pub struct ServicesClient {
     inner: Client,
+    /// Owns the background capability-grant task spawned by `create` when
+    /// `remote_diagnostics` is set; aborted when the client is dropped.
+    _grant_task: Option<AbortOnDropHandle<()>>,
 }
 
 #[napi]
@@ -83,14 +102,33 @@ impl ServicesClient {
             .into());
         }
 
+        // The grant target is the platform endpoint named in the API secret,
+        // so remote diagnostics cannot work with an ssh key credential.
+        let remote_diagnostics = options.remote_diagnostics.unwrap_or(false);
+        if remote_diagnostics && options.ssh_key_pem.is_some() {
+            return Err(anyhow::anyhow!(
+                "remoteDiagnostics requires an apiSecret (or apiSecretFromEnv) credential"
+            )
+            .into());
+        }
+
+        // The platform endpoint id, extracted from the api secret before it
+        // moves into the builder; this is who the capability grant targets.
+        let mut platform_id: Option<iroh::EndpointId> = None;
         if let Some(secret) = options.api_secret {
-            builder = builder
-                .api_secret_from_str(&secret)
+            let ticket = ApiSecret::from_str(&secret)
                 .map_err(|e| anyhow::anyhow!("invalid api secret: {e:?}"))?;
-        } else if options.api_secret_from_env.unwrap_or(false) {
+            platform_id = Some(ticket.addr().id);
             builder = builder
-                .api_secret_from_env()
+                .api_secret(ticket)
+                .map_err(|e| anyhow::anyhow!("creating api token: {e:?}"))?;
+        } else if options.api_secret_from_env.unwrap_or(false) {
+            let ticket = ApiSecret::from_env_var(iroh_services::API_SECRET_ENV_VAR_NAME)
                 .map_err(|e| anyhow::anyhow!("api secret env var: {e:?}"))?;
+            platform_id = Some(ticket.addr().id);
+            builder = builder
+                .api_secret(ticket)
+                .map_err(|e| anyhow::anyhow!("creating api token: {e:?}"))?;
         } else if let Some(pem) = options.ssh_key_pem {
             builder = builder
                 .ssh_key(&pem)
@@ -114,7 +152,37 @@ impl ServicesClient {
             .build()
             .await
             .map_err(|e| anyhow::anyhow!("services build failed: {e:?}"))?;
-        Ok(ServicesClient { inner })
+
+        // The grant dials the (possibly offline) platform endpoint, so run it
+        // in the background instead of blocking client startup on it. Retry
+        // until it lands: the feature targets endpoints with bad networks,
+        // which are exactly the ones likely to start offline. Grants are
+        // idempotent and the task dies with the client.
+        let grant_task = match (remote_diagnostics, platform_id) {
+            (true, Some(platform_id)) => {
+                let client = inner.clone();
+                Some(AbortOnDropHandle::new(n0_future::task::spawn(async move {
+                    let mut delay = Duration::from_secs(1);
+                    while let Err(err) = client
+                        .grant_capability(platform_id, [NetDiagnosticsCap::GetAny])
+                        .await
+                    {
+                        warn!(
+                            "failed to grant net-diagnostics capability, \
+                             retrying in {delay:?}: {err:?}"
+                        );
+                        tokio::time::sleep(delay).await;
+                        delay = (delay * 2).min(Duration::from_secs(60));
+                    }
+                })))
+            }
+            _ => None,
+        };
+
+        Ok(ServicesClient {
+            inner,
+            _grant_task: grant_task,
+        })
     }
 
     /// Read the current endpoint name from the local client.
@@ -163,5 +231,57 @@ impl ServicesClient {
             .await
             .map_err(|e| anyhow::anyhow!("{e:?}"))?;
         Ok(report.into())
+    }
+}
+
+/// The ALPN of the iroh-services dial-back protocol served by `ClientHost`.
+#[napi]
+pub fn client_host_alpn() -> Vec<u8> {
+    iroh_services::CLIENT_HOST_ALPN.to_vec()
+}
+
+/// Serves the iroh-services dial-back protocol on an endpoint.
+///
+/// The platform connects on `clientHostAlpn()` to run network diagnostics on
+/// demand (the dashboard's Run Diagnostics button). Incoming requests must
+/// present a capability token issued by this endpoint; pair with
+/// `ServicesOptions.remoteDiagnostics`, which grants that token to the
+/// platform.
+///
+/// Construct one `ClientHost` and, in the accept loop, call
+/// `handleConnection` for each connection whose ALPN equals
+/// `clientHostAlpn()`.
+///
+/// Like any served protocol, the ALPN is an open accept surface: anyone can
+/// connect, but requests without a capability token issued by this endpoint
+/// are rejected before diagnostics run.
+#[napi]
+pub struct ClientHost {
+    inner: iroh_services::ClientHost,
+}
+
+#[napi]
+impl ClientHost {
+    /// Create a host serving diagnostics for the given endpoint.
+    #[napi(constructor)]
+    pub fn new(endpoint: &Endpoint) -> Self {
+        Self {
+            inner: iroh_services::ClientHost::new(endpoint.raw()),
+        }
+    }
+
+    /// Serve one accepted dial-back connection to completion.
+    ///
+    /// The returned promise resolves only once the remote closes the
+    /// connection, which can take tens of seconds while diagnostics run. Do
+    /// not await it inline in an accept loop; let it run concurrently
+    /// (`host.handleConnection(conn).catch(...)`) so the loop keeps
+    /// accepting.
+    #[napi]
+    pub async fn handle_connection(&self, conn: &Connection) -> Result<()> {
+        self.inner
+            .accept(conn.raw().clone())
+            .await
+            .map_err(|e| anyhow::anyhow!("{e:?}").into())
     }
 }

--- a/iroh-js/test/services.mjs
+++ b/iroh-js/test/services.mjs
@@ -2,7 +2,7 @@ import { test, suite } from 'node:test'
 import assert from 'node:assert'
 
 import pkg from '../index.js'
-const { Endpoint, ServicesClient, presetMinimal } = pkg
+const { ClientHost, Endpoint, ServicesClient, clientHostAlpn, presetMinimal } = pkg
 
 // Well-formed (but fake) API secret — the remote does not exist, but the
 // client connects lazily so construction still succeeds. Validates the
@@ -42,6 +42,35 @@ suite('services client', () => {
   test('rejects malformed secret', async () => {
     const ep = await endpoint()
     await assert.rejects(ServicesClient.create(ep, { apiSecret: 'not-a-valid-ticket' }))
+    await ep.close()
+  })
+
+  test('remote diagnostics boots with fake secret', async () => {
+    const ep = await endpoint()
+    const client = await ServicesClient.create(ep, {
+      apiSecret: FAKE_API_SECRET,
+      remoteDiagnostics: true,
+    })
+    assert.ok(client)
+    await ep.close()
+  })
+
+  test('remote diagnostics rejects ssh key credential', async () => {
+    const ep = await endpoint()
+    // Match the message: a malformed pem also rejects, and this test must
+    // fail if the remoteDiagnostics guard (not pem parsing) goes.
+    await assert.rejects(
+      ServicesClient.create(ep, { sshKeyPem: 'irrelevant', remoteDiagnostics: true }),
+      /remoteDiagnostics/,
+    )
+    await ep.close()
+  })
+
+  test('client host constructs and alpn is stable', async () => {
+    const ep = await endpoint()
+    const host = new ClientHost(ep)
+    assert.ok(host)
+    assert.equal(Buffer.from(clientHostAlpn()).toString(), 'n0/n0des-client-host/1')
     await ep.close()
   })
 })

--- a/kotlin/lib/src/test/kotlin/computer/iroh/ServicesTest.kt
+++ b/kotlin/lib/src/test/kotlin/computer/iroh/ServicesTest.kt
@@ -2,6 +2,7 @@ package computer.iroh
 
 import kotlinx.coroutines.runBlocking
 import kotlin.test.Test
+import kotlin.test.assertContains
 import kotlin.test.assertFailsWith
 
 // Well-formed (but fake) API secret — the remote does not exist, but the
@@ -44,6 +45,29 @@ class ServicesTest {
         assertFailsWith<Exception> {
             ServicesClient.create(ep, ServicesOptions(apiSecret = "not-a-valid-ticket"))
         }
+        ep.shutdown()
+    }
+
+    @Test fun remoteDiagnosticsBootsWithFakeSecret() = runBlocking {
+        val ep = endpoint()
+        ServicesClient.create(
+            ep,
+            ServicesOptions(apiSecret = FAKE_API_SECRET, remoteDiagnostics = true),
+        )
+        ep.shutdown()
+    }
+
+    @Test fun remoteDiagnosticsRejectsSshKeyCredential() = runBlocking {
+        val ep = endpoint()
+        // Check the message: a malformed pem also throws, and this test must
+        // fail if the remote_diagnostics guard (not pem parsing) goes.
+        val err = assertFailsWith<Exception> {
+            ServicesClient.create(
+                ep,
+                ServicesOptions(sshKeyPem = "irrelevant", remoteDiagnostics = true),
+            )
+        }
+        assertContains(err.message.orEmpty(), "remote_diagnostics")
         ep.shutdown()
     }
 }

--- a/kotlin/lib/src/test/kotlin/computer/iroh/ServicesTest.kt
+++ b/kotlin/lib/src/test/kotlin/computer/iroh/ServicesTest.kt
@@ -61,13 +61,15 @@ class ServicesTest {
         val ep = endpoint()
         // Check the message: a malformed pem also throws, and this test must
         // fail if the remote_diagnostics guard (not pem parsing) goes.
-        val err = assertFailsWith<Exception> {
+        val err = assertFailsWith<IrohException> {
             ServicesClient.create(
                 ep,
                 ServicesOptions(sshKeyPem = "irrelevant", remoteDiagnostics = true),
             )
         }
-        assertContains(err.message.orEmpty(), "remote_diagnostics")
+        // IrohException carries the Rust error text in the message() method,
+        // not the (null) Exception.message property.
+        assertContains(err.message(), "remote_diagnostics")
         ep.shutdown()
     }
 }

--- a/python/services_test.py
+++ b/python/services_test.py
@@ -46,3 +46,25 @@ async def test_services_client_rejects_malformed_secret():
     with pytest.raises(Exception):
         await ServicesClient.create(ep, ServicesOptions(api_secret="not-a-valid-ticket"))
     await ep.close()
+
+
+async def test_remote_diagnostics_boots_with_fake_secret():
+    ep = await _endpoint()
+    client = await ServicesClient.create(
+        ep,
+        ServicesOptions(api_secret=FAKE_API_SECRET, remote_diagnostics=True),
+    )
+    assert client is not None
+    await ep.close()
+
+
+async def test_remote_diagnostics_rejects_ssh_key_credential():
+    ep = await _endpoint()
+    # Match the message: a malformed pem also raises, and this test must
+    # fail if the remote_diagnostics guard (not pem parsing) goes.
+    with pytest.raises(Exception, match="remote_diagnostics"):
+        await ServicesClient.create(
+            ep,
+            ServicesOptions(ssh_key_pem="irrelevant", remote_diagnostics=True),
+        )
+    await ep.close()

--- a/python/services_test.py
+++ b/python/services_test.py
@@ -60,11 +60,13 @@ async def test_remote_diagnostics_boots_with_fake_secret():
 
 async def test_remote_diagnostics_rejects_ssh_key_credential():
     ep = await _endpoint()
-    # Match the message: a malformed pem also raises, and this test must
-    # fail if the remote_diagnostics guard (not pem parsing) goes.
-    with pytest.raises(Exception, match="remote_diagnostics"):
+    # Check the message: a malformed pem also raises, and this test must
+    # fail if the remote_diagnostics guard (not pem parsing) goes. IrohError
+    # carries the Rust error text in its message() method, not in str(e).
+    with pytest.raises(Exception) as excinfo:
         await ServicesClient.create(
             ep,
             ServicesOptions(ssh_key_pem="irrelevant", remote_diagnostics=True),
         )
+    assert "remote_diagnostics" in excinfo.value.message()
     await ep.close()

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -511,6 +511,12 @@ impl From<endpoint::Connection> for Connection {
     }
 }
 
+impl Connection {
+    pub(crate) fn raw(&self) -> &endpoint::Connection {
+        &self.0
+    }
+}
+
 #[uniffi::export]
 impl Connection {
     /// The ALPN protocol negotiated for this connection.

--- a/src/services.rs
+++ b/src/services.rs
@@ -1,13 +1,19 @@
-//! Binding for `iroh-services` — push metrics to services.iroh.computer.
+//! Binding for `iroh-services` — push metrics to services.iroh.computer and
+//! serve platform-initiated network diagnostics.
 //!
 //! Mirrors `iroh_services::Client`. Construct via [`ServicesClient::create`] with
 //! a built [`Endpoint`] plus credentials supplied through [`ServicesOptions`].
+//! [`ClientHost`] and [`services_client_host`] serve the dial-back protocol the
+//! platform uses to run diagnostics on demand.
 
-use std::time::Duration;
+use std::{str::FromStr, sync::Arc, time::Duration};
 
-use iroh_services::{Client, ClientBuilder};
+use iroh::protocol::ProtocolHandler as _;
+use iroh_services::{ApiSecret, Client, ClientBuilder, caps::NetDiagnosticsCap};
+use n0_future::task::AbortOnDropHandle;
+use tracing::warn;
 
-use crate::{Endpoint, IrohError};
+use crate::{CallbackError, Connection, Endpoint, IrohError, ProtocolCreator, ProtocolHandler};
 
 /// Build options for [`ServicesClient`].
 ///
@@ -35,6 +41,21 @@ pub struct ServicesOptions {
     /// automatic interval pushes; if omitted the upstream default applies.
     #[uniffi(default = None)]
     pub metrics_interval_ms: Option<u64>,
+    /// When true, let the iroh-services platform run network diagnostics
+    /// against this endpoint on demand: [`ServicesClient::create`] grants the
+    /// net-diagnostics capability to the platform endpoint named in the API
+    /// secret. Requires an api-secret credential. The endpoint must also
+    /// serve the dial-back protocol; see [`ClientHost`] and
+    /// [`services_client_host`].
+    ///
+    /// The grant is best-effort: it runs in the background and is retried
+    /// until it succeeds or the client is dropped; failures are logged, not
+    /// surfaced. Each grant is valid for 30 days and re-issued on every
+    /// client creation. A diagnostics run shares the endpoint's network
+    /// details (direct addresses, NAT characteristics, relay latencies) with
+    /// the platform.
+    #[uniffi(default = None)]
+    pub remote_diagnostics: Option<bool>,
 }
 
 /// Flattened summary of an `iroh_services::net_diagnostics::DiagnosticsReport`.
@@ -88,6 +109,9 @@ impl From<iroh_services::net_diagnostics::DiagnosticsReport> for DiagnosticsSumm
 #[derive(Clone, uniffi::Object)]
 pub struct ServicesClient {
     inner: Client,
+    /// Owns the background capability-grant task spawned by [`Self::create`]
+    /// when `remote_diagnostics` is set; aborted when the last clone drops.
+    _grant_task: Option<Arc<AbortOnDropHandle<()>>>,
 }
 
 #[uniffi::export]
@@ -118,14 +142,33 @@ impl ServicesClient {
             .into());
         }
 
+        // The grant target is the platform endpoint named in the API secret,
+        // so remote diagnostics cannot work with an ssh key credential.
+        let remote_diagnostics = options.remote_diagnostics.unwrap_or(false);
+        if remote_diagnostics && options.ssh_key_pem.is_some() {
+            return Err(anyhow::anyhow!(
+                "remote_diagnostics requires an api_secret (or api_secret_from_env) credential"
+            )
+            .into());
+        }
+
+        // The platform endpoint id, extracted from the api secret before it
+        // moves into the builder; this is who the capability grant targets.
+        let mut platform_id: Option<iroh::EndpointId> = None;
         if let Some(secret) = options.api_secret {
-            builder = builder
-                .api_secret_from_str(&secret)
+            let ticket = ApiSecret::from_str(&secret)
                 .map_err(|e| anyhow::anyhow!("invalid api secret: {e:?}"))?;
-        } else if options.api_secret_from_env.unwrap_or(false) {
+            platform_id = Some(ticket.addr().id);
             builder = builder
-                .api_secret_from_env()
+                .api_secret(ticket)
+                .map_err(|e| anyhow::anyhow!("creating api token: {e:?}"))?;
+        } else if options.api_secret_from_env.unwrap_or(false) {
+            let ticket = ApiSecret::from_env_var(iroh_services::API_SECRET_ENV_VAR_NAME)
                 .map_err(|e| anyhow::anyhow!("api secret env var: {e:?}"))?;
+            platform_id = Some(ticket.addr().id);
+            builder = builder
+                .api_secret(ticket)
+                .map_err(|e| anyhow::anyhow!("creating api token: {e:?}"))?;
         } else if let Some(pem) = options.ssh_key_pem {
             builder = builder
                 .ssh_key(&pem)
@@ -149,7 +192,39 @@ impl ServicesClient {
             .build()
             .await
             .map_err(|e| anyhow::anyhow!("services build failed: {e:?}"))?;
-        Ok(ServicesClient { inner })
+
+        // The grant dials the (possibly offline) platform endpoint, so run it
+        // in the background instead of blocking client startup on it. Retry
+        // until it lands: the feature targets endpoints with bad networks,
+        // which are exactly the ones likely to start offline. Grants are
+        // idempotent and the task dies with the client.
+        let grant_task = match (remote_diagnostics, platform_id) {
+            (true, Some(platform_id)) => {
+                let client = inner.clone();
+                Some(Arc::new(AbortOnDropHandle::new(n0_future::task::spawn(
+                    async move {
+                        let mut delay = Duration::from_secs(1);
+                        while let Err(err) = client
+                            .grant_capability(platform_id, [NetDiagnosticsCap::GetAny])
+                            .await
+                        {
+                            warn!(
+                                "failed to grant net-diagnostics capability, \
+                                 retrying in {delay:?}: {err:?}"
+                            );
+                            tokio::time::sleep(delay).await;
+                            delay = (delay * 2).min(Duration::from_secs(60));
+                        }
+                    },
+                ))))
+            }
+            _ => None,
+        };
+
+        Ok(ServicesClient {
+            inner,
+            _grant_task: grant_task,
+        })
     }
 
     /// Read the current endpoint name from the local client.
@@ -204,6 +279,97 @@ impl ServicesClient {
             .map_err(|e| anyhow::anyhow!("{e:?}"))?;
         Ok(report.into())
     }
+}
+
+/// The ALPN of the iroh-services dial-back protocol served by [`ClientHost`].
+#[uniffi::export]
+pub fn client_host_alpn() -> Vec<u8> {
+    iroh_services::CLIENT_HOST_ALPN.to_vec()
+}
+
+/// Serves the iroh-services dial-back protocol on an endpoint.
+///
+/// The platform connects on [`client_host_alpn`] to run network diagnostics
+/// on demand (the dashboard's Run Diagnostics button). Incoming requests must
+/// present a capability token issued by this endpoint; pair with
+/// [`ServicesOptions::remote_diagnostics`], which grants that token to the
+/// platform.
+///
+/// Apps that register protocol handlers at bind time should mount
+/// [`services_client_host`] instead and never need this type. Apps that
+/// drive their own accept loop construct a `ClientHost` once and call
+/// [`Self::handle_connection`] for each connection whose ALPN equals
+/// [`client_host_alpn`].
+///
+/// Like any served protocol, the ALPN is an open accept surface: anyone can
+/// connect, but requests without a capability token issued by this endpoint
+/// are rejected before diagnostics run.
+#[derive(uniffi::Object)]
+pub struct ClientHost {
+    inner: iroh_services::ClientHost,
+}
+
+#[uniffi::export]
+impl ClientHost {
+    /// Create a host serving diagnostics for the given endpoint.
+    #[uniffi::constructor]
+    pub fn new(endpoint: &Endpoint) -> Self {
+        Self {
+            inner: iroh_services::ClientHost::new(endpoint.raw()),
+        }
+    }
+
+    /// Serve one accepted dial-back connection to completion.
+    ///
+    /// The returned future resolves only once the remote closes the
+    /// connection, which can take tens of seconds while diagnostics run. Do
+    /// not await it inline in an accept loop; run it as its own task so the
+    /// loop keeps accepting.
+    #[uniffi::method(async_runtime = "tokio")]
+    pub async fn handle_connection(&self, conn: &Connection) -> Result<(), IrohError> {
+        self.inner
+            .accept(conn.raw().clone())
+            .await
+            .map_err(|e| anyhow::anyhow!("{e:?}").into())
+    }
+}
+
+/// A [`ProtocolCreator`] serving the iroh-services dial-back protocol.
+///
+/// Mount it at bind time under [`client_host_alpn`] via
+/// [`EndpointOptions::protocols`].
+///
+/// [`EndpointOptions::protocols`]: crate::EndpointOptions::protocols
+#[uniffi::export]
+pub fn services_client_host() -> Arc<dyn ProtocolCreator> {
+    Arc::new(ClientHostCreator)
+}
+
+#[derive(Debug)]
+struct ClientHostCreator;
+
+impl ProtocolCreator for ClientHostCreator {
+    fn create(&self, endpoint: Arc<Endpoint>) -> Arc<dyn ProtocolHandler> {
+        Arc::new(ClientHostHandler {
+            inner: iroh_services::ClientHost::new(endpoint.raw()),
+        })
+    }
+}
+
+struct ClientHostHandler {
+    inner: iroh_services::ClientHost,
+}
+
+#[async_trait::async_trait]
+impl ProtocolHandler for ClientHostHandler {
+    async fn accept(&self, conn: Arc<Connection>) -> Result<(), CallbackError> {
+        self.inner
+            .accept(conn.raw().clone())
+            .await
+            .map_err(|e| anyhow::anyhow!("{e:?}").into())
+    }
+
+    async fn shutdown(&self) {}
 }
 
 #[cfg(test)]
@@ -280,5 +446,151 @@ mod tests {
         .await;
         assert!(res.is_err(), "must reject a malformed api secret");
         ep.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_remote_diagnostics_rejects_ssh_key_credential() {
+        let ep = minimal_endpoint().await;
+        let res = ServicesClient::create(
+            &ep,
+            ServicesOptions {
+                ssh_key_pem: Some("irrelevant".to_string()),
+                remote_diagnostics: Some(true),
+                ..Default::default()
+            },
+        )
+        .await;
+        // Assert on the message: a malformed pem also errors, and this test
+        // must fail if the remote_diagnostics guard (not pem parsing) goes.
+        let err = res
+            .err()
+            .expect("must reject ssh key credential")
+            .to_string();
+        assert!(
+            err.contains("remote_diagnostics"),
+            "expected the remote_diagnostics guard, got: {err}"
+        );
+        ep.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_remote_diagnostics_boots_with_fake_secret() {
+        let ep = minimal_endpoint().await;
+        let client = ServicesClient::create(
+            &ep,
+            ServicesOptions {
+                api_secret: Some(FAKE_API_SECRET.to_string()),
+                remote_diagnostics: Some(true),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("client should construct; the grant runs (and fails) in the background");
+        drop(client);
+        ep.close().await.unwrap();
+    }
+
+    /// Full dial-back round trip against an FFI endpoint: mount the protocol
+    /// via [`services_client_host`] at bind, mint a token with the same
+    /// issuer/audience shape `grant_capability` delivers (issued by the
+    /// server, audience the dialer), then authenticate and request a
+    /// diagnostics report over irpc exactly like the platform would.
+    ///
+    /// Slow by construction (about 20s): the server runs a real diagnostics
+    /// probe whose relay and net-report phases time out offline. There is no
+    /// FFI knob to shorten the upstream timeouts.
+    #[tokio::test]
+    async fn test_client_host_serves_diagnostics() {
+        use std::collections::HashMap;
+
+        use iroh_services::{
+            ClientHostClient,
+            caps::{Caps, create_grant_token},
+            protocol::{Auth, RunNetworkDiagnostics},
+        };
+        use irpc_iroh::IrohLazyRemoteConnection;
+
+        let mut protocols: HashMap<Vec<u8>, Arc<dyn ProtocolCreator>> = HashMap::new();
+        protocols.insert(client_host_alpn(), services_client_host());
+        let server = Endpoint::bind(EndpointOptions {
+            preset: Some(crate::preset_minimal()),
+            protocols: Some(protocols),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+
+        let dialer = iroh::Endpoint::builder(iroh::endpoint::presets::Minimal)
+            .bind()
+            .await
+            .unwrap();
+
+        let rcan = create_grant_token(
+            server.raw().secret_key().clone(),
+            dialer.id(),
+            Duration::from_secs(60),
+            Caps::new([NetDiagnosticsCap::GetAny]),
+        )
+        .unwrap();
+
+        let conn =
+            IrohLazyRemoteConnection::new(dialer.clone(), server.raw().addr(), client_host_alpn());
+        let client = ClientHostClient::boxed(conn);
+
+        client.rpc(Auth { caps: rcan }).await.unwrap();
+        let report = client
+            .rpc(RunNetworkDiagnostics)
+            .await
+            .unwrap()
+            .expect("expected Ok(DiagnosticsReport)");
+        assert_eq!(report.endpoint_id, server.raw().id());
+
+        server.close().await.unwrap();
+        dialer.close().await;
+    }
+
+    /// The manual accept-loop path: [`ClientHost::handle_connection`] must
+    /// return once the remote goes away instead of hanging the loop forever.
+    /// (The full protocol exchange is covered by the round-trip test above;
+    /// this exercises the wiring JS and accept-loop apps use.)
+    #[tokio::test]
+    async fn test_handle_connection_returns_on_remote_close() {
+        let server = Endpoint::bind(EndpointOptions {
+            preset: Some(crate::preset_minimal()),
+            alpns: Some(vec![client_host_alpn()]),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+        let host = ClientHost::new(&server);
+
+        let dialer = iroh::Endpoint::builder(iroh::endpoint::presets::Minimal)
+            .bind()
+            .await
+            .unwrap();
+        let server_addr = server.raw().addr();
+        let dial = tokio::spawn(async move {
+            let conn = dialer
+                .connect(server_addr, iroh_services::CLIENT_HOST_ALPN)
+                .await
+                .unwrap();
+            conn.close(0u32.into(), b"done");
+            dialer.close().await;
+        });
+
+        let incoming = server.accept_next().await.unwrap();
+        let accepting = incoming.accept().await.unwrap();
+        let conn = accepting.connect().await.unwrap();
+        // Ok or Err both fine; the handler just must not hang once the
+        // remote has closed.
+        let _ = tokio::time::timeout(
+            std::time::Duration::from_secs(10),
+            host.handle_connection(&conn),
+        )
+        .await
+        .expect("handle_connection must return after the remote closes");
+
+        dial.await.unwrap();
+        server.close().await.unwrap();
     }
 }


### PR DESCRIPTION
Closes #241.

The dashboard's Run Diagnostics button dials back into an endpoint over the `n0/n0des-client-host/1` ALPN, authorized by a capability token the endpoint grants to the platform. Both halves were Rust-only, so the button stayed disabled for every FFI endpoint. This exposes them with one option plus one mount:

```python
# grant: one flag on the client the app already creates
svc = await ServicesClient.create(ep, ServicesOptions(
    api_secret=KEY,
    remote_diagnostics=True,
))

# serve: mount at bind (router apps)...
ep = await Endpoint.bind(EndpointOptions(
    protocols={client_host_alpn(): services_client_host()},
))
# ...or one match arm in a manual accept loop
if alpn == client_host_alpn():
    asyncio.create_task(client_host.handle_connection(conn))
```

## Design notes

- `remote_diagnostics` grants `NetDiagnosticsCap::GetAny` to the platform endpoint named in the API secret, in a background task owned by the client that retries with backoff. The feature targets endpoints with bad networks, which are exactly the ones likely to start offline; a one-shot grant would silently strand them. Requires an api-secret credential (the ssh-key path carries no platform endpoint to grant to).
- Serving has two entry points because the FFI's internal router only exists when protocols are registered at bind, and `iroh::protocol::Router` accepts no post-spawn registrations: `services_client_host()` (a built-in `ProtocolCreator`) for bind-time mounting, and `ClientHost.handle_connection()` for manual accept loops. iroh-js has no router, so it gets only the latter.
- `handle_connection` resolves when the remote closes the connection; the docs in both bindings warn against awaiting it inline in the accept loop.
- One uniffi change covers Swift, Kotlin, and Python; `iroh-js` mirrors it in napi with regenerated `index.js`/`index.d.ts` (the regen also picks up the `1.0.0-rc.1` version-check strings; the committed copy predated the version bump).

## Tests

- Rust: a full dial-back round trip against an FFI endpoint (auth with a server-issued token, real diagnostics report over irpc, mirroring iroh-services' own `client_host` tests; needs the new `irpc`/`irpc-iroh` dev-deps). Note it is slow by construction (~20s of offline relay/net-report timeouts; no FFI knob to shorten them). Plus a cheap accept-loop wiring test and option-validation tests.
- JS/Python/Kotlin: validation tests mirrored per the repo convention; the ssh-key rejection tests assert on the guard's message so they cannot pass vacuously.
- Not verifiable here: the real dashboard end-to-end. Plan is to verify with the hello-iroh-ffi demo apps once this ships in a release.

## Upstream observations (out of scope, filing separately if wanted)

- `verify_rcan` in iroh-services checks issuer/audience/origin but never token expiry, so dial-back grants effectively outlive `DEFAULT_CAP_EXPIRY`.
- `ClientHost::handle_connection` holds the connection until the *remote* closes; closing server-side after the report would free handlers sooner.
- The FFI's `ssh_key_pem` credential path cannot set a remote, so `ClientBuilder::build()` always fails with `MissingRemote`; pre-existing and untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)