### PR TITLE
ci(js): fix publishing tag

### DIFF
--- a/.github/workflows/ci_js.yml
+++ b/.github/workflows/ci_js.yml
@@ -509,17 +509,18 @@ jobs:
         run: yarn artifacts
       - name: Move README # Hack to get npm README to work
         run: cp README.md ../README.md
+      - name: Compute npm dist-tag
+        # Prerelease versions (e.g. 1.0.0-rc.1) must publish under a non-`latest`
+        # dist-tag — npm 11.5+ refuses otherwise. Stable versions go to `latest`.
+        id: npm_tag
+        if: github.event_name == 'workflow_dispatch' || startsWith(github.event.ref, 'refs/tags/v')
+        run: |
+          echo "tag=$(node -p "/-/.test(require('./package.json').version) ? 'next' : 'latest'")" >> "$GITHUB_OUTPUT"
       - name: Publish
         # Auth via npm Trusted Publishing (OIDC, no token). Configured per-package
         # at https://www.npmjs.com/package/<pkg>/access → Trusted publishers.
-        # NPM_CONFIG_TAG: pre-1.0 versions (anything semver-prerelease, e.g.
-        # 1.0.0-rc.1) must be published under a non-`latest` dist-tag — npm
-        # 11.5+ refuses the publish otherwise. `next` is the existing dist-tag
-        # this package uses for prereleases. Bare `npm install @number0/iroh`
-        # keeps resolving to the previous stable until a 1.0.0 release without
-        # this env is cut.
         if: github.event_name == 'workflow_dispatch' || startsWith(github.event.ref, 'refs/tags/v')
         run: npm publish --access public --provenance
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_CONFIG_TAG: next
+          NPM_CONFIG_TAG: ${{ steps.npm_tag.outputs.tag }}


### PR DESCRIPTION
NPM tags have been manually updated for  `1.0.0`

Closes #250