### PR TITLE
refactor(endpoint)!: String instead of Vec<u8>

### DIFF
--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -178,7 +178,7 @@ pub struct EndpointOptions {
     /// an internal router is spawned to dispatch incoming connections to the
     /// supplied handlers.
     #[uniffi(default = None)]
-    pub protocols: Option<HashMap<Vec<u8>, Arc<dyn ProtocolCreator>>>,
+    pub protocols: Option<HashMap<String, Arc<dyn ProtocolCreator>>>,
 }
 
 #[uniffi::export(with_foreign)]


### PR DESCRIPTION
This patch has to do with figuring out a way to generate golang FFI bindings. See https://github.com/NordSecurity/uniffi-bindgen-go/issues/52#issuecomment-4777452355. I'm unsure of the impact of this on the other bindings but this fixes the `go` binding generation with `uniffi-bindgen-go` directly. The resulting generated code from `uniffi-bindgen-go` gives then `Protocols *map[string]ProtocolCreator` instead `Protocols *map[[]byte]ProtocolCreator` (which is invalid Go code).