### PR TITLE
feat(swift): add Mac Catalyst slice to xcframework

### DIFF
--- a/.github/workflows/ci_swift.yml
+++ b/.github/workflows/ci_swift.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
         with:
-          targets: aarch64-apple-ios,aarch64-apple-ios-sim,x86_64-apple-ios,aarch64-apple-darwin
+          targets: aarch64-apple-ios,aarch64-apple-ios-sim,x86_64-apple-ios,aarch64-apple-darwin,aarch64-apple-ios-macabi
       - uses: Swatinem/rust-cache@v2
       - uses: davidB/rust-cargo-make@v1
       - name: cargo make test-swift

--- a/.github/workflows/release_swift.yml
+++ b/.github/workflows/release_swift.yml
@@ -27,7 +27,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
       - uses: dtolnay/rust-toolchain@stable
         with:
-          targets: aarch64-apple-ios,aarch64-apple-ios-sim,x86_64-apple-ios,aarch64-apple-darwin
+          targets: aarch64-apple-ios,aarch64-apple-ios-sim,x86_64-apple-ios,aarch64-apple-darwin,aarch64-apple-ios-macabi
       - uses: Swatinem/rust-cache@v2
       - uses: davidB/rust-cargo-make@v1
       - name: Build xcframework + verify + zip

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -14,7 +14,7 @@
 #
 # Bindgen / packaging:
 #   cargo make bindgen-kotlin
-#   cargo make swift-xcframework # full 4-target Apple xcframework (release)
+#   cargo make swift-xcframework # full 5-target Apple xcframework (release)
 #   cargo make python-wheel
 #
 # Most tasks are workspace = false so cargo-make does not fan out per member.
@@ -406,6 +406,16 @@ arch -arm64 xcodebuild build \
   CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" \
   -quiet
 
+# 1b. Mac Catalyst — build only. Catches link errors on the maccatalyst slice
+#     (arm64-only; consumers pin EXCLUDED_ARCHS[sdk=macosx*]=x86_64 like they
+#     do for the arm64-only macOS slice).
+echo "==> xcodebuild build for Mac Catalyst (build-only, no run)"
+arch -arm64 xcodebuild build \
+  -scheme IrohLib \
+  -destination "platform=macOS,variant=Mac Catalyst" \
+  -derivedDataPath .xcode-verify-ddata \
+  -quiet
+
 # 2. iOS Simulator — full xcodebuild test boots a sim, installs the test
 #    bundle, and runs IrohLibTests on the iOS runtime. Catches "links but
 #    crashes on iOS startup" + verifies the simulator slice actually loads.
@@ -491,7 +501,7 @@ args = ["scripts/verify_kotlin_consumer.sh"]
 
 [tasks.docs-swift]
 description = "Build the Swift DocC docs, laid out for Pages static hosting."
-# Always builds the full 4-target xcframework. The previous `swift-macos-
+# Always builds the full 5-target xcframework. The previous `swift-macos-
 # framework` macOS-only path used a hand-laid framework skeleton; with the
 # `xcodebuild -create-xcframework -library` build pipeline, all four slices
 # come from the same one-shot xcodebuild invocation and there's no slim

--- a/Package.swift
+++ b/Package.swift
@@ -47,7 +47,8 @@ let package = Package(
     name: "IrohLib",
     platforms: [
         .iOS("17.5"),
-        .macOS("14.5")
+        .macOS("14.5"),
+        .macCatalyst("17.5")
     ],
     products: [
         .library(

--- a/make_swift.sh
+++ b/make_swift.sh
@@ -66,6 +66,8 @@ echo "Building x86_64-apple-ios"
 cargo build --release --target x86_64-apple-ios
 echo "Building aarch64-apple-darwin"
 cargo build --release --target aarch64-apple-darwin
+echo "Building aarch64-apple-ios-macabi"
+cargo build --release --target aarch64-apple-ios-macabi
 
 # Wipe outputs so we don't blend stale slices into the new xcframework.
 rm -rf "$FRAMEWORK_NAME.xcframework"
@@ -78,11 +80,11 @@ mkdir -p "$INCLUDE_DIR"
 # that names the module `Iroh` to match what the Swift consumer imports).
 cargo run --bin uniffi-bindgen generate --language swift --out-dir ./$INCLUDE_DIR --library "$TARGET_DIR/debug/lib${UDL_NAME}.dylib" --config uniffi.toml
 
-# Stage a single headers directory shared across all three slices — same
-# .h + module.modulemap, so xcodebuild copies the same Headers/ into each
-# slice. Export.h is a one-line umbrella so the modulemap can `umbrella
-# header "Export.h"` without uniffi-generated names leaking into the
-# module surface.
+# Stage a single headers directory shared across every slice — same .h +
+# module.modulemap, so xcodebuild copies the same Headers/ into each slice.
+# Export.h is a one-line umbrella so the modulemap can `umbrella header
+# "Export.h"` without uniffi-generated names leaking into the module
+# surface.
 HEADERS_STAGE="$TARGET_DIR/apple-xcf-headers"
 rm -rf "$HEADERS_STAGE"
 mkdir -p "$HEADERS_STAGE"
@@ -122,6 +124,8 @@ xcodebuild -create-xcframework \
     -library "$SIM_FAT" \
     -headers "$HEADERS_STAGE" \
     -library "$TARGET_DIR/aarch64-apple-darwin/release/lib${UDL_NAME}.a" \
+    -headers "$HEADERS_STAGE" \
+    -library "$TARGET_DIR/aarch64-apple-ios-macabi/release/lib${UDL_NAME}.a" \
     -headers "$HEADERS_STAGE" \
     -output "$FRAMEWORK_NAME.xcframework"
 


### PR DESCRIPTION
arm64-only to match the existing macOS-arm64 policy. Resolves #268.