### PR TITLE
feat(js)!: accept and return Uint8Array for all byte APIs

### DIFF
--- a/iroh-js/index.d.ts
+++ b/iroh-js/index.d.ts
@@ -3,7 +3,7 @@
 /** A server-side handshake in progress. */
 export declare class Accepting {
   connect(): Promise<Connection>
-  alpn(): Promise<Array<number>>
+  alpn(): Promise<Uint8Array>
 }
 
 /** A bidirectional QUIC stream pair. */
@@ -15,25 +15,25 @@ export declare class BiStream {
 /** A client-side handshake in progress. */
 export declare class Connecting {
   connect(): Promise<Connection>
-  alpn(): Promise<Array<number>>
+  alpn(): Promise<Uint8Array>
   remoteId(): Promise<EndpointId>
 }
 
 /** An active QUIC connection. */
 export declare class Connection {
-  alpn(): Array<number>
+  alpn(): Uint8Array
   remoteId(): EndpointId
   side(): Side
   openUni(): Promise<SendStream>
   acceptUni(): Promise<RecvStream>
   openBi(): Promise<BiStream>
   acceptBi(): Promise<BiStream>
-  readDatagram(): Promise<Array<number>>
+  readDatagram(): Promise<Uint8Array>
   closed(): Promise<string>
   closeReason(): string | null
-  close(errorCode: bigint, reason: Array<number>): void
-  sendDatagram(data: Array<number>): void
-  sendDatagramWait(data: Array<number>): Promise<void>
+  close(errorCode: bigint, reason: Uint8Array): void
+  sendDatagram(data: Uint8Array): void
+  sendDatagramWait(data: Uint8Array): Promise<void>
   maxDatagramSize(): number | null
   datagramSendBufferSpace(): number
   stableId(): number
@@ -67,7 +67,7 @@ export declare class Endpoint {
   /** The secret key backing this endpoint's identity. */
   secretKey(): SecretKey
   /** Replace the set of advertised ALPNs. */
-  setAlpns(alpns: Array<Array<number>>): void
+  setAlpns(alpns: Array<Uint8Array>): void
   /** Add an external (manually-known) socket address. */
   addExternalAddr(addr: string): Promise<void>
   /** Remove a previously-added external address. */
@@ -81,9 +81,9 @@ export declare class Endpoint {
   /** Remove a relay configuration at runtime. */
   removeRelay(url: string): Promise<boolean>
   /** Connect to a remote endpoint via the given ALPN. */
-  connect(addr: EndpointAddr, alpn: Array<number>): Promise<Connection>
+  connect(addr: EndpointAddr, alpn: Uint8Array): Promise<Connection>
   /** Begin a connection attempt, returning the in-progress handle. */
-  connectPending(addr: EndpointAddr, alpn: Array<number>): Promise<Connecting>
+  connectPending(addr: EndpointAddr, alpn: Uint8Array): Promise<Connecting>
   /** Pull the next incoming connection attempt. */
   acceptNext(): Promise<Incoming | null>
   /** Watch for changes to this endpoint's address. */
@@ -140,9 +140,9 @@ export declare class EndpointBuilder {
   /** Replay the n0 preset with relays disabled. */
   applyN0DisableRelay(): void
   /** Set the endpoint secret key (32 bytes). */
-  secretKey(bytes: Array<number>): void
+  secretKey(bytes: Uint8Array): void
   /** Set the advertised ALPNs. */
-  alpns(alpns: Array<Array<number>>): void
+  alpns(alpns: Array<Uint8Array>): void
   /** Set the relay mode. */
   relayMode(mode: RelayMode): void
   /** Set the address the endpoint binds to (`host:port`). */
@@ -156,17 +156,17 @@ export declare class EndpointId {
   /** Returns true if both [`EndpointId`]s are equal. */
   equals(other: EndpointId): boolean
   /** Get the underlying 32 bytes. */
-  toBytes(): Array<number>
+  toBytes(): Uint8Array
   /** Parse an [`EndpointId`] from its base32 representation. */
   static fromString(s: string): EndpointId
   /** Construct an [`EndpointId`] from raw bytes (32 bytes). */
-  static fromBytes(bytes: Array<number>): EndpointId
+  static fromBytes(bytes: Uint8Array): EndpointId
   /** Short base32 prefix. */
   fmtShort(): string
   /** Base32 string form. */
   toString(): string
   /** Verify a signature on `message` against this endpoint's key. */
-  verify(message: Array<number>, signature: Signature): void
+  verify(message: Uint8Array, signature: Signature): void
 }
 
 /** A token containing information for establishing a connection to an endpoint. */
@@ -194,9 +194,9 @@ export declare class Incoming {
 
 /** The incoming half of a QUIC stream. */
 export declare class RecvStream {
-  read(sizeLimit: number): Promise<Array<number>>
-  readExact(size: number): Promise<Array<number>>
-  readToEnd(sizeLimit: number): Promise<Array<number>>
+  read(sizeLimit: number): Promise<Uint8Array>
+  readExact(size: number): Promise<Uint8Array>
+  readToEnd(sizeLimit: number): Promise<Uint8Array>
   id(): Promise<string>
   bytesRead(): Promise<number>
   stop(errorCode: bigint): Promise<void>
@@ -250,19 +250,19 @@ export declare class SecretKey {
   /** Generate a new random secret key. */
   static generate(): SecretKey
   /** Construct from raw bytes (32 bytes). */
-  static fromBytes(bytes: Array<number>): SecretKey
+  static fromBytes(bytes: Uint8Array): SecretKey
   /** Raw 32-byte form. */
-  toBytes(): Array<number>
+  toBytes(): Uint8Array
   /** The public [`EndpointId`] derived from this secret key. */
   public(): EndpointId
   /** Sign a message, producing an ed25519 signature. */
-  sign(message: Array<number>): Signature
+  sign(message: Uint8Array): Signature
 }
 
 /** The outgoing half of a QUIC stream. */
 export declare class SendStream {
-  write(buf: Array<number>): Promise<number>
-  writeAll(buf: Array<number>): Promise<void>
+  write(buf: Uint8Array): Promise<number>
+  writeAll(buf: Uint8Array): Promise<void>
   finish(): Promise<void>
   reset(errorCode: bigint): Promise<void>
   setPriority(p: number): Promise<void>
@@ -290,9 +290,9 @@ export declare class ServicesClient {
 /** An ed25519 signature over a message. */
 export declare class Signature {
   /** Construct from raw bytes (64 bytes). */
-  static fromBytes(bytes: Array<number>): Signature
+  static fromBytes(bytes: Uint8Array): Signature
   /** Raw 64-byte form. */
-  toBytes(): Array<number>
+  toBytes(): Uint8Array
   /** Lowercase hex representation. */
   toString(): string
 }
@@ -339,8 +339,8 @@ export interface DiagnosticsSummary {
  */
 export interface EndpointOptions {
   bindAddr?: string
-  secretKey?: Array<number>
-  alpns?: Array<Array<number>>
+  secretKey?: Uint8Array
+  alpns?: Array<Uint8Array>
 }
 
 /** Where an incoming connection came from. */

--- a/iroh-js/src/endpoint.rs
+++ b/iroh-js/src/endpoint.rs
@@ -64,8 +64,9 @@ impl EndpointBuilder {
 
     /// Set the endpoint secret key (32 bytes).
     #[napi]
-    pub fn secret_key(&self, bytes: Vec<u8>) -> Result<()> {
+    pub fn secret_key(&self, bytes: Uint8Array) -> Result<()> {
         let key: [u8; 32] = bytes
+            .as_ref()
             .try_into()
             .map_err(|_| anyhow::anyhow!("secret_key must be 32 bytes"))?;
         self.map(|b| b.secret_key(iroh::SecretKey::from_bytes(&key)));
@@ -74,7 +75,8 @@ impl EndpointBuilder {
 
     /// Set the advertised ALPNs.
     #[napi]
-    pub fn alpns(&self, alpns: Vec<Vec<u8>>) {
+    pub fn alpns(&self, alpns: Vec<Uint8Array>) {
+        let alpns: Vec<Vec<u8>> = alpns.into_iter().map(|a| a.to_vec()).collect();
         self.map(|b| b.alpns(alpns));
     }
 
@@ -250,12 +252,12 @@ pub struct ConnectionStats {
 ///
 /// `bind` applies the n0 preset by default. For a custom preset use
 /// [`Endpoint::builder`] + the `EndpointBuilder` surface.
-#[derive(Debug, Default)]
+#[derive(Default)]
 #[napi(object)]
 pub struct EndpointOptions {
     pub bind_addr: Option<String>,
-    pub secret_key: Option<Vec<u8>>,
-    pub alpns: Option<Vec<Vec<u8>>>,
+    pub secret_key: Option<Uint8Array>,
+    pub alpns: Option<Vec<Uint8Array>>,
 }
 
 /// An iroh endpoint.
@@ -363,7 +365,8 @@ impl Endpoint {
 
     /// Replace the set of advertised ALPNs.
     #[napi]
-    pub fn set_alpns(&self, alpns: Vec<Vec<u8>>) {
+    pub fn set_alpns(&self, alpns: Vec<Uint8Array>) {
+        let alpns: Vec<Vec<u8>> = alpns.into_iter().map(|a| a.to_vec()).collect();
         self.inner.set_alpns(alpns);
     }
 
@@ -416,7 +419,7 @@ impl Endpoint {
 
     /// Connect to a remote endpoint via the given ALPN.
     #[napi]
-    pub async fn connect(&self, addr: &EndpointAddr, alpn: Vec<u8>) -> Result<Connection> {
+    pub async fn connect(&self, addr: &EndpointAddr, alpn: Uint8Array) -> Result<Connection> {
         let addr: iroh::EndpointAddr = addr.try_into()?;
         let conn = self
             .inner
@@ -428,7 +431,11 @@ impl Endpoint {
 
     /// Begin a connection attempt, returning the in-progress handle.
     #[napi]
-    pub async fn connect_pending(&self, addr: &EndpointAddr, alpn: Vec<u8>) -> Result<Connecting> {
+    pub async fn connect_pending(
+        &self,
+        addr: &EndpointAddr,
+        alpn: Uint8Array,
+    ) -> Result<Connecting> {
         let addr: iroh::EndpointAddr = addr.try_into()?;
         let connecting = self
             .inner
@@ -578,15 +585,13 @@ impl Accepting {
     }
 
     #[napi]
-    pub async fn alpn(&self) -> Result<Vec<u8>> {
+    pub async fn alpn(&self) -> Result<Uint8Array> {
         let mut guard = self.0.lock().await;
         let inner = guard
             .as_mut()
             .ok_or_else(|| anyhow::anyhow!("Accepting already consumed"))?;
-        inner
-            .alpn()
-            .await
-            .map_err(|e| anyhow::anyhow!("{e:?}").into())
+        let bytes = inner.alpn().await.map_err(|e| anyhow::anyhow!("{e:?}"))?;
+        Ok(bytes.into())
     }
 }
 
@@ -609,15 +614,13 @@ impl Connecting {
     }
 
     #[napi]
-    pub async fn alpn(&self) -> Result<Vec<u8>> {
+    pub async fn alpn(&self) -> Result<Uint8Array> {
         let mut guard = self.0.lock().await;
         let inner = guard
             .as_mut()
             .ok_or_else(|| anyhow::anyhow!("Connecting already consumed"))?;
-        inner
-            .alpn()
-            .await
-            .map_err(|e| anyhow::anyhow!("{e:?}").into())
+        let bytes = inner.alpn().await.map_err(|e| anyhow::anyhow!("{e:?}"))?;
+        Ok(bytes.into())
     }
 
     #[napi]
@@ -637,8 +640,8 @@ pub struct Connection(Arc<endpoint::Connection>);
 #[napi]
 impl Connection {
     #[napi]
-    pub fn alpn(&self) -> Vec<u8> {
-        self.0.alpn().to_vec()
+    pub fn alpn(&self) -> Uint8Array {
+        self.0.alpn().to_vec().into()
     }
 
     #[napi]
@@ -698,13 +701,13 @@ impl Connection {
     }
 
     #[napi]
-    pub async fn read_datagram(&self) -> Result<Vec<u8>> {
+    pub async fn read_datagram(&self) -> Result<Uint8Array> {
         let res = self
             .0
             .read_datagram()
             .await
             .map_err(|e| anyhow::anyhow!("{e:?}"))?;
-        Ok(res.to_vec())
+        Ok(res.to_vec().into())
     }
 
     #[napi]
@@ -718,7 +721,7 @@ impl Connection {
     }
 
     #[napi]
-    pub fn close(&self, error_code: BigInt, reason: Vec<u8>) -> Result<()> {
+    pub fn close(&self, error_code: BigInt, reason: Uint8Array) -> Result<()> {
         let code =
             endpoint::VarInt::from_u64(error_code.get_u64().1).map_err(anyhow::Error::from)?;
         self.0.close(code, &reason);
@@ -726,17 +729,17 @@ impl Connection {
     }
 
     #[napi]
-    pub fn send_datagram(&self, data: Vec<u8>) -> Result<()> {
+    pub fn send_datagram(&self, data: Uint8Array) -> Result<()> {
         self.0
-            .send_datagram(data.into())
+            .send_datagram(data.to_vec().into())
             .map_err(|e| anyhow::anyhow!("{e:?}"))?;
         Ok(())
     }
 
     #[napi]
-    pub async fn send_datagram_wait(&self, data: Vec<u8>) -> Result<()> {
+    pub async fn send_datagram_wait(&self, data: Uint8Array) -> Result<()> {
         self.0
-            .send_datagram_wait(data.into())
+            .send_datagram_wait(data.to_vec().into())
             .await
             .map_err(|e| anyhow::anyhow!("{e:?}"))?;
         Ok(())
@@ -853,14 +856,14 @@ impl SendStream {
 #[napi]
 impl SendStream {
     #[napi]
-    pub async fn write(&self, buf: Vec<u8>) -> Result<i64> {
+    pub async fn write(&self, buf: Uint8Array) -> Result<i64> {
         let mut s = self.0.lock().await;
         let n = s.write(&buf).await.map_err(|e| anyhow::anyhow!("{e:?}"))?;
         Ok(n as i64)
     }
 
     #[napi]
-    pub async fn write_all(&self, buf: Vec<u8>) -> Result<()> {
+    pub async fn write_all(&self, buf: Uint8Array) -> Result<()> {
         let mut s = self.0.lock().await;
         s.write_all(&buf)
             .await
@@ -924,7 +927,7 @@ impl RecvStream {
 #[napi]
 impl RecvStream {
     #[napi]
-    pub async fn read(&self, size_limit: u32) -> Result<Vec<u8>> {
+    pub async fn read(&self, size_limit: u32) -> Result<Uint8Array> {
         let mut buf = vec![0u8; size_limit as usize];
         let mut r = self.0.lock().await;
         let res = r
@@ -933,27 +936,27 @@ impl RecvStream {
             .map_err(|e| anyhow::anyhow!("{e:?}"))?;
         let len = res.unwrap_or(0);
         buf.truncate(len);
-        Ok(buf)
+        Ok(buf.into())
     }
 
     #[napi]
-    pub async fn read_exact(&self, size: u32) -> Result<Vec<u8>> {
+    pub async fn read_exact(&self, size: u32) -> Result<Uint8Array> {
         let mut buf = vec![0u8; size as usize];
         let mut r = self.0.lock().await;
         r.read_exact(&mut buf)
             .await
             .map_err(|e| anyhow::anyhow!("{e:?}"))?;
-        Ok(buf)
+        Ok(buf.into())
     }
 
     #[napi]
-    pub async fn read_to_end(&self, size_limit: u32) -> Result<Vec<u8>> {
+    pub async fn read_to_end(&self, size_limit: u32) -> Result<Uint8Array> {
         let mut r = self.0.lock().await;
         let res = r
             .read_to_end(size_limit as usize)
             .await
             .map_err(|e| anyhow::anyhow!("{e:?}"))?;
-        Ok(res)
+        Ok(res.into())
     }
 
     #[napi]

--- a/iroh-js/src/key.rs
+++ b/iroh-js/src/key.rs
@@ -44,8 +44,8 @@ impl EndpointId {
 
     /// Get the underlying 32 bytes.
     #[napi]
-    pub fn to_bytes(&self) -> Vec<u8> {
-        self.key.to_vec()
+    pub fn to_bytes(&self) -> Uint8Array {
+        self.key.to_vec().into()
     }
 
     /// Parse an [`EndpointId`] from its base32 representation.
@@ -57,8 +57,9 @@ impl EndpointId {
 
     /// Construct an [`EndpointId`] from raw bytes (32 bytes).
     #[napi(factory)]
-    pub fn from_bytes(bytes: Vec<u8>) -> Result<Self> {
+    pub fn from_bytes(bytes: Uint8Array) -> Result<Self> {
         let bytes: [u8; 32] = bytes
+            .as_ref()
             .try_into()
             .map_err(|_| anyhow::anyhow!("EndpointId requires exactly 32 bytes"))?;
         let key = iroh::EndpointId::from_bytes(&bytes).map_err(anyhow::Error::from)?;
@@ -79,7 +80,7 @@ impl EndpointId {
 
     /// Verify a signature on `message` against this endpoint's key.
     #[napi]
-    pub fn verify(&self, message: Vec<u8>, signature: &Signature) -> Result<()> {
+    pub fn verify(&self, message: Uint8Array, signature: &Signature) -> Result<()> {
         iroh::EndpointId::from(self)
             .verify(&message, &signature.0)
             .map_err(|e| anyhow::anyhow!("signature verification failed: {e:?}").into())
@@ -113,8 +114,9 @@ impl SecretKey {
 
     /// Construct from raw bytes (32 bytes).
     #[napi(factory)]
-    pub fn from_bytes(bytes: Vec<u8>) -> Result<Self> {
+    pub fn from_bytes(bytes: Uint8Array) -> Result<Self> {
         let bytes: [u8; 32] = bytes
+            .as_ref()
             .try_into()
             .map_err(|_| anyhow::anyhow!("SecretKey requires exactly 32 bytes"))?;
         Ok(SecretKey(iroh::SecretKey::from_bytes(&bytes)))
@@ -122,8 +124,8 @@ impl SecretKey {
 
     /// Raw 32-byte form.
     #[napi]
-    pub fn to_bytes(&self) -> Vec<u8> {
-        self.0.to_bytes().to_vec()
+    pub fn to_bytes(&self) -> Uint8Array {
+        self.0.to_bytes().to_vec().into()
     }
 
     /// The public [`EndpointId`] derived from this secret key.
@@ -134,7 +136,7 @@ impl SecretKey {
 
     /// Sign a message, producing an ed25519 signature.
     #[napi]
-    pub fn sign(&self, message: Vec<u8>) -> Signature {
+    pub fn sign(&self, message: Uint8Array) -> Signature {
         Signature(self.0.sign(&message))
     }
 }
@@ -148,8 +150,9 @@ pub struct Signature(pub(crate) iroh_base::Signature);
 impl Signature {
     /// Construct from raw bytes (64 bytes).
     #[napi(factory)]
-    pub fn from_bytes(bytes: Vec<u8>) -> Result<Self> {
+    pub fn from_bytes(bytes: Uint8Array) -> Result<Self> {
         let bytes: [u8; 64] = bytes
+            .as_ref()
             .try_into()
             .map_err(|_| anyhow::anyhow!("Signature requires exactly 64 bytes"))?;
         Ok(Signature(iroh_base::Signature::from_bytes(&bytes)))
@@ -157,8 +160,8 @@ impl Signature {
 
     /// Raw 64-byte form.
     #[napi]
-    pub fn to_bytes(&self) -> Vec<u8> {
-        self.0.to_bytes().to_vec()
+    pub fn to_bytes(&self) -> Uint8Array {
+        self.0.to_bytes().to_vec().into()
     }
 
     /// Lowercase hex representation.

--- a/iroh-js/test/endpoint.mjs
+++ b/iroh-js/test/endpoint.mjs
@@ -4,7 +4,7 @@ import assert from 'node:assert'
 import pkg from '../index.js'
 const { Endpoint, EndpointTicket, RelayMode, presetMinimal } = pkg
 
-const ALPN = Array.from(Buffer.from('iroh-ffi/test/0', 'utf8'))
+const ALPN = Buffer.from('iroh-ffi/test/0', 'utf8')
 
 // A "preset" in JS is any function that configures an EndpointBuilder.
 async function bindMinimal() {
@@ -93,7 +93,8 @@ suite('endpoint', () => {
       assert.ok(incoming)
       const accepting = await incoming.accept()
       const conn = await accepting.connect()
-      assert.deepEqual(conn.alpn(), ALPN)
+      assert.ok(conn.alpn() instanceof Uint8Array)
+      assert.deepEqual(conn.alpn(), new Uint8Array(ALPN))
       const bi = await conn.acceptBi()
       const recv = bi.recv
       const send = bi.send
@@ -111,19 +112,21 @@ suite('endpoint', () => {
     assert.ok(conn.paths().length > 0)
 
     const bi = await conn.openBi()
-    await bi.send.writeAll(Array.from(Buffer.from('hello iroh')))
+    await bi.send.writeAll(Buffer.from('hello iroh'))
     await bi.send.finish()
     const echoed = await bi.recv.readToEnd(64)
+    assert.ok(echoed instanceof Uint8Array)
     assert.equal(Buffer.from(echoed).toString('utf8'), 'hello iroh')
 
-    conn.sendDatagram(Array.from(Buffer.from('ping')))
+    conn.sendDatagram(Buffer.from('ping'))
     const pong = await conn.readDatagram()
+    assert.ok(pong instanceof Uint8Array)
     assert.equal(Buffer.from(pong).toString('utf8'), 'ping')
 
     const stats = conn.stats()
     assert.ok(stats.udpTxDatagrams > 0)
 
-    conn.close(0n, Array.from(Buffer.from('bye')))
+    conn.close(0n, Buffer.from('bye'))
     await serverTask
     await client.close()
     await server.close()
@@ -144,7 +147,7 @@ suite('endpoint', () => {
     const client = await bindClient()
     const conn = await client.connect(serverAddr, ALPN)
     const send = await conn.openUni()
-    await send.writeAll(Array.from(Buffer.from('unidirectional')))
+    await send.writeAll(Buffer.from('unidirectional'))
     await send.finish()
 
     await serverTask

--- a/iroh-js/test/key.mjs
+++ b/iroh-js/test/key.mjs
@@ -6,17 +6,18 @@ const { EndpointId, SecretKey, Signature } = pkg
 
 const keyStr = '523c7996bad77424e96786cf7a7205115337a5b4565cd25506a0f297b191a5ea'
 const fmtStr = '523c7996ba'
-const bytes = Array.from(new Uint8Array([
+const bytes = new Uint8Array([
   0x52, 0x3c, 0x79, 0x96, 0xba, 0xd7, 0x74, 0x24,
   0xe9, 0x67, 0x86, 0xcf, 0x7a, 0x72, 0x05, 0x11,
   0x53, 0x37, 0xa5, 0xb4, 0x56, 0x5c, 0xd2, 0x55,
   0x06, 0xa0, 0xf2, 0x97, 0xb1, 0x91, 0xa5, 0xea,
-]))
+])
 
 suite('endpoint id', () => {
   test('from string', () => {
     const id = EndpointId.fromString(keyStr)
     assert.equal(id.toString(), keyStr)
+    assert.ok(id.toBytes() instanceof Uint8Array)
     assert.deepEqual(id.toBytes(), bytes)
     assert.equal(id.fmtShort(), fmtStr)
   })
@@ -28,12 +29,19 @@ suite('endpoint id', () => {
     assert.equal(id.fmtShort(), fmtStr)
   })
 
+  // Regression for #276: byte inputs accept Buffer as well as Uint8Array
+  // (Node's Buffer is a Uint8Array subclass), no per-byte Array.from() copy.
+  test('from bytes: accepts Buffer', () => {
+    const id = EndpointId.fromBytes(Buffer.from(bytes))
+    assert.equal(id.toString(), keyStr)
+  })
+
   test('equality', () => {
     assert.ok(EndpointId.fromString(keyStr).equals(EndpointId.fromBytes(bytes)))
   })
 
   test('rejects bad bytes', () => {
-    assert.throws(() => EndpointId.fromBytes([1, 2, 3]))
+    assert.throws(() => EndpointId.fromBytes(new Uint8Array([1, 2, 3])))
   })
 })
 
@@ -41,6 +49,7 @@ suite('secret key', () => {
   test('bytes round trip', () => {
     const secret = SecretKey.generate()
     const raw = secret.toBytes()
+    assert.ok(raw instanceof Uint8Array)
     assert.equal(raw.length, 32)
     const secret2 = SecretKey.fromBytes(raw)
     assert.deepEqual(secret.toBytes(), secret2.toBytes())
@@ -50,10 +59,11 @@ suite('secret key', () => {
   test('sign / verify round trip', () => {
     const secret = SecretKey.generate()
     const pub = secret.public()
-    const msg = Array.from(Buffer.from('hello iroh', 'utf8'))
+    const msg = Buffer.from('hello iroh', 'utf8')
     const sig = secret.sign(msg)
 
     const raw = sig.toBytes()
+    assert.ok(raw instanceof Uint8Array)
     assert.equal(raw.length, 64)
     const sig2 = Signature.fromBytes(raw)
     assert.deepEqual(sig2.toBytes(), raw)
@@ -65,7 +75,7 @@ suite('secret key', () => {
   test('verify rejects tampered message', () => {
     const secret = SecretKey.generate()
     const pub = secret.public()
-    const sig = secret.sign(Array.from(Buffer.from('original')))
-    assert.throws(() => pub.verify(Array.from(Buffer.from('tampered')), sig))
+    const sig = secret.sign(Buffer.from('original'))
+    assert.throws(() => pub.verify(Buffer.from('tampered'), sig))
   })
 })


### PR DESCRIPTION
Closes  #276

BREAKING: byte-bearing inputs now take Uint8Array 