### PR TITLE
feat(services): add preset_iroh_services for authenticated relays

### DIFF
--- a/iroh-js/index.d.ts
+++ b/iroh-js/index.d.ts
@@ -416,6 +416,26 @@ export interface PathStatsRecord {
   currentMtu: number
 }
 
+/**
+ * Point an endpoint at your project's dedicated relays.
+ *
+ * Mirrors `iroh_services::preset()`: mints a short-lived access token scoped to
+ * the endpoint's key and to relay use only, then configures the builder to use
+ * your relays with that token. Installs the crypto provider, like the other
+ * preset helpers, so it needs no baseline preset before it.
+ *
+ * Unlike the Rust builder, `relays` is required — there is no implicit fallback
+ * to the n0 public relays. Use [`crate::preset_n0`] if that is what you want.
+ *
+ * ```js
+ * const b = Endpoint.builder()
+ * presetIrohServices(b, { relays: [relayUrl], apiSecret: apiKey })
+ * const ep = await b.bind()
+ * await ep.online()
+ * ```
+ */
+export declare function presetIrohServices(builder: EndpointBuilder, options: ServicesPresetOptions): void
+
 /** The minimal preset (no external dependencies; good for tests / offline). */
 export declare function presetMinimal(builder: EndpointBuilder): void
 
@@ -444,6 +464,37 @@ export interface ServicesOptions {
   name?: string
   /** Metrics push interval (ms). `0` disables interval pushes. */
   metricsIntervalMs?: number
+}
+
+/**
+ * Options for [`preset_iroh_services`].
+ *
+ * Supply *exactly one* of `api_secret` or `api_secret_from_env`.
+ */
+export interface ServicesPresetOptions {
+  /**
+   * Your project's relay URLs. Required, and must be non-empty: this preset
+   * exists to point an endpoint at dedicated relays. To use the n0 public
+   * relays instead, apply [`crate::preset_n0`].
+   */
+  relays: Array<string>
+  /**
+   * Encoded API secret string (`services1...`). The relay access token is
+   * minted from this.
+   */
+  apiSecret?: string
+  /** If true, read the API secret from `IROH_SERVICES_API_SECRET`. */
+  apiSecretFromEnv?: boolean
+  /**
+   * The endpoint's own identity key (32 bytes) — not your API secret. The
+   * access token is scoped to it, so pass the same key you persist for your
+   * endpoint's identity. A fresh key is generated when omitted.
+   *
+   * Set the key *here*, not via `EndpointBuilder.secretKey`: a key applied
+   * after this preset replaces the one the token is scoped to, and the relays
+   * reject the endpoint.
+   */
+  endpointSecretKey?: Array<number>
 }
 
 /** Set the logging level. */

--- a/iroh-js/index.d.ts
+++ b/iroh-js/index.d.ts
@@ -424,9 +424,6 @@ export interface PathStatsRecord {
  * your relays with that token. Installs the crypto provider, like the other
  * preset helpers, so it needs no baseline preset before it.
  *
- * Unlike the Rust builder, `relays` is required — there is no implicit fallback
- * to the n0 public relays. Use [`crate::preset_n0`] if that is what you want.
- *
  * ```js
  * const b = Endpoint.builder()
  * presetIrohServices(b, { relays: [relayUrl], apiSecret: apiKey })
@@ -473,11 +470,12 @@ export interface ServicesOptions {
  */
 export interface ServicesPresetOptions {
   /**
-   * Your project's relay URLs. Required, and must be non-empty: this preset
-   * exists to point an endpoint at dedicated relays. To use the n0 public
-   * relays instead, apply [`crate::preset_n0`].
+   * Your project's relay URLs. Defaults to the n0 public relays when
+   * omitted, matching `iroh_services::preset()`. Passing an empty list is an
+   * error rather than a silent fallback — that is nearly always a filtered
+   * list that came back empty.
    */
-  relays: Array<string>
+  relays?: Array<string>
   /**
    * Encoded API secret string (`services1...`). The relay access token is
    * minted from this.

--- a/iroh-js/index.d.ts
+++ b/iroh-js/index.d.ts
@@ -139,7 +139,12 @@ export declare class EndpointBuilder {
   applyMinimal(): void
   /** Replay the n0 preset with relays disabled. */
   applyN0DisableRelay(): void
-  /** Set the endpoint secret key (32 bytes). */
+  /**
+   * Set the endpoint secret key (32 bytes).
+   *
+   * Throws if a preset already pinned the key because it minted a credential
+   * scoped to it — see [`crate::preset_iroh_services`].
+   */
   secretKey(bytes: Array<number>): void
   /** Set the advertised ALPNs. */
   alpns(alpns: Array<Array<number>>): void
@@ -489,8 +494,8 @@ export interface ServicesPresetOptions {
    * endpoint's identity. A fresh key is generated when omitted.
    *
    * Set the key *here*, not via `EndpointBuilder.secretKey`: a key applied
-   * after this preset replaces the one the token is scoped to, and the relays
-   * reject the endpoint.
+   * after this preset would replace the one the token is scoped to. Doing
+   * that throws, rather than silently failing auth — this preset pins the key.
    */
   endpointSecretKey?: Array<number>
 }

--- a/iroh-js/index.d.ts
+++ b/iroh-js/index.d.ts
@@ -495,7 +495,8 @@ export interface ServicesPresetOptions {
    *
    * Set the key *here*, not via `EndpointBuilder.secretKey`: a key applied
    * after this preset would replace the one the token is scoped to. Doing
-   * that throws, rather than silently failing auth — this preset pins the key.
+   * that throws — even for bit-identical bytes — rather than silently
+   * failing auth: this preset pins the key.
    */
   endpointSecretKey?: Array<number>
 }

--- a/iroh-js/src/endpoint.rs
+++ b/iroh-js/src/endpoint.rs
@@ -37,7 +37,11 @@ impl EndpointBuilder {
     /// Record that a preset minted a credential scoped to the key it just set,
     /// so a later [`Self::secret_key`] would invalidate that credential rather
     /// than simply changing the endpoint's identity.
+    ///
+    /// Takes the builder mutex so the flag becomes visible atomically with any
+    /// subsequent [`Self::secret_key`] check, closing the check-then-act window.
     pub(crate) fn pin_secret_key(&self) {
+        let _guard = self.inner.lock().unwrap();
         self.key_pinned
             .store(true, std::sync::atomic::Ordering::Relaxed);
     }
@@ -85,6 +89,10 @@ impl EndpointBuilder {
     /// scoped to it — see [`crate::preset_iroh_services`].
     #[napi]
     pub fn secret_key(&self, bytes: Vec<u8>) -> Result<()> {
+        let key: [u8; 32] = bytes
+            .try_into()
+            .map_err(|_| anyhow::anyhow!("secret_key must be 32 bytes"))?;
+        let mut guard = self.inner.lock().unwrap();
         if self.key_pinned.load(std::sync::atomic::Ordering::Relaxed) {
             return Err(anyhow::anyhow!(
                 "endpoint secret key is pinned by presetIrohServices: its relay access token is \
@@ -93,10 +101,8 @@ impl EndpointBuilder {
             )
             .into());
         }
-        let key: [u8; 32] = bytes
-            .try_into()
-            .map_err(|_| anyhow::anyhow!("secret_key must be 32 bytes"))?;
-        self.map(|b| b.secret_key(iroh::SecretKey::from_bytes(&key)));
+        let b = guard.take().expect("EndpointBuilder consumed");
+        *guard = Some(b.secret_key(iroh::SecretKey::from_bytes(&key)));
         Ok(())
     }
 

--- a/iroh-js/src/endpoint.rs
+++ b/iroh-js/src/endpoint.rs
@@ -40,6 +40,13 @@ impl EndpointBuilder {
         let b = guard.take().expect("EndpointBuilder consumed");
         *guard = Some(f(b));
     }
+
+    /// Replay an upstream `iroh::endpoint::presets::Preset` on the wrapped
+    /// builder, so a preset helper can delegate to a real iroh preset instead
+    /// of re-implementing it against [`EndpointBuilder`].
+    pub(crate) fn apply_iroh_preset(&self, preset: impl presets::Preset) {
+        self.map(|b| preset.apply(b));
+    }
 }
 
 #[napi]

--- a/iroh-js/src/endpoint.rs
+++ b/iroh-js/src/endpoint.rs
@@ -23,13 +23,23 @@ use crate::{EndpointAddr, RelayMode, SecretKey, WatchHandle, path, watch};
 #[napi]
 pub struct EndpointBuilder {
     inner: std::sync::Mutex<Option<iroh::endpoint::Builder>>,
+    key_pinned: std::sync::atomic::AtomicBool,
 }
 
 impl EndpointBuilder {
     fn new(builder: iroh::endpoint::Builder) -> Self {
         Self {
             inner: std::sync::Mutex::new(Some(builder)),
+            key_pinned: std::sync::atomic::AtomicBool::new(false),
         }
+    }
+
+    /// Record that a preset minted a credential scoped to the key it just set,
+    /// so a later [`Self::secret_key`] would invalidate that credential rather
+    /// than simply changing the endpoint's identity.
+    pub(crate) fn pin_secret_key(&self) {
+        self.key_pinned
+            .store(true, std::sync::atomic::Ordering::Relaxed);
     }
 
     fn map<F>(&self, f: F)
@@ -70,8 +80,19 @@ impl EndpointBuilder {
     }
 
     /// Set the endpoint secret key (32 bytes).
+    ///
+    /// Throws if a preset already pinned the key because it minted a credential
+    /// scoped to it — see [`crate::preset_iroh_services`].
     #[napi]
     pub fn secret_key(&self, bytes: Vec<u8>) -> Result<()> {
+        if self.key_pinned.load(std::sync::atomic::Ordering::Relaxed) {
+            return Err(anyhow::anyhow!(
+                "endpoint secret key is pinned by presetIrohServices: its relay access token is \
+                 scoped to that key, so replacing it would make the relays reject this endpoint. \
+                 Set the key via ServicesPresetOptions.endpointSecretKey instead."
+            )
+            .into());
+        }
         let key: [u8; 32] = bytes
             .try_into()
             .map_err(|_| anyhow::anyhow!("secret_key must be 32 bytes"))?;

--- a/iroh-js/src/services.rs
+++ b/iroh-js/src/services.rs
@@ -12,10 +12,11 @@ use crate::{Endpoint, EndpointBuilder};
 #[derive(Debug, Default)]
 #[napi(object)]
 pub struct ServicesPresetOptions {
-    /// Your project's relay URLs. Required, and must be non-empty: this preset
-    /// exists to point an endpoint at dedicated relays. To use the n0 public
-    /// relays instead, apply [`crate::preset_n0`].
-    pub relays: Vec<String>,
+    /// Your project's relay URLs. Defaults to the n0 public relays when
+    /// omitted, matching `iroh_services::preset()`. Passing an empty list is an
+    /// error rather than a silent fallback — that is nearly always a filtered
+    /// list that came back empty.
+    pub relays: Option<Vec<String>>,
     /// Encoded API secret string (`services1...`). The relay access token is
     /// minted from this.
     pub api_secret: Option<String>,
@@ -38,9 +39,6 @@ pub struct ServicesPresetOptions {
 /// your relays with that token. Installs the crypto provider, like the other
 /// preset helpers, so it needs no baseline preset before it.
 ///
-/// Unlike the Rust builder, `relays` is required — there is no implicit fallback
-/// to the n0 public relays. Use [`crate::preset_n0`] if that is what you want.
-///
 /// ```js
 /// const b = Endpoint.builder()
 /// presetIrohServices(b, { relays: [relayUrl], apiSecret: apiKey })
@@ -52,13 +50,6 @@ pub fn preset_iroh_services(
     builder: &EndpointBuilder,
     options: ServicesPresetOptions,
 ) -> Result<()> {
-    if options.relays.is_empty() {
-        return Err(anyhow::anyhow!(
-            "ServicesPresetOptions requires at least one relay url; use presetN0() for the n0 public relays"
-        )
-        .into());
-    }
-
     let mut preset = iroh_services::preset();
 
     preset = match (
@@ -85,9 +76,18 @@ pub fn preset_iroh_services(
             .map_err(|e| anyhow::anyhow!("api secret env var: {e:?}"))?,
     };
 
-    preset = preset
-        .relays(options.relays)
-        .map_err(|e| anyhow::anyhow!("invalid relay url: {e:?}"))?;
+    // Omitted relays keep the builder's n0 default; an empty list does not.
+    if let Some(relays) = options.relays {
+        if relays.is_empty() {
+            return Err(anyhow::anyhow!(
+                "ServicesPresetOptions: relays is empty; omit it to use the n0 relays"
+            )
+            .into());
+        }
+        preset = preset
+            .relays(relays)
+            .map_err(|e| anyhow::anyhow!("invalid relay url: {e:?}"))?;
+    }
 
     if let Some(bytes) = options.endpoint_secret_key {
         let key: [u8; 32] = bytes

--- a/iroh-js/src/services.rs
+++ b/iroh-js/src/services.rs
@@ -28,7 +28,8 @@ pub struct ServicesPresetOptions {
     ///
     /// Set the key *here*, not via `EndpointBuilder.secretKey`: a key applied
     /// after this preset would replace the one the token is scoped to. Doing
-    /// that throws, rather than silently failing auth — this preset pins the key.
+    /// that throws — even for bit-identical bytes — rather than silently
+    /// failing auth: this preset pins the key.
     pub endpoint_secret_key: Option<Vec<u8>>,
 }
 

--- a/iroh-js/src/services.rs
+++ b/iroh-js/src/services.rs
@@ -27,8 +27,8 @@ pub struct ServicesPresetOptions {
     /// endpoint's identity. A fresh key is generated when omitted.
     ///
     /// Set the key *here*, not via `EndpointBuilder.secretKey`: a key applied
-    /// after this preset replaces the one the token is scoped to, and the relays
-    /// reject the endpoint.
+    /// after this preset would replace the one the token is scoped to. Doing
+    /// that throws, rather than silently failing auth — this preset pins the key.
     pub endpoint_secret_key: Option<Vec<u8>>,
 }
 
@@ -101,6 +101,9 @@ pub fn preset_iroh_services(
         .build()
         .map_err(|e| anyhow::anyhow!("services preset build failed: {e:?}"))?;
     builder.apply_iroh_preset(preset);
+    // The access token is scoped to the key the preset just set, so a later
+    // `secretKey` call must throw rather than silently break relay auth.
+    builder.pin_secret_key();
     Ok(())
 }
 

--- a/iroh-js/src/services.rs
+++ b/iroh-js/src/services.rs
@@ -4,7 +4,105 @@ use iroh_services::{Client, ClientBuilder};
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
 
-use crate::Endpoint;
+use crate::{Endpoint, EndpointBuilder};
+
+/// Options for [`preset_iroh_services`].
+///
+/// Supply *exactly one* of `api_secret` or `api_secret_from_env`.
+#[derive(Debug, Default)]
+#[napi(object)]
+pub struct ServicesPresetOptions {
+    /// Your project's relay URLs. Required, and must be non-empty: this preset
+    /// exists to point an endpoint at dedicated relays. To use the n0 public
+    /// relays instead, apply [`crate::preset_n0`].
+    pub relays: Vec<String>,
+    /// Encoded API secret string (`services1...`). The relay access token is
+    /// minted from this.
+    pub api_secret: Option<String>,
+    /// If true, read the API secret from `IROH_SERVICES_API_SECRET`.
+    pub api_secret_from_env: Option<bool>,
+    /// The endpoint's own identity key (32 bytes) — not your API secret. The
+    /// access token is scoped to it, so pass the same key you persist for your
+    /// endpoint's identity. A fresh key is generated when omitted.
+    ///
+    /// Set the key *here*, not via `EndpointBuilder.secretKey`: a key applied
+    /// after this preset replaces the one the token is scoped to, and the relays
+    /// reject the endpoint.
+    pub endpoint_secret_key: Option<Vec<u8>>,
+}
+
+/// Point an endpoint at your project's dedicated relays.
+///
+/// Mirrors `iroh_services::preset()`: mints a short-lived access token scoped to
+/// the endpoint's key and to relay use only, then configures the builder to use
+/// your relays with that token. Installs the crypto provider, like the other
+/// preset helpers, so it needs no baseline preset before it.
+///
+/// Unlike the Rust builder, `relays` is required — there is no implicit fallback
+/// to the n0 public relays. Use [`crate::preset_n0`] if that is what you want.
+///
+/// ```js
+/// const b = Endpoint.builder()
+/// presetIrohServices(b, { relays: [relayUrl], apiSecret: apiKey })
+/// const ep = await b.bind()
+/// await ep.online()
+/// ```
+#[napi]
+pub fn preset_iroh_services(
+    builder: &EndpointBuilder,
+    options: ServicesPresetOptions,
+) -> Result<()> {
+    if options.relays.is_empty() {
+        return Err(anyhow::anyhow!(
+            "ServicesPresetOptions requires at least one relay url; use presetN0() for the n0 public relays"
+        )
+        .into());
+    }
+
+    let mut preset = iroh_services::preset();
+
+    preset = match (
+        options.api_secret,
+        options.api_secret_from_env.unwrap_or(false),
+    ) {
+        (Some(_), true) => {
+            return Err(anyhow::anyhow!(
+                "ServicesPresetOptions: supply only one of api_secret / api_secret_from_env"
+            )
+            .into());
+        }
+        (None, false) => {
+            return Err(anyhow::anyhow!(
+                "ServicesPresetOptions requires one of api_secret or api_secret_from_env=true"
+            )
+            .into());
+        }
+        (Some(secret), false) => preset
+            .api_secret_from_str(&secret)
+            .map_err(|e| anyhow::anyhow!("invalid api secret: {e:?}"))?,
+        (None, true) => preset
+            .api_secret_from_env()
+            .map_err(|e| anyhow::anyhow!("api secret env var: {e:?}"))?,
+    };
+
+    preset = preset
+        .relays(options.relays)
+        .map_err(|e| anyhow::anyhow!("invalid relay url: {e:?}"))?;
+
+    if let Some(bytes) = options.endpoint_secret_key {
+        let key: [u8; 32] = bytes
+            .as_slice()
+            .try_into()
+            .map_err(|e| anyhow::anyhow!("invalid endpoint secret key length: {e:?}"))?;
+        preset = preset.secret_key(iroh::SecretKey::from_bytes(&key));
+    }
+
+    let preset = preset
+        .build()
+        .map_err(|e| anyhow::anyhow!("services preset build failed: {e:?}"))?;
+    builder.apply_iroh_preset(preset);
+    Ok(())
+}
 
 /// Build options for [`ServicesClient`].
 #[derive(Debug, Default)]

--- a/iroh-js/test/services.mjs
+++ b/iroh-js/test/services.mjs
@@ -75,7 +75,10 @@ suite('services preset', () => {
     )
   })
 
-  test('requires relays — no implicit fallback to n0', () => {
+  test('relays', () => {
+    // Omitted falls back to the n0 relays, as in Rust.
+    presetIrohServices(Endpoint.builder(), { apiSecret: FAKE_API_SECRET })
+    // An explicitly empty list does not.
     assert.throws(() =>
       presetIrohServices(Endpoint.builder(), { relays: [], apiSecret: FAKE_API_SECRET }),
     )

--- a/iroh-js/test/services.mjs
+++ b/iroh-js/test/services.mjs
@@ -75,6 +75,14 @@ suite('services preset', () => {
     )
   })
 
+  test('pins the endpoint key', () => {
+    // The token is scoped to the preset's key, so setting one afterwards must
+    // throw rather than break relay auth at connect time.
+    const b = Endpoint.builder()
+    presetIrohServices(b, { relays, apiSecret: FAKE_API_SECRET })
+    assert.throws(() => b.secretKey(Buffer.alloc(32, 7)))
+  })
+
   test('relays', () => {
     // Omitted falls back to the n0 relays, as in Rust.
     presetIrohServices(Endpoint.builder(), { apiSecret: FAKE_API_SECRET })

--- a/iroh-js/test/services.mjs
+++ b/iroh-js/test/services.mjs
@@ -2,7 +2,7 @@ import { test, suite } from 'node:test'
 import assert from 'node:assert'
 
 import pkg from '../index.js'
-const { Endpoint, ServicesClient, presetMinimal } = pkg
+const { Endpoint, ServicesClient, presetIrohServices, presetMinimal } = pkg
 
 // Well-formed (but fake) API secret — the remote does not exist, but the
 // client connects lazily so construction still succeeds. Validates the
@@ -43,5 +43,47 @@ suite('services client', () => {
     const ep = await endpoint()
     await assert.rejects(ServicesClient.create(ep, { apiSecret: 'not-a-valid-ticket' }))
     await ep.close()
+  })
+})
+
+suite('services preset', () => {
+  const relays = ['https://relay.example.org/']
+
+  test('binds with custom relays', async () => {
+    // The relay is unreachable, but bind does not connect, so this checks the
+    // mint -> relay map -> builder plumbing.
+    const b = Endpoint.builder()
+    presetIrohServices(b, { relays, apiSecret: FAKE_API_SECRET })
+    const ep = await b.bind()
+    assert.ok(ep.boundSockets().length > 0)
+    await ep.close()
+  })
+
+  test('rejects bad options', () => {
+    const b = () => Endpoint.builder()
+    assert.throws(() => presetIrohServices(b(), { relays }))
+    assert.throws(() =>
+      presetIrohServices(b(), { relays, apiSecret: FAKE_API_SECRET, apiSecretFromEnv: true }),
+    )
+    assert.throws(() => presetIrohServices(b(), { relays, apiSecret: 'not-a-valid-ticket' }))
+    assert.throws(() =>
+      presetIrohServices(b(), {
+        relays,
+        apiSecret: FAKE_API_SECRET,
+        endpointSecretKey: Buffer.alloc(16),
+      }),
+    )
+  })
+
+  test('requires relays — no implicit fallback to n0', () => {
+    assert.throws(() =>
+      presetIrohServices(Endpoint.builder(), { relays: [], apiSecret: FAKE_API_SECRET }),
+    )
+    assert.throws(() =>
+      presetIrohServices(Endpoint.builder(), {
+        relays: ['not a url'],
+        apiSecret: FAKE_API_SECRET,
+      }),
+    )
   })
 })

--- a/kotlin/lib/src/main/kotlin/computer/iroh/iroh_ffi.kt
+++ b/kotlin/lib/src/main/kotlin/computer/iroh/iroh_ffi.kt
@@ -2706,7 +2706,7 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
     if (lib.uniffi_iroh_ffi_checksum_method_endpointbuilder_relay_mode() != 17405) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_iroh_ffi_checksum_method_endpointbuilder_secret_key() != 35604) {
+    if (lib.uniffi_iroh_ffi_checksum_method_endpointbuilder_secret_key() != 1964) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_iroh_ffi_checksum_method_preset_apply() != 64281) {
@@ -6693,6 +6693,9 @@ public interface EndpointBuilderInterface {
 
     /**
      * Set the endpoint secret key (32 bytes).
+     *
+     * Errors if a preset already pinned the key because it minted a credential
+     * scoped to it — see `preset_iroh_services`.
      */
     fun `secretKey`(`bytes`: kotlin.ByteArray)
 
@@ -6930,6 +6933,9 @@ open class EndpointBuilder :
 
     /**
      * Set the endpoint secret key (32 bytes).
+     *
+     * Errors if a preset already pinned the key because it minted a credential
+     * scoped to it — see `preset_iroh_services`.
      */
     @Throws(IrohException::class)
     override fun `secretKey`(`bytes`: kotlin.ByteArray) =
@@ -14132,8 +14138,9 @@ data class ServicesPresetOptions(
      * endpoint's identity. A fresh key is generated when omitted.
      *
      * Set the key *here*, not on `EndpointOptions::secret_key`: option fields
-     * are layered on top of the preset, so an `EndpointOptions` key replaces
-     * the one the token is scoped to and the relays reject the endpoint.
+     * are layered on top of the preset, so an `EndpointOptions` key would
+     * replace the one the token is scoped to. Doing that is an error, not a
+     * silent auth failure — this preset pins the key.
      */
     var `endpointSecretKey`: kotlin.ByteArray? = null,
 ) {

--- a/kotlin/lib/src/main/kotlin/computer/iroh/iroh_ffi.kt
+++ b/kotlin/lib/src/main/kotlin/computer/iroh/iroh_ffi.kt
@@ -2508,7 +2508,7 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
     if (lib.uniffi_iroh_ffi_checksum_func_preset_n0_disable_relay() != 45395) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_iroh_ffi_checksum_func_preset_iroh_services() != 23155) {
+    if (lib.uniffi_iroh_ffi_checksum_func_preset_iroh_services() != 59955) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_iroh_ffi_checksum_method_accepting_alpn() != 1935) {
@@ -14111,11 +14111,12 @@ public object FfiConverterTypeServicesOptions : FfiConverterRustBuffer<ServicesO
  */
 data class ServicesPresetOptions(
     /**
-     * Your project's relay URLs. Required, and must be non-empty: this preset
-     * exists to point an endpoint at dedicated relays. To use the n0 public
-     * relays instead, pass [`crate::preset_n0`] as the endpoint's preset.
+     * Your project's relay URLs. Defaults to the n0 public relays when
+     * omitted, matching `iroh_services::preset()`. Passing an empty list is an
+     * error rather than a silent fallback — that is nearly always a filtered
+     * list that came back empty.
      */
-    var `relays`: List<kotlin.String>,
+    var `relays`: List<kotlin.String>? = null,
     /**
      * Encoded API secret string (`services1...`). The relay access token is
      * minted from this.
@@ -14145,7 +14146,7 @@ data class ServicesPresetOptions(
 public object FfiConverterTypeServicesPresetOptions : FfiConverterRustBuffer<ServicesPresetOptions> {
     override fun read(buf: ByteBuffer): ServicesPresetOptions =
         ServicesPresetOptions(
-            FfiConverterSequenceString.read(buf),
+            FfiConverterOptionalSequenceString.read(buf),
             FfiConverterOptionalString.read(buf),
             FfiConverterOptionalBoolean.read(buf),
             FfiConverterOptionalByteArray.read(buf),
@@ -14153,7 +14154,7 @@ public object FfiConverterTypeServicesPresetOptions : FfiConverterRustBuffer<Ser
 
     override fun allocationSize(value: ServicesPresetOptions) =
         (
-            FfiConverterSequenceString.allocationSize(value.`relays`) +
+            FfiConverterOptionalSequenceString.allocationSize(value.`relays`) +
                 FfiConverterOptionalString.allocationSize(value.`apiSecret`) +
                 FfiConverterOptionalBoolean.allocationSize(value.`apiSecretFromEnv`) +
                 FfiConverterOptionalByteArray.allocationSize(value.`endpointSecretKey`)
@@ -14163,7 +14164,7 @@ public object FfiConverterTypeServicesPresetOptions : FfiConverterRustBuffer<Ser
         value: ServicesPresetOptions,
         buf: ByteBuffer,
     ) {
-        FfiConverterSequenceString.write(value.`relays`, buf)
+        FfiConverterOptionalSequenceString.write(value.`relays`, buf)
         FfiConverterOptionalString.write(value.`apiSecret`, buf)
         FfiConverterOptionalBoolean.write(value.`apiSecretFromEnv`, buf)
         FfiConverterOptionalByteArray.write(value.`endpointSecretKey`, buf)
@@ -15151,6 +15152,38 @@ public object FfiConverterOptionalTypeRelayConfig : FfiConverterRustBuffer<Relay
 /**
  * @suppress
  */
+public object FfiConverterOptionalSequenceString : FfiConverterRustBuffer<List<kotlin.String>?> {
+    override fun read(buf: ByteBuffer): List<kotlin.String>? {
+        if (buf.get().toInt() == 0) {
+            return null
+        }
+        return FfiConverterSequenceString.read(buf)
+    }
+
+    override fun allocationSize(value: List<kotlin.String>?): ULong {
+        if (value == null) {
+            return 1UL
+        } else {
+            return 1UL + FfiConverterSequenceString.allocationSize(value)
+        }
+    }
+
+    override fun write(
+        value: List<kotlin.String>?,
+        buf: ByteBuffer,
+    ) {
+        if (value == null) {
+            buf.put(0)
+        } else {
+            buf.put(1)
+            FfiConverterSequenceString.write(value, buf)
+        }
+    }
+}
+
+/**
+ * @suppress
+ */
 public object FfiConverterOptionalSequenceByteArray : FfiConverterRustBuffer<List<kotlin.ByteArray>?> {
     override fun read(buf: ByteBuffer): List<kotlin.ByteArray>? {
         if (buf.get().toInt() == 0) {
@@ -15422,9 +15455,6 @@ fun `presetN0DisableRelay`(): Preset =
  * Mirrors `iroh_services::preset()`: mints a short-lived access token scoped to
  * the endpoint's key and to relay use only, then configures the endpoint to use
  * your relays with that token. Pass the result as `EndpointOptions::preset`.
- *
- * Unlike the Rust builder, `relays` is required — there is no implicit fallback
- * to the n0 public relays. Use [`crate::preset_n0`] if that is what you want.
  *
  * The token is minted here, at preset-build time, so build the preset shortly
  * before binding the endpoint.

--- a/kotlin/lib/src/main/kotlin/computer/iroh/iroh_ffi.kt
+++ b/kotlin/lib/src/main/kotlin/computer/iroh/iroh_ffi.kt
@@ -14126,16 +14126,15 @@ data class ServicesPresetOptions(
      */
     var `apiSecretFromEnv`: kotlin.Boolean? = null,
     /**
-     * Endpoint secret key (32 bytes) — the endpoint's own identity key, not
-     * your API secret. The access token is scoped to it, so pass the same key
-     * you persist for your endpoint's identity. A fresh key is generated when
-     * omitted.
+     * The endpoint's own identity key (32 bytes) — not your API secret. The
+     * access token is scoped to it, so pass the same key you persist for your
+     * endpoint's identity. A fresh key is generated when omitted.
      *
      * Set the key *here*, not on `EndpointOptions::secret_key`: option fields
      * are layered on top of the preset, so an `EndpointOptions` key replaces
      * the one the token is scoped to and the relays reject the endpoint.
      */
-    var `secretKey`: kotlin.ByteArray? = null,
+    var `endpointSecretKey`: kotlin.ByteArray? = null,
 ) {
     companion object
 }
@@ -14157,7 +14156,7 @@ public object FfiConverterTypeServicesPresetOptions : FfiConverterRustBuffer<Ser
             FfiConverterSequenceString.allocationSize(value.`relays`) +
                 FfiConverterOptionalString.allocationSize(value.`apiSecret`) +
                 FfiConverterOptionalBoolean.allocationSize(value.`apiSecretFromEnv`) +
-                FfiConverterOptionalByteArray.allocationSize(value.`secretKey`)
+                FfiConverterOptionalByteArray.allocationSize(value.`endpointSecretKey`)
         )
 
     override fun write(
@@ -14167,7 +14166,7 @@ public object FfiConverterTypeServicesPresetOptions : FfiConverterRustBuffer<Ser
         FfiConverterSequenceString.write(value.`relays`, buf)
         FfiConverterOptionalString.write(value.`apiSecret`, buf)
         FfiConverterOptionalBoolean.write(value.`apiSecretFromEnv`, buf)
-        FfiConverterOptionalByteArray.write(value.`secretKey`, buf)
+        FfiConverterOptionalByteArray.write(value.`endpointSecretKey`, buf)
     }
 }
 

--- a/kotlin/lib/src/main/kotlin/computer/iroh/iroh_ffi.kt
+++ b/kotlin/lib/src/main/kotlin/computer/iroh/iroh_ffi.kt
@@ -14137,10 +14137,10 @@ data class ServicesPresetOptions(
      * access token is scoped to it, so pass the same key you persist for your
      * endpoint's identity. A fresh key is generated when omitted.
      *
-     * Set the key *here*, not on `EndpointOptions::secret_key`: option fields
-     * are layered on top of the preset, so an `EndpointOptions` key would
-     * replace the one the token is scoped to. Doing that is an error, not a
-     * silent auth failure — this preset pins the key.
+     * Set the key *here*, not via `EndpointOptions::secret_key` or
+     * `EndpointBuilder::secret_key`: both are layered on top of the preset and
+     * would replace the one the token is scoped to. Doing that is an error,
+     * not a silent auth failure — this preset pins the key.
      */
     var `endpointSecretKey`: kotlin.ByteArray? = null,
 ) {

--- a/kotlin/lib/src/main/kotlin/computer/iroh/iroh_ffi.kt
+++ b/kotlin/lib/src/main/kotlin/computer/iroh/iroh_ffi.kt
@@ -1006,6 +1006,8 @@ internal object IntegrityCheckingUniffiLib {
 
     external fun uniffi_iroh_ffi_checksum_func_preset_n0_disable_relay(): Int
 
+    external fun uniffi_iroh_ffi_checksum_func_preset_iroh_services(): Int
+
     external fun uniffi_iroh_ffi_checksum_method_accepting_alpn(): Int
 
     external fun uniffi_iroh_ffi_checksum_method_accepting_connect(): Int
@@ -2275,6 +2277,11 @@ internal object UniffiLib {
 
     external fun uniffi_iroh_ffi_fn_func_preset_n0_disable_relay(uniffi_out_err: UniffiRustCallStatus): Long
 
+    external fun uniffi_iroh_ffi_fn_func_preset_iroh_services(
+        `options`: RustBuffer.ByValue,
+        uniffi_out_err: UniffiRustCallStatus,
+    ): Long
+
     external fun ffi_iroh_ffi_rustbuffer_alloc(
         `size`: Long,
         uniffi_out_err: UniffiRustCallStatus,
@@ -2499,6 +2506,9 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_iroh_ffi_checksum_func_preset_n0_disable_relay() != 45395) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_iroh_ffi_checksum_func_preset_iroh_services() != 23155) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_iroh_ffi_checksum_method_accepting_alpn() != 1935) {
@@ -14094,6 +14104,73 @@ public object FfiConverterTypeServicesOptions : FfiConverterRustBuffer<ServicesO
     }
 }
 
+/**
+ * Options for [`preset_iroh_services`].
+ *
+ * Supply *exactly one* of `api_secret` or `api_secret_from_env`.
+ */
+data class ServicesPresetOptions(
+    /**
+     * Your project's relay URLs. Required, and must be non-empty: this preset
+     * exists to point an endpoint at dedicated relays. To use the n0 public
+     * relays instead, pass [`crate::preset_n0`] as the endpoint's preset.
+     */
+    var `relays`: List<kotlin.String>,
+    /**
+     * Encoded API secret string (`services1...`). The relay access token is
+     * minted from this.
+     */
+    var `apiSecret`: kotlin.String? = null,
+    /**
+     * If true, read the API secret from `IROH_SERVICES_API_SECRET`.
+     */
+    var `apiSecretFromEnv`: kotlin.Boolean? = null,
+    /**
+     * Endpoint secret key (32 bytes) — the endpoint's own identity key, not
+     * your API secret. The access token is scoped to it, so pass the same key
+     * you persist for your endpoint's identity. A fresh key is generated when
+     * omitted.
+     *
+     * Set the key *here*, not on `EndpointOptions::secret_key`: option fields
+     * are layered on top of the preset, so an `EndpointOptions` key replaces
+     * the one the token is scoped to and the relays reject the endpoint.
+     */
+    var `secretKey`: kotlin.ByteArray? = null,
+) {
+    companion object
+}
+
+/**
+ * @suppress
+ */
+public object FfiConverterTypeServicesPresetOptions : FfiConverterRustBuffer<ServicesPresetOptions> {
+    override fun read(buf: ByteBuffer): ServicesPresetOptions =
+        ServicesPresetOptions(
+            FfiConverterSequenceString.read(buf),
+            FfiConverterOptionalString.read(buf),
+            FfiConverterOptionalBoolean.read(buf),
+            FfiConverterOptionalByteArray.read(buf),
+        )
+
+    override fun allocationSize(value: ServicesPresetOptions) =
+        (
+            FfiConverterSequenceString.allocationSize(value.`relays`) +
+                FfiConverterOptionalString.allocationSize(value.`apiSecret`) +
+                FfiConverterOptionalBoolean.allocationSize(value.`apiSecretFromEnv`) +
+                FfiConverterOptionalByteArray.allocationSize(value.`secretKey`)
+        )
+
+    override fun write(
+        value: ServicesPresetOptions,
+        buf: ByteBuffer,
+    ) {
+        FfiConverterSequenceString.write(value.`relays`, buf)
+        FfiConverterOptionalString.write(value.`apiSecret`, buf)
+        FfiConverterOptionalBoolean.write(value.`apiSecretFromEnv`, buf)
+        FfiConverterOptionalByteArray.write(value.`secretKey`, buf)
+    }
+}
+
 sealed class CallbackException : kotlin.Exception() {
     class Exception : CallbackException() {
         override val message
@@ -15337,5 +15414,26 @@ fun `presetN0DisableRelay`(): Preset =
     FfiConverterTypePreset.lift(
         uniffiRustCall { _status ->
             UniffiLib.uniffi_iroh_ffi_fn_func_preset_n0_disable_relay(_status)
+        },
+    )
+
+/**
+ * Build an endpoint preset for your project's dedicated relays.
+ *
+ * Mirrors `iroh_services::preset()`: mints a short-lived access token scoped to
+ * the endpoint's key and to relay use only, then configures the endpoint to use
+ * your relays with that token. Pass the result as `EndpointOptions::preset`.
+ *
+ * Unlike the Rust builder, `relays` is required — there is no implicit fallback
+ * to the n0 public relays. Use [`crate::preset_n0`] if that is what you want.
+ *
+ * The token is minted here, at preset-build time, so build the preset shortly
+ * before binding the endpoint.
+ */
+@Throws(IrohException::class)
+fun `presetIrohServices`(`options`: ServicesPresetOptions): Preset =
+    FfiConverterTypePreset.lift(
+        uniffiRustCallWithError(IrohException) { _status ->
+            UniffiLib.uniffi_iroh_ffi_fn_func_preset_iroh_services(FfiConverterTypeServicesPresetOptions.lower(`options`), _status)
         },
     )

--- a/python/services_test.py
+++ b/python/services_test.py
@@ -5,7 +5,15 @@
 # the options -> builder -> client plumbing without any network.
 import pytest
 
-from iroh import Endpoint, EndpointOptions, ServicesClient, ServicesOptions, preset_minimal
+from iroh import (
+    Endpoint,
+    EndpointOptions,
+    ServicesClient,
+    ServicesOptions,
+    ServicesPresetOptions,
+    preset_iroh_services,
+    preset_minimal,
+)
 
 FAKE_API_SECRET = (
     "servicesaaqaobyha4dqobyha4dqobyha4dqobyha4dqobyha4dqobyha4dqob"
@@ -46,3 +54,40 @@ async def test_services_client_rejects_malformed_secret():
     with pytest.raises(Exception):
         await ServicesClient.create(ep, ServicesOptions(api_secret="not-a-valid-ticket"))
     await ep.close()
+
+
+async def test_services_preset_binds_with_custom_relays():
+    # The relay is unreachable, but bind does not connect, so this checks the
+    # mint -> relay map -> builder plumbing.
+    preset = preset_iroh_services(
+        ServicesPresetOptions(
+            relays=["https://relay.example.org/"],
+            api_secret=FAKE_API_SECRET,
+        )
+    )
+    ep = await Endpoint.bind(EndpointOptions(preset=preset))
+    assert ep.bound_sockets()
+    await ep.close()
+
+
+def test_services_preset_rejects_bad_options():
+    relays = ["https://relay.example.org/"]
+    with pytest.raises(Exception):
+        preset_iroh_services(ServicesPresetOptions(relays=relays))
+    with pytest.raises(Exception):
+        preset_iroh_services(
+            ServicesPresetOptions(
+                relays=relays, api_secret=FAKE_API_SECRET, api_secret_from_env=True
+            )
+        )
+    with pytest.raises(Exception):
+        preset_iroh_services(
+            ServicesPresetOptions(relays=relays, api_secret="not-a-valid-ticket")
+        )
+    # No implicit fallback to the n0 relays.
+    with pytest.raises(Exception):
+        preset_iroh_services(ServicesPresetOptions(relays=[], api_secret=FAKE_API_SECRET))
+    with pytest.raises(Exception):
+        preset_iroh_services(
+            ServicesPresetOptions(relays=["not a url"], api_secret=FAKE_API_SECRET)
+        )

--- a/python/services_test.py
+++ b/python/services_test.py
@@ -84,10 +84,14 @@ def test_services_preset_rejects_bad_options():
         preset_iroh_services(
             ServicesPresetOptions(relays=relays, api_secret="not-a-valid-ticket")
         )
-    # No implicit fallback to the n0 relays.
+    # An explicitly empty list errors; omitting it falls back to the n0 relays.
     with pytest.raises(Exception):
         preset_iroh_services(ServicesPresetOptions(relays=[], api_secret=FAKE_API_SECRET))
     with pytest.raises(Exception):
         preset_iroh_services(
             ServicesPresetOptions(relays=["not a url"], api_secret=FAKE_API_SECRET)
         )
+
+
+def test_services_preset_defaults_to_n0_relays():
+    assert preset_iroh_services(ServicesPresetOptions(api_secret=FAKE_API_SECRET))

--- a/python/services_test.py
+++ b/python/services_test.py
@@ -95,3 +95,16 @@ def test_services_preset_rejects_bad_options():
 
 def test_services_preset_defaults_to_n0_relays():
     assert preset_iroh_services(ServicesPresetOptions(api_secret=FAKE_API_SECRET))
+
+
+async def test_services_preset_pins_the_endpoint_key():
+    # The token is scoped to the preset's key, so an EndpointOptions key must
+    # fail loudly rather than break relay auth at connect time.
+    preset = preset_iroh_services(
+        ServicesPresetOptions(
+            relays=["https://relay.example.org/"],
+            api_secret=FAKE_API_SECRET,
+        )
+    )
+    with pytest.raises(Exception):
+        await Endpoint.bind(EndpointOptions(preset=preset, secret_key=bytes(32)))

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -22,13 +22,23 @@ use crate::{
 #[derive(uniffi::Object)]
 pub struct EndpointBuilder {
     inner: std::sync::Mutex<Option<iroh::endpoint::Builder>>,
+    key_pinned: std::sync::atomic::AtomicBool,
 }
 
 impl EndpointBuilder {
     pub(crate) fn from_inner(builder: iroh::endpoint::Builder) -> Self {
         Self {
             inner: std::sync::Mutex::new(Some(builder)),
+            key_pinned: std::sync::atomic::AtomicBool::new(false),
         }
+    }
+
+    /// Record that a preset minted a credential scoped to the key it just set,
+    /// so a later [`Self::secret_key`] would invalidate that credential rather
+    /// than simply changing the endpoint's identity.
+    pub(crate) fn pin_secret_key(&self) {
+        self.key_pinned
+            .store(true, std::sync::atomic::Ordering::Relaxed);
     }
 
     fn map<F>(&self, f: F)
@@ -82,7 +92,17 @@ impl EndpointBuilder {
     }
 
     /// Set the endpoint secret key (32 bytes).
+    ///
+    /// Errors if a preset already pinned the key because it minted a credential
+    /// scoped to it — see `preset_iroh_services`.
     pub fn secret_key(&self, bytes: Vec<u8>) -> Result<(), IrohError> {
+        if self.key_pinned.load(std::sync::atomic::Ordering::Relaxed) {
+            return Err(IrohError::invalid_input(
+                "endpoint secret key is pinned by preset_iroh_services: its relay access token is \
+                 scoped to that key, so replacing it would make the relays reject this endpoint. \
+                 Set the key via ServicesPresetOptions.endpoint_secret_key instead.",
+            ));
+        }
         let key: [u8; 32] = AsRef::<[u8]>::as_ref(&bytes)
             .try_into()
             .map_err(|e| IrohError::invalid_input(format!("invalid secret key length: {e:?}")))?;

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -36,7 +36,11 @@ impl EndpointBuilder {
     /// Record that a preset minted a credential scoped to the key it just set,
     /// so a later [`Self::secret_key`] would invalidate that credential rather
     /// than simply changing the endpoint's identity.
+    ///
+    /// Takes the builder mutex so the flag becomes visible atomically with any
+    /// subsequent [`Self::secret_key`] check, closing the check-then-act window.
     pub(crate) fn pin_secret_key(&self) {
+        let _guard = self.inner.lock().unwrap();
         self.key_pinned
             .store(true, std::sync::atomic::Ordering::Relaxed);
     }
@@ -96,6 +100,11 @@ impl EndpointBuilder {
     /// Errors if a preset already pinned the key because it minted a credential
     /// scoped to it — see `preset_iroh_services`.
     pub fn secret_key(&self, bytes: Vec<u8>) -> Result<(), IrohError> {
+        let key: [u8; 32] = AsRef::<[u8]>::as_ref(&bytes)
+            .try_into()
+            .map_err(|e| IrohError::invalid_input(format!("invalid secret key length: {e:?}")))?;
+        let key = iroh::SecretKey::from_bytes(&key);
+        let mut guard = self.inner.lock().unwrap();
         if self.key_pinned.load(std::sync::atomic::Ordering::Relaxed) {
             return Err(IrohError::invalid_input(
                 "endpoint secret key is pinned by preset_iroh_services: its relay access token is \
@@ -103,11 +112,8 @@ impl EndpointBuilder {
                  Set the key via ServicesPresetOptions.endpoint_secret_key instead.",
             ));
         }
-        let key: [u8; 32] = AsRef::<[u8]>::as_ref(&bytes)
-            .try_into()
-            .map_err(|e| IrohError::invalid_input(format!("invalid secret key length: {e:?}")))?;
-        let key = iroh::SecretKey::from_bytes(&key);
-        self.map(|b| b.secret_key(key));
+        let builder = guard.take().expect("EndpointBuilder consumed");
+        *guard = Some(builder.secret_key(key));
         Ok(())
     }
 

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -40,6 +40,13 @@ impl EndpointBuilder {
         *guard = Some(f(builder));
     }
 
+    /// Replay an upstream `iroh::endpoint::presets::Preset` on the wrapped
+    /// builder. Lets a Rust-side [`Preset`] impl delegate to a real iroh preset
+    /// instead of re-implementing it against [`EndpointBuilder`].
+    pub(crate) fn apply_iroh_preset(&self, preset: impl presets::Preset) {
+        self.map(|b| preset.apply(b));
+    }
+
     pub(crate) fn take_inner(&self) -> Result<iroh::endpoint::Builder, IrohError> {
         self.inner
             .lock()

--- a/src/services.rs
+++ b/src/services.rs
@@ -57,16 +57,15 @@ pub struct ServicesPresetOptions {
     /// If true, read the API secret from `IROH_SERVICES_API_SECRET`.
     #[uniffi(default = None)]
     pub api_secret_from_env: Option<bool>,
-    /// Endpoint secret key (32 bytes) — the endpoint's own identity key, not
-    /// your API secret. The access token is scoped to it, so pass the same key
-    /// you persist for your endpoint's identity. A fresh key is generated when
-    /// omitted.
+    /// The endpoint's own identity key (32 bytes) — not your API secret. The
+    /// access token is scoped to it, so pass the same key you persist for your
+    /// endpoint's identity. A fresh key is generated when omitted.
     ///
     /// Set the key *here*, not on `EndpointOptions::secret_key`: option fields
     /// are layered on top of the preset, so an `EndpointOptions` key replaces
     /// the one the token is scoped to and the relays reject the endpoint.
     #[uniffi(default = None)]
-    pub secret_key: Option<Vec<u8>>,
+    pub endpoint_secret_key: Option<Vec<u8>>,
 }
 
 /// Wraps `iroh_services::IrohServicesPreset` as a foreign-visible [`Preset`].
@@ -128,10 +127,10 @@ pub fn preset_iroh_services(options: ServicesPresetOptions) -> Result<Arc<dyn Pr
         .relays(options.relays)
         .map_err(|e| anyhow::anyhow!("invalid relay url: {e:?}"))?;
 
-    if let Some(bytes) = options.secret_key {
-        let key: [u8; 32] = AsRef::<[u8]>::as_ref(&bytes)
-            .try_into()
-            .map_err(|e| IrohError::invalid_input(format!("invalid secret key length: {e:?}")))?;
+    if let Some(bytes) = options.endpoint_secret_key {
+        let key: [u8; 32] = AsRef::<[u8]>::as_ref(&bytes).try_into().map_err(|e| {
+            IrohError::invalid_input(format!("invalid endpoint secret key length: {e:?}"))
+        })?;
         builder = builder.secret_key(iroh::SecretKey::from_bytes(&key));
     }
 
@@ -421,6 +420,18 @@ mod tests {
             })
             .is_err(),
             "must reject a malformed api key"
+        );
+    }
+
+    #[test]
+    fn test_services_preset_rejects_short_endpoint_key() {
+        assert!(
+            preset_iroh_services(ServicesPresetOptions {
+                endpoint_secret_key: Some(vec![0u8; 16]),
+                ..preset_options()
+            })
+            .is_err(),
+            "must reject an endpoint key that is not 32 bytes"
         );
     }
 

--- a/src/services.rs
+++ b/src/services.rs
@@ -2,12 +2,16 @@
 //!
 //! Mirrors `iroh_services::Client`. Construct via [`ServicesClient::create`] with
 //! a built [`Endpoint`] plus credentials supplied through [`ServicesOptions`].
+//!
+//! [`preset_iroh_services`] mirrors `iroh_services::preset()`: an endpoint
+//! preset that points at your project's dedicated relays and authenticates to
+//! them with a token minted from your API key.
 
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 
 use iroh_services::{Client, ClientBuilder};
 
-use crate::{Endpoint, IrohError};
+use crate::{Endpoint, EndpointBuilder, IrohError, Preset};
 
 /// Build options for [`ServicesClient`].
 ///
@@ -35,6 +39,106 @@ pub struct ServicesOptions {
     /// automatic interval pushes; if omitted the upstream default applies.
     #[uniffi(default = None)]
     pub metrics_interval_ms: Option<u64>,
+}
+
+/// Options for [`preset_iroh_services`].
+///
+/// Supply *exactly one* of `api_secret` or `api_secret_from_env`.
+#[derive(derive_more::Debug, Default, uniffi::Record)]
+pub struct ServicesPresetOptions {
+    /// Your project's relay URLs. Required, and must be non-empty: this preset
+    /// exists to point an endpoint at dedicated relays. To use the n0 public
+    /// relays instead, pass [`crate::preset_n0`] as the endpoint's preset.
+    pub relays: Vec<String>,
+    /// Encoded API secret string (`services1...`). The relay access token is
+    /// minted from this.
+    #[uniffi(default = None)]
+    pub api_secret: Option<String>,
+    /// If true, read the API secret from `IROH_SERVICES_API_SECRET`.
+    #[uniffi(default = None)]
+    pub api_secret_from_env: Option<bool>,
+    /// Endpoint secret key (32 bytes) — the endpoint's own identity key, not
+    /// your API secret. The access token is scoped to it, so pass the same key
+    /// you persist for your endpoint's identity. A fresh key is generated when
+    /// omitted.
+    ///
+    /// Set the key *here*, not on `EndpointOptions::secret_key`: option fields
+    /// are layered on top of the preset, so an `EndpointOptions` key replaces
+    /// the one the token is scoped to and the relays reject the endpoint.
+    #[uniffi(default = None)]
+    pub secret_key: Option<Vec<u8>>,
+}
+
+/// Wraps `iroh_services::IrohServicesPreset` as a foreign-visible [`Preset`].
+struct ServicesPreset(iroh_services::IrohServicesPreset);
+
+impl Preset for ServicesPreset {
+    fn apply(&self, builder: Arc<EndpointBuilder>) {
+        builder.apply_iroh_preset(self.0.clone());
+    }
+}
+
+/// Build an endpoint preset for your project's dedicated relays.
+///
+/// Mirrors `iroh_services::preset()`: mints a short-lived access token scoped to
+/// the endpoint's key and to relay use only, then configures the endpoint to use
+/// your relays with that token. Pass the result as `EndpointOptions::preset`.
+///
+/// Unlike the Rust builder, `relays` is required — there is no implicit fallback
+/// to the n0 public relays. Use [`crate::preset_n0`] if that is what you want.
+///
+/// The token is minted here, at preset-build time, so build the preset shortly
+/// before binding the endpoint.
+#[uniffi::export]
+pub fn preset_iroh_services(options: ServicesPresetOptions) -> Result<Arc<dyn Preset>, IrohError> {
+    if options.relays.is_empty() {
+        return Err(anyhow::anyhow!(
+            "ServicesPresetOptions requires at least one relay url; use preset_n0() for the n0 public relays"
+        )
+        .into());
+    }
+
+    let mut builder = iroh_services::preset();
+
+    builder = match (
+        options.api_secret,
+        options.api_secret_from_env.unwrap_or(false),
+    ) {
+        (Some(_), true) => {
+            return Err(anyhow::anyhow!(
+                "ServicesPresetOptions: supply only one of api_secret / api_secret_from_env"
+            )
+            .into());
+        }
+        (None, false) => {
+            return Err(anyhow::anyhow!(
+                "ServicesPresetOptions requires one of api_secret or api_secret_from_env=true"
+            )
+            .into());
+        }
+        (Some(secret), false) => builder
+            .api_secret_from_str(&secret)
+            .map_err(|e| anyhow::anyhow!("invalid api secret: {e:?}"))?,
+        (None, true) => builder
+            .api_secret_from_env()
+            .map_err(|e| anyhow::anyhow!("api secret env var: {e:?}"))?,
+    };
+
+    builder = builder
+        .relays(options.relays)
+        .map_err(|e| anyhow::anyhow!("invalid relay url: {e:?}"))?;
+
+    if let Some(bytes) = options.secret_key {
+        let key: [u8; 32] = AsRef::<[u8]>::as_ref(&bytes)
+            .try_into()
+            .map_err(|e| IrohError::invalid_input(format!("invalid secret key length: {e:?}")))?;
+        builder = builder.secret_key(iroh::SecretKey::from_bytes(&key));
+    }
+
+    let preset = builder
+        .build()
+        .map_err(|e| anyhow::anyhow!("services preset build failed: {e:?}"))?;
+    Ok(Arc::new(ServicesPreset(preset)))
 }
 
 /// Flattened summary of an `iroh_services::net_diagnostics::DiagnosticsReport`.
@@ -265,6 +369,79 @@ mod tests {
         .await;
         assert!(res.is_err(), "must reject when >1 credentials supplied");
         ep.close().await.unwrap();
+    }
+
+    /// Options with a valid credential + relay, for tests that vary one field.
+    fn preset_options() -> ServicesPresetOptions {
+        ServicesPresetOptions {
+            relays: vec!["https://relay.example.org/".to_string()],
+            api_secret: Some(FAKE_API_SECRET.to_string()),
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn test_services_preset_binds_with_custom_relays() {
+        let preset = preset_iroh_services(preset_options()).expect("preset should build");
+
+        // No connection is attempted at bind time, so the unreachable relay is
+        // fine — this checks the mint -> relay map -> builder plumbing.
+        let ep = Endpoint::bind(EndpointOptions {
+            preset: Some(preset),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+        assert!(!ep.bound_sockets().is_empty());
+        ep.close().await.unwrap();
+    }
+
+    #[test]
+    fn test_services_preset_rejects_bad_credentials() {
+        assert!(
+            preset_iroh_services(ServicesPresetOptions {
+                api_secret: None,
+                ..preset_options()
+            })
+            .is_err(),
+            "must reject when no credential is supplied"
+        );
+        assert!(
+            preset_iroh_services(ServicesPresetOptions {
+                api_secret_from_env: Some(true),
+                ..preset_options()
+            })
+            .is_err(),
+            "must reject when >1 credentials supplied"
+        );
+        assert!(
+            preset_iroh_services(ServicesPresetOptions {
+                api_secret: Some("not-a-valid-ticket".to_string()),
+                ..preset_options()
+            })
+            .is_err(),
+            "must reject a malformed api key"
+        );
+    }
+
+    #[test]
+    fn test_services_preset_requires_relays() {
+        assert!(
+            preset_iroh_services(ServicesPresetOptions {
+                relays: vec![],
+                ..preset_options()
+            })
+            .is_err(),
+            "must reject an empty relay list rather than falling back to n0"
+        );
+        assert!(
+            preset_iroh_services(ServicesPresetOptions {
+                relays: vec!["not a url".to_string()],
+                ..preset_options()
+            })
+            .is_err(),
+            "must reject a malformed relay url"
+        );
     }
 
     #[tokio::test]

--- a/src/services.rs
+++ b/src/services.rs
@@ -46,10 +46,12 @@ pub struct ServicesOptions {
 /// Supply *exactly one* of `api_secret` or `api_secret_from_env`.
 #[derive(derive_more::Debug, Default, uniffi::Record)]
 pub struct ServicesPresetOptions {
-    /// Your project's relay URLs. Required, and must be non-empty: this preset
-    /// exists to point an endpoint at dedicated relays. To use the n0 public
-    /// relays instead, pass [`crate::preset_n0`] as the endpoint's preset.
-    pub relays: Vec<String>,
+    /// Your project's relay URLs. Defaults to the n0 public relays when
+    /// omitted, matching `iroh_services::preset()`. Passing an empty list is an
+    /// error rather than a silent fallback — that is nearly always a filtered
+    /// list that came back empty.
+    #[uniffi(default = None)]
+    pub relays: Option<Vec<String>>,
     /// Encoded API secret string (`services1...`). The relay access token is
     /// minted from this.
     #[uniffi(default = None)]
@@ -83,20 +85,10 @@ impl Preset for ServicesPreset {
 /// the endpoint's key and to relay use only, then configures the endpoint to use
 /// your relays with that token. Pass the result as `EndpointOptions::preset`.
 ///
-/// Unlike the Rust builder, `relays` is required — there is no implicit fallback
-/// to the n0 public relays. Use [`crate::preset_n0`] if that is what you want.
-///
 /// The token is minted here, at preset-build time, so build the preset shortly
 /// before binding the endpoint.
 #[uniffi::export]
 pub fn preset_iroh_services(options: ServicesPresetOptions) -> Result<Arc<dyn Preset>, IrohError> {
-    if options.relays.is_empty() {
-        return Err(anyhow::anyhow!(
-            "ServicesPresetOptions requires at least one relay url; use preset_n0() for the n0 public relays"
-        )
-        .into());
-    }
-
     let mut builder = iroh_services::preset();
 
     builder = match (
@@ -123,9 +115,18 @@ pub fn preset_iroh_services(options: ServicesPresetOptions) -> Result<Arc<dyn Pr
             .map_err(|e| anyhow::anyhow!("api secret env var: {e:?}"))?,
     };
 
-    builder = builder
-        .relays(options.relays)
-        .map_err(|e| anyhow::anyhow!("invalid relay url: {e:?}"))?;
+    // Omitted relays keep the builder's n0 default; an empty list does not.
+    if let Some(relays) = options.relays {
+        if relays.is_empty() {
+            return Err(anyhow::anyhow!(
+                "ServicesPresetOptions: relays is empty; omit it to use the n0 relays"
+            )
+            .into());
+        }
+        builder = builder
+            .relays(relays)
+            .map_err(|e| anyhow::anyhow!("invalid relay url: {e:?}"))?;
+    }
 
     if let Some(bytes) = options.endpoint_secret_key {
         let key: [u8; 32] = AsRef::<[u8]>::as_ref(&bytes).try_into().map_err(|e| {
@@ -373,7 +374,7 @@ mod tests {
     /// Options with a valid credential + relay, for tests that vary one field.
     fn preset_options() -> ServicesPresetOptions {
         ServicesPresetOptions {
-            relays: vec!["https://relay.example.org/".to_string()],
+            relays: Some(vec!["https://relay.example.org/".to_string()]),
             api_secret: Some(FAKE_API_SECRET.to_string()),
             ..Default::default()
         }
@@ -436,18 +437,26 @@ mod tests {
     }
 
     #[test]
-    fn test_services_preset_requires_relays() {
+    fn test_services_preset_relays() {
         assert!(
             preset_iroh_services(ServicesPresetOptions {
-                relays: vec![],
+                relays: None,
                 ..preset_options()
             })
-            .is_err(),
-            "must reject an empty relay list rather than falling back to n0"
+            .is_ok(),
+            "omitted relays must fall back to the n0 relays, as in Rust"
         );
         assert!(
             preset_iroh_services(ServicesPresetOptions {
-                relays: vec!["not a url".to_string()],
+                relays: Some(vec![]),
+                ..preset_options()
+            })
+            .is_err(),
+            "an explicitly empty list must error, not silently fall back"
+        );
+        assert!(
+            preset_iroh_services(ServicesPresetOptions {
+                relays: Some(vec!["not a url".to_string()]),
                 ..preset_options()
             })
             .is_err(),

--- a/src/services.rs
+++ b/src/services.rs
@@ -64,8 +64,9 @@ pub struct ServicesPresetOptions {
     /// endpoint's identity. A fresh key is generated when omitted.
     ///
     /// Set the key *here*, not on `EndpointOptions::secret_key`: option fields
-    /// are layered on top of the preset, so an `EndpointOptions` key replaces
-    /// the one the token is scoped to and the relays reject the endpoint.
+    /// are layered on top of the preset, so an `EndpointOptions` key would
+    /// replace the one the token is scoped to. Doing that is an error, not a
+    /// silent auth failure — this preset pins the key.
     #[uniffi(default = None)]
     pub endpoint_secret_key: Option<Vec<u8>>,
 }
@@ -76,6 +77,9 @@ struct ServicesPreset(iroh_services::IrohServicesPreset);
 impl Preset for ServicesPreset {
     fn apply(&self, builder: Arc<EndpointBuilder>) {
         builder.apply_iroh_preset(self.0.clone());
+        // The access token is scoped to the key the preset just set, so a later
+        // `secret_key` call must fail rather than silently break relay auth.
+        builder.pin_secret_key();
     }
 }
 
@@ -422,6 +426,22 @@ mod tests {
             .is_err(),
             "must reject a malformed api key"
         );
+    }
+
+    #[tokio::test]
+    async fn test_services_preset_pins_the_endpoint_key() {
+        let preset = preset_iroh_services(preset_options()).unwrap();
+
+        // The token is scoped to the preset's key, so an EndpointOptions key —
+        // layered on top of the preset — must fail loudly, not break relay auth
+        // at connect time.
+        let res = Endpoint::bind(EndpointOptions {
+            preset: Some(preset),
+            secret_key: Some(vec![7u8; 32]),
+            ..Default::default()
+        })
+        .await;
+        assert!(res.is_err(), "must reject a key set outside the preset");
     }
 
     #[test]

--- a/src/services.rs
+++ b/src/services.rs
@@ -63,10 +63,10 @@ pub struct ServicesPresetOptions {
     /// access token is scoped to it, so pass the same key you persist for your
     /// endpoint's identity. A fresh key is generated when omitted.
     ///
-    /// Set the key *here*, not on `EndpointOptions::secret_key`: option fields
-    /// are layered on top of the preset, so an `EndpointOptions` key would
-    /// replace the one the token is scoped to. Doing that is an error, not a
-    /// silent auth failure — this preset pins the key.
+    /// Set the key *here*, not via `EndpointOptions::secret_key` or
+    /// `EndpointBuilder::secret_key`: both are layered on top of the preset and
+    /// would replace the one the token is scoped to. Doing that is an error,
+    /// not a silent auth failure — this preset pins the key.
     #[uniffi(default = None)]
     pub endpoint_secret_key: Option<Vec<u8>>,
 }

--- a/src/services.rs
+++ b/src/services.rs
@@ -444,6 +444,26 @@ mod tests {
         assert!(res.is_err(), "must reject a key set outside the preset");
     }
 
+    #[tokio::test]
+    async fn test_services_preset_pins_even_identical_key() {
+        // The pin is unconditional: even bit-identical bytes are rejected. The
+        // policy is "set it in exactly one place," not "set it to the same
+        // value" — the latter invites a future reader to relax the guard.
+        let key_bytes = vec![7u8; 32];
+        let preset = preset_iroh_services(ServicesPresetOptions {
+            endpoint_secret_key: Some(key_bytes.clone()),
+            ..preset_options()
+        })
+        .unwrap();
+        let res = Endpoint::bind(EndpointOptions {
+            preset: Some(preset),
+            secret_key: Some(key_bytes),
+            ..Default::default()
+        })
+        .await;
+        assert!(res.is_err(), "identical key must still be rejected");
+    }
+
     #[test]
     fn test_services_preset_rejects_short_endpoint_key() {
         assert!(


### PR DESCRIPTION
## What

Adds `preset_iroh_services` to all four bindings — the equivalent of `iroh_services::preset()`, which was Rust-only.

```
ServicesPresetOptions {
    relays: Option<Vec<String>>,          // omitted -> n0 relays, as in Rust
    api_secret: Option<String>,
    api_secret_from_env: Option<bool>,
    endpoint_secret_key: Option<Vec<u8>>,
}
```

| | call |
|---|---|
| Python | `preset_iroh_services(ServicesPresetOptions(relays=[…], api_secret=…))` |
| Swift | `try presetIrohServices(options: ServicesPresetOptions(relays: […], apiSecret: …))` |
| Kotlin | `presetIrohServices(ServicesPresetOptions(relays = listOf(…), apiSecret = …))` |
| JavaScript | `presetIrohServices(builder, { relays: […], apiSecret: … })` |

JavaScript takes the builder as its first argument because a preset in JS is a function applied to an `EndpointBuilder` (like `presetN0`), not a value passed to `bind()`:

```js
const builder = Endpoint.builder()
presetIrohServices(builder, { relays: [relayUrl], apiSecret: apiKey })
const ep = await builder.bind()
await ep.online()
```

## Why

Dedicated relays require an access token: an rcan signed by the project API secret, scoped to relay use and to the endpoint's public key. `iroh_services::preset()` mints it; the bindings exposed `RelayConfig.auth_token` but nothing that could produce a token, so authenticated relays were unreachable from the bindings.

## Notes for review

- **Delegates rather than reimplements.** Both bindings wrap `iroh_services::IrohServicesPreset` and apply it through a new crate-internal `EndpointBuilder::apply_iroh_preset`, so token minting and relay-map wiring stay upstream. The JS helper installs the crypto provider itself (via the upstream preset's N0 baseline), so it needs no preceding `presetN0`/`presetMinimal`.
- **Behaviour matches the Rust builder**, including the n0 relay fallback when `relays` is omitted. The one addition: an explicitly *empty* list errors instead of falling back, since that's nearly always a filtered list that came back empty — Rust would quietly hand you an empty relay map.
- **The endpoint key is pinned.** The access token is scoped to the endpoint's public key, so setting the key again after the preset (`EndpointOptions::secret_key`, which `bind()` layers on top, or `EndpointBuilder::secret_key` / `secretKey` directly) used to invalidate the token silently: the endpoint bound fine and the relays rejected it later. `EndpointBuilder` now tracks the pin and `secret_key` errors, naming `ServicesPresetOptions::endpoint_secret_key` in the message. It rejects any later key including an identical one — "set it in exactly one place" beats an equality rule.
- **`api_secret` / `api_secret_from_env`** match the shipped `ServicesOptions` and the `IROH_SERVICES_API_SECRET` env var, so the two records read the same.
- **`endpoint_secret_key`, not `secret_key`.** It's the endpoint's identity key, and `secretKey` next to `apiSecret` read like two spellings of the same credential.

## Testing

- 6 Rust tests: binds with custom relays, pins the endpoint key, rejects bad credentials, rejects a short endpoint key, relay handling (omitted / empty / malformed). `cargo test` 23/23.
- 4 Python and 4 JS tests over the real FFI, including the pin guard. Python suite 25/25, `node --test` 24/24.
- `cargo make clippy` clean, `cargo make format` applied, Kotlin bindings regenerated via `cargo make bindgen-kotlin`, `index.d.ts` regenerated via `napi build`.
- No Kotlin/Swift tests — same uniffi metadata, mechanical glue. Generated signatures for Python, Swift, and Kotlin were checked by running bindgen.
- `iroh-js/index.js` is deliberately **not** in the diff: the local napi CLI rewrites unrelated loader boilerplate (`require('fs')` → `require('node:fs')`). Only the `index.d.ts` additions are committed.

## Related

Docs PR: n0-computer/docs.iroh.computer#86 — depends on this shipping in a release, since the snippet documents `preset_iroh_services`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)