### PR TITLE
fix(js): report only connected home relays

### DIFF
--- a/iroh-js/src/watch.rs
+++ b/iroh-js/src/watch.rs
@@ -54,7 +54,11 @@ pub(crate) fn spawn_home_relay_watch(
         use iroh::Watcher;
         let mut stream = endpoint.home_relay_status().stream();
         while let Some(statuses) = stream.next().await {
-            let urls: Vec<String> = statuses.into_iter().map(|s| s.url().to_string()).collect();
+            let urls: Vec<String> = statuses
+                .into_iter()
+                .filter(|status| status.is_connected())
+                .map(|status| status.url().to_string())
+                .collect();
             cb.call(Ok(urls), ThreadsafeFunctionCallMode::NonBlocking);
         }
     });


### PR DESCRIPTION
## Summary

- filter `home_relay_status()` snapshots to statuses whose relay connection is currently established
- make `watchHomeRelay` emit an empty list during relay outage instead of retaining the known relay URL
- preserve the existing callback and watch-handle API

This is a follow-up to #281. Without the filter, the watcher is process-safe but cannot distinguish a configured relay from a connected relay, so consumers cannot react to relay restart.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p number0_iroh`
- built the macOS arm64 N-API addon and observed `watchHomeRelay` returning the connected n0 relay
- authenticated Volt canary: relay restart emitted loss and recovery updates 65 ms apart; the daemon PID and endpoint identity remained unchanged, and a cellular cold launch reconnected with zero relay auth errors

This pull request is AI-generated by Volt.
